### PR TITLE
New stab at a different Signs architecture

### DIFF
--- a/lib/content/predictions.ex
+++ b/lib/content/predictions.ex
@@ -1,0 +1,11 @@
+defmodule Content.Predictions do
+  defstruct [times: []]
+
+  def from_times(times) do
+    %__MODULE__{times: times}
+  end
+
+  def to_text(%__MODULE__{times: times}) do
+    "Next trains in #{Enum.join(times, ", ")} seconds"
+  end
+end

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -1,0 +1,39 @@
+defmodule Engine.Predictions do
+  use GenServer
+  require Logger
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc "The seconds away we predict vehicles are from the given stop"
+  def for_stop(pid \\ __MODULE__, gtfs_stop_id) do
+    GenServer.call(pid, {:for_stop, gtfs_stop_id})
+  end
+
+  def init([]) do
+    schedule_update(self())
+    Process.send_after(self(), :test_update, 5_000)
+    state = %{"70265" => [80, 200], "70266" => [90, 180]}
+    {:ok, state}
+  end
+
+  def handle_call({:for_stop, gtfs_stop_id}, _from, state) do
+    {:reply, state[gtfs_stop_id], state}
+  end
+
+  def handle_info(:update, state) do
+    schedule_update(self())
+    Logger.info("Updating Predictions State...")
+    {:noreply, state}
+  end
+
+  def handle_info(:test_update, state) do
+    Logger.info("Test updating predictions state...")
+    {:noreply, %{state | "70265" => [50, 150]}}
+  end
+
+  defp schedule_update(pid) do
+    Process.send_after(pid, :update, 1_000)
+  end
+end

--- a/lib/engine/schedules.ex
+++ b/lib/engine/schedules.ex
@@ -1,0 +1,11 @@
+defmodule Engine.Schedules do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    {:ok, []}
+  end
+end

--- a/lib/engine/static.ex
+++ b/lib/engine/static.ex
@@ -1,0 +1,11 @@
+defmodule Engine.Static do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    {:ok, []}
+  end
+end

--- a/lib/pa_ess_updater.ex
+++ b/lib/pa_ess_updater.ex
@@ -1,0 +1,17 @@
+defmodule PaEssUpdater do
+  use GenServer
+  require Logger
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def update_sign(pa_ess_id, content) do
+    text = Content.Predictions.to_text(content) # this could be a @behaviour to handle different kinds of messages
+    Logger.info("Updated sign #{inspect(pa_ess_id)} with: #{text}")
+  end
+
+  def init([]) do
+    {:ok, []}
+  end
+end

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -7,15 +7,16 @@ defmodule RealtimeSigns do
     import Supervisor.Spec, warn: false
 
     children = [
-      supervisor(Sign.Supervisor, []),
+      worker(Engine.Predictions, []),
+      worker(Engine.Schedules, []),
+      worker(Engine.Static, []),
+      worker(PaEssUpdater, []),
+      supervisor(Signs.Supervisor, []),
+      worker(Signs.Starter, [], restart: :transient)
     ]
 
     opts = [strategy: :one_for_one, name: __MODULE__]
     :ok = :error_logger.add_report_handler(Sentry.Logger)
     Supervisor.start_link(children, opts)
-  end
-
-  def hello do
-    :world
   end
 end

--- a/lib/signs/sign.ex
+++ b/lib/signs/sign.ex
@@ -1,0 +1,46 @@
+defmodule Signs.Sign do
+  use GenServer
+  require Logger
+
+  defstruct [
+    :id, :pa_ess_id, :gtfs_stop_id, :route_id, :current_content
+  ]
+
+  def start_link(config) do
+    GenServer.start_link(__MODULE__, config)
+  end
+
+  def init(%{"type" => "normal"} = config) do
+    schedule_update(self())
+
+    sign = %__MODULE__{
+      id: config["id"],
+      pa_ess_id: {config["pa_ess_loc"], config["pa_ess_zone"]},
+      gtfs_stop_id: config["gtfs_stop_id"],
+      route_id: config["route_id"],
+      current_content: nil
+    }
+
+    {:ok, sign}
+  end
+
+  def handle_info(:update_content, sign) do
+    schedule_update(self())
+
+    content =
+      sign.gtfs_stop_id
+      |> Engine.Predictions.for_stop
+      |> Content.Predictions.from_times
+
+    if content == sign.current_content do
+      {:noreply, sign}
+    else
+      PaEssUpdater.update_sign(sign.pa_ess_id, content)
+      {:noreply, %{sign | current_content: content}}
+    end
+  end
+
+  defp schedule_update(pid) do
+    Process.send_after(pid, :update_content, 1_000)
+  end
+end

--- a/lib/signs/starter.ex
+++ b/lib/signs/starter.ex
@@ -1,0 +1,16 @@
+defmodule Signs.Starter do
+  def start_link do
+    Task.start_link(__MODULE__, :run, [])
+  end
+
+  def run do
+    :realtime_signs
+    |> :code.priv_dir
+    |> Path.join("signs.json")
+    |> File.read!
+    |> Poison.Parser.parse!
+    |> Enum.each(fn sign_config ->
+      Signs.Supervisor.start_child(sign_config)
+    end)
+  end
+end

