### PR TITLE
Pad headways

### DIFF
--- a/lib/headway/schedule_headway.ex
+++ b/lib/headway/schedule_headway.ex
@@ -50,6 +50,10 @@ defmodule Headway.ScheduleHeadway do
   end
 
   @spec calculate_headway_range([DateTime.t]) :: headway_range
+  defp calculate_headway_range([previous_time, upcoming_time]) do
+    actual_headway = {Timex.diff(upcoming_time, previous_time , :minutes), nil}
+    pad_headway_range(actual_headway)
+  end
   defp calculate_headway_range([previous_time, upcoming_time, second_upcoming_time]) do
     actual_headway = {Timex.diff(upcoming_time, previous_time, :minutes), Timex.diff(second_upcoming_time, upcoming_time, :minutes)}
     pad_headway_range(actual_headway)

--- a/test/headway/schedule_headway_test.exs
+++ b/test/headway/schedule_headway_test.exs
@@ -128,6 +128,22 @@ defmodule Headway.ScheduleHeadwayTest do
       headways = group_headways_for_stations(schedules, ["111"], Timex.to_datetime(@current_time, "America/New_York"))
       assert headways == %{"111" => {5, 7}}
     end
+
+    test "Pads headway when only two times are given" do
+      times = [
+        ~N[2017-07-04 09:01:00],
+        ~N[2017-07-04 09:02:00],
+      ]
+
+      schedules = Enum.map(times, fn time ->
+        %{"relationships" => %{"stop" => %{"data" => %{"id" => "111"}}},
+          "attributes" => %{"departure_time" => Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")}}
+      end)
+
+      headways = group_headways_for_stations(schedules, ["111"], Timex.to_datetime(@current_time, "America/New_York"))
+      {:first_departure, headway, _first_time} = Map.get(headways, "111")
+      assert headway == {5, nil}
+    end
   end
 
   describe "format_headway_range/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Pad SL3 Headways](https://app.asana.com/0/584764604969369/615919815717898)

Pads the headways calculated for static stations. Gives both values an upper bound, and adds two minutes to the upper value.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
