### PR TITLE
use heartbeat to monitor signs app

### DIFF
--- a/prod_startup.sh
+++ b/prod_startup.sh
@@ -1,2 +1,2 @@
 source ~/.realtime_signs.settings
-mix run --no-halt
+elixir --erl "-heart" -S mix run --no-halt


### PR DESCRIPTION
running on staging currently.  we will need to set the `HEARTBEAT_COMMAND` in the prod settings, which ill do before we merge it so it doesnt just end up in the prod instance (not that it would matter, but it just seems like good practice)