--- a/lib/signs/supervisor.ex
+++ b/lib/signs/supervisor.ex
@@ -1,0 +1,42 @@
+defmodule Signs.Supervisor do
+  @moduledoc """
+  Dynamic Supervisor of all the signs. Every hardware sign that we control
+  (technically, "zone" of signs that always display the same content), is
+  managed by its own GenServer, supervised by this supervisor.
+
+  At app start up, the Signs.Starter task reads the signs.config and uses
+  it to call `start_child` on this supervisor.
+
+  Depending on the "type" of sign, this supervisor will start up the
+  relevant GenServer. Most signs will be a Signs.Sign, which determines
+  its display message from (in priority order) Drupal static text,
+  predictions if available, schedules for headways. We also support
+  ...?
+
+  (If all the signs are similar "enough", maybe we only need one type of
+  GenServer. I'm forgetting all the use cases we discussed for how signs
+  could differ. One-liners vs. two? Stops Away vs time? GreenLine Park St
+  weird cases?)
+  """
+
+  use DynamicSupervisor
+
+  def start_link do
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def start_child(sign_config) do
+    sign_mod = case sign_config["type"] do
+      "normal" -> Signs.Sign
+    end
+
+    DynamicSupervisor.start_child(__MODULE__, {sign_mod, sign_config})
+  end
+
+  def init([]) do
+    DynamicSupervisor.init(
+      strategy: :one_for_one,
+      extra_arguments: []
+    )
+  end
+end

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "MBUT0",
+    "pa_ess_loc": "MBUT",
+    "pa_ess_zone": 0,
+    "gtfs_stop_id": "70266",
+    "route_id": "Mattapan",
+    "type": "normal"
+  },
+  {
+    "id": "MBUT1",
+    "pa_ess_loc": "MBUT",
+    "pa_ess_zone": 1,
+    "gtfs_stop_id": "70265",
+    "route_id": "Mattapan",
+    "type": "normal"
+  }
+]


### PR DESCRIPTION
A brief stab at laying out the architecture we white boarded on Friday. (Note that because I used a `DynamicSupervisor`, it requires Elixir 1.6.) It doesn't do much - mostly just starts up the relevant GenServers and establishes some of the ways they interact with each other. I mostly hope this makes concrete some of what we were talking about so it can serve as a basis for discussion.

Start with the application root:

```
children = [
  worker(Engine.Predictions, []),
  worker(Engine.Schedules, []),
  worker(Engine.Static, []),
  worker(PaEssUpdater, []),
  supervisor(Signs.Supervisor, []),
  worker(Signs.Starter, [], restart: :transient)
]
```

The first three GenServers that are started up are our "Engines". These are responsible for keeping their own state with regard to predictions, schedules (headways), and static content (from the CMS). They will run independently, periodically fetching PB files or hitting the API or whatever, and updating their own internal state. The signs will query them periodically for information relevant to them.

The next GenServer is the `PaEssUpdater`. This is the one that actually makes the HTTP POSTs to the signs server. We set it up as a GenServer, to serialize all requests through it, so we can throttle as necessary (per that one ticket).

A big change to the architecture is the `Signs.Supervisor`, which starts up next. It's a `DynamicSupervisor` (from Elixir 1.6), which means its children can be added dynamically, rather than being specified in the config, like most supervisors. **Each sign will be its own GenServer**, keeping track of what's displayed currently, when and how it should update, and sending messages to `PaEssUpdater` if need be.

Then lastly, per [Jose Valim's recommendation](https://elixirforum.com/t/how-to-start-dynamic-supervisor-workers-on-application-startup/3582), we have a transient worker, the `Signs.Starter`, that will read the `priv/signs.json` config, and start up GenServers for all the signs, adding them under the `Signs.Supervisor`.

Once the app is up and running, the meat of the sign work is done independently by all the sign GenServers. They periodically pull from the various Engines to decide what to display, compare that to what they're currently displaying, and send a message to the `PaEssUpdater` if necessary. They also keep track of their individual timeouts, to know when they need to refresh the sign anyway.

One architectural question that's still up in the air is how to handle the different "kinds" of signs: predicted times vs stops away, station signs at gtfs stops vs mezzanine and random other signs, one liners vs two. As I have it now, `signs.json` configures for each sign what "type" it is, and then the `Signs.Supervisor.start_child/1` function, can boot up a different GenServer for that sign, depending on the type.

Another smaller architectural piece is pulling out content on signs as structs, for a little typechecked safety. The idea is that each sign has a `:current_content` field, stored as a struct depending on whether it's, e.g., a headway message or a predicted minutes or stops away or whatever. And the `PaEssUpdater.update_sign/2` function takes the content struct as a parameter, and then calls `to_text()` on it. This enforces that whatever happens in the app, only certain kinds of messages can be sent to the signs servers.

The app is in a working, if mostly stubbed out, place. It's configured with two signs in the `signs.json`, and the `Engine.Predictions` has hardcoded data for those two stops. When the app boots up, a GenServer for each sign will be spun up, they will each reach out to the `Engine.Predictions` and get their "predicted times", and send a message to the `PaEssUpdater`. This is logged in the console. The `Engine.Predictions` will loop once per second to "update" its state, but will not change anything. The signs will check their predictions once per second, realize that nothing has changed, and not send a message to the `PaEssUpdater`. Then, 5 seconds after the app starts, the `Engine.Predictions` will change for _one_ of the stops. That stop's sign will notice the change and send a `PaEssUpdater` message to update.