### PR TITLE
always use a duration of 180 seconds for countdowns

### DIFF
--- a/lib/sign/state.ex
+++ b/lib/sign/state.ex
@@ -250,7 +250,7 @@ defmodule Sign.State do
 
     message = Message.new
     |> Message.placement(platform, line)
-    |> Message.erase_after(expiration_time(prediction_time))
+    |> Message.erase_after(@three_minutes)
     |> Message.message(message(Message.headsign(trip.direction_id, trip.route_id, stop_id), prediction_time, stop_id))
 
     arriving_announcement = if announce_arriving?(prediction_time) do
@@ -267,10 +267,6 @@ defmodule Sign.State do
 
     {message, arriving_announcement, countdown_announcement}
   end
-
-  defp expiration_time(:boarding), do: 10
-  defp expiration_time(0), do: 30
-  defp expiration_time(_), do: @three_minutes
 
   defp announce_arriving?(prediction_time) do
     prediction_time == 0

--- a/test/sign/state_test.exs
+++ b/test/sign/state_test.exs
@@ -98,7 +98,7 @@ defmodule Sign.StateTest do
       %Content{
         messages: [
           %Message{
-            duration: 30,
+            duration: 180,
             message: [{"Mattapan       ARR", nil}],
             placement: ["s1"],
             when: nil},
@@ -142,7 +142,7 @@ defmodule Sign.StateTest do
       %Content{
         messages: [
           %Message{
-            duration: 30,
+            duration: 180,
             message: [{"Mattapan       ARR", nil}],
             placement: ["s1"],
             when: nil},
@@ -273,7 +273,7 @@ defmodule Sign.StateTest do
       %Content{
         messages: [
           %Message{
-            duration: 10,
+            duration: 180,
             message: [{"Mattapan       BRD", nil}],
             placement: ["s1"]},
           %Message{
@@ -346,7 +346,7 @@ defmodule Sign.StateTest do
       %Content{
         messages: [
           %Message{
-            duration: 30,
+            duration: 180,
             message: [{"Mattapan    ARR", nil}],
             placement: ["m1"],
             when: nil}


### PR DESCRIPTION
#### Summary of changes
Fix for an annoying bug

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
