### PR TITLE
Handle HTTP errors

### DIFF
--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -1,5 +1,5 @@
 defmodule Fake.HTTPoison do
-  def get(url, headers, options \\ []) do
+  def get(url, headers \\ [], options \\ []) do
     if options[:stream_to] do
       send options[:stream_to], %HTTPoison.AsyncStatus{code: 200}
       send options[:stream_to], %HTTPoison.AsyncChunk{chunk: "lol"}
@@ -26,6 +26,9 @@ defmodule Fake.HTTPoison do
     json = %{"data" => [%{"relationships" => "trip"}]}
     encoded = Poison.encode!(json)
     {:ok, %HTTPoison.Response{status_code: 200, body: encoded}}
+  end
+  def mock_response("unknown") do
+    {:error, "unknown response"}
   end
   def mock_response("https://api-v3.mbta.com/schedules" <> _) do
     json = %{"data" => []}

--- a/lib/sign/predictions.ex
+++ b/lib/sign/predictions.ex
@@ -1,21 +1,25 @@
 defmodule Sign.Predictions do
   use GenServer
+  require Logger
 
-  def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, :ok, opts)
+  @vehicle_positions_url "https://s3.amazonaws.com/mbta-gtfs-s3/VehiclePositions.pb"
+  @trip_updates_url "https://s3.amazonaws.com/mbta-gtfs-s3/TripUpdates.pb"
+  @default_opts [vehicle_positions_url: @vehicle_positions_url, trip_updates_url: @trip_updates_url, name: __MODULE__]
+
+  def start_link(user_opts \\ []) do
+    opts = Keyword.merge(@default_opts, user_opts)
+    GenServer.start_link(__MODULE__, opts, opts)
   end
 
-  def init(state) do
+  def init(opts) do
     schedule_download()
-    {:ok, state}
+    {:ok, Keyword.take(opts, [:vehicle_positions_url, :trip_updates_url])}
   end
 
   def handle_info(:download, state) do
-    raw_vehicle_positions = HTTPoison.get!("https://s3.amazonaws.com/mbta-gtfs-s3/VehiclePositions.pb")
-    raw_trip_updates = HTTPoison.get!("https://s3.amazonaws.com/mbta-gtfs-s3/TripUpdates.pb")
-    vehicle_positions = GTFS.Realtime.FeedMessage.decode(raw_vehicle_positions.body)
-    trip_updates = GTFS.Realtime.FeedMessage.decode(raw_trip_updates.body)
-    current_time = Timex.now
+    vehicle_positions = state[:vehicle_positions_url] |> fetch_pb_file() |> decode_response()
+    trip_updates = state[:trip_updates_url] |> fetch_pb_file() |> decode_response()
+    current_time = Timex.now()
 
     Sign.State.update(trip_updates, vehicle_positions, current_time)
 
@@ -25,5 +29,29 @@ defmodule Sign.Predictions do
 
   defp schedule_download() do
     Process.send_after(self(), :download, 1 * 1000)
+  end
+
+  @spec fetch_pb_file(String.t) :: {:ok, String.t} | {:error, String.t, String.t}
+  defp fetch_pb_file(url) do
+    http_client = Application.get_env(:realtime_signs, :http_client)
+    case http_client.get(url) do
+      {:ok, %HTTPoison.Response{body: body, status_code: status}} when status >= 200 and status < 300 ->
+        {:ok, body}
+      {:ok, %HTTPoison.Response{status_code: status}} ->
+        {:error, "Status code #{inspect status}", url}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, "#{inspect reason}", url}
+      _ ->
+      {:error, "unknown reason", url}
+    end
+  end
+
+  @spec decode_response({:ok, String.t} | {:error, String.t, String.t}) :: map
+  defp decode_response({:error, reason, url}) do
+    Logger.warn("Failed HTTP GET to #{inspect url}: #{inspect reason}")
+    %{}
+  end
+  defp decode_response({:ok, body}) do
+    GTFS.Realtime.FeedMessage.decode(body)
   end
 end

--- a/lib/sign/state.ex
+++ b/lib/sign/state.ex
@@ -48,6 +48,9 @@ defmodule Sign.State do
 
     {:reply, :ok, new_state}
   end
+  def handle_call({:update, _trip_updates, _vehicle_positions, _current_time}, _from, sign_state) do
+    {:reply, :ok, sign_state}
+  end
   def handle_call(:reset, _from, _state) do
     {:reply, :ok, %{}}
   end

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "httpoison": {:hex, :httpoison, "1.0.0", "1f02f827148d945d40b24f0b0a89afe40bfe037171a6cf70f2486976d86921cd", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], [], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [], [], "hexpm"},
-  "logger_splunk_backend": {:git, "https://github.com/mbta/logger_splunk_backend.git", "1057b0090db96d2cb078c3e1d37b9e4408a09501", []},
+  "logger_splunk_backend": {:git, "https://github.com/mbta/logger_splunk_backend.git", "89c1d3d3eb5c2b189a8aff1e40d2abf6ce2057ef", []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/sign/predictions_test.exs
+++ b/test/sign/predictions_test.exs
@@ -1,0 +1,37 @@
+defmodule Sign.PredictionsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  import Sign.Predictions
+
+  describe "handle_info/3" do
+    test "handles 500 status code" do
+      status_error_url = "https://api-v3.mbta.com/schedules?filter[stop]=500_error"
+      opts = [vehicle_positions_url: status_error_url, trip_updates_url: "", name: :test]
+      log = capture_log [level: :warn], fn -> 
+        handle_info(:download, opts)
+      end
+
+      assert log =~ "Status code 500"
+    end
+
+    test "handles http error" do
+      error_url = "https://api-v3.mbta.com/schedules?filter[stop]=unknown_error"
+      opts = [vehicle_positions_url: error_url, trip_updates_url: "", name: :test]
+      log = capture_log [level: :warn], fn -> 
+        handle_info(:download, opts)
+      end
+
+      assert log =~ "Bad URL"
+    end
+
+    test "handles unknown error" do
+      unknown_error_url = "unknown"
+      opts = [vehicle_positions_url: unknown_error_url, trip_updates_url: "", name: :test]
+      log = capture_log [level: :warn], fn -> 
+        handle_info(:download, opts)
+      end
+
+      assert log =~ "unknown reason"
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Handle HTTP timeout without crashing](https://app.asana.com/0/584764604969369/601400708419225)

Updated the SplunkLoggerBackend dep, which now handles HTTP errors. Also handles the `GET` request to download the pb files in case that fails.
#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
