### PR TITLE
Log all posts to signs server

### DIFF
--- a/lib/sign/updater.ex
+++ b/lib/sign/updater.ex
@@ -39,6 +39,7 @@ defmodule Sign.Updater do
   defp http_client, do: Application.get_env(:realtime_signs, :http_client)
 
   defp log_sign_update(command, current_time) do
+    Logger.info("Sign.Updater.send_request: #{command}")
     date_str =
       current_time
       |> RTR.Utilities.Time.get_service_date


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

I think we might be missing some of our logging. In particular, I wasn't seeing any logs that included the message_id corresponding to arriving and countdown announcements.

We do log every post to the signs HTTP server, but only to a file (which I wasn't able to find on opstech3 - so it might not be doing that...). This changes updates it to use the standard Logger so it shows up in splunk.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
