### PR TITLE
Remove date filter

### DIFF
--- a/lib/headway/schedule_headway.ex
+++ b/lib/headway/schedule_headway.ex
@@ -12,16 +12,7 @@ defmodule Headway.ScheduleHeadway do
   @spec build_request([Station.id]) :: String.t
   def build_request(station_ids) do
     id_filter = station_ids |> Enum.map(&URI.encode/1) |> Enum.join(",")
-    @schedule_api_url <> "?filter[stop]=#{id_filter}#{date_filter()}"
-  end
-
-  defp date_filter() do
-    start_date = ~D[2018-04-21]
-    if Mix.env != :test and Timex.compare(Timex.today(), start_date) < 0 do
-      "&filter[date]=2018-04-21"
-    else
-      ""
-    end
+    @schedule_api_url <> "?filter[stop]=#{id_filter}"
   end
 
   @spec group_headways_for_stations([map], [Station.id], DateTime.t) :: %{Station.id => t}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

Removes the date filter for sl3 buses. Now it will always fetch schedule data for the current day: https://api-v3.mbta.com/docs/swagger/index.html#/Schedule/ApiWeb_ScheduleController_index

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
