### PR TITLE
Use spanish announcement bridge ID

### DIFF
--- a/lib/sign/static/announcements.ex
+++ b/lib/sign/static/announcements.ex
@@ -15,7 +15,7 @@ defmodule Sign.Static.Announcements do
   }
   @english_bridge_base_var 5500
   @spanish_bridge_base_var 37000
-  @bridge_closing_soon_mid %{:english => 136, :spanish => 153}
+  @bridge_closing_soon_mid %{:english => 136, :spanish => 157}
   @bridge_closing_duration %{:english => 135, :spanish => 152}
 
   @spec from_schedule_headways(%{Station.id => ScheduleHeadway.t}, DateTime.t, Chelsea.status) :: [Message.t]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

Changes the Spanish "Bridge closing soon" announcement message id from our placeholder to the actual message ID.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
