### PR TITLE
Handle non 200 status code

### DIFF
--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -46,6 +46,9 @@ defmodule Fake.HTTPoison do
 
       {:ok, %HTTPoison.Response{status_code: 200, body: feed_message}}
   end
+  def mock_response("trip_updates_304") do
+    {:ok, %HTTPoison.Response{status_code: 304}}
+  end
   def mock_response("https://api-v3.mbta.com/schedules?filter[stop]=500_error") do
     {:ok, %HTTPoison.Response{status_code: 500, body: ""}}
   end

--- a/test/engine/predictions_test.exs
+++ b/test/engine/predictions_test.exs
@@ -1,0 +1,15 @@
+defmodule Engine.PredictionsTest do
+  use ExUnit.Case, async: true
+  import Engine.Predictions
+
+  describe "handle_info/2" do
+    test "keeps existing state when trip_update url has not been modified" do
+      trip_update_url = Application.get_env(:realtime_signs, :trip_update_url)
+      Application.put_env(:realtime_signs, :trip_update_url, "trip_updates_304")
+      existing_state = {~N[2017-07-04 09:05:00], %{"stop_id" => "prediction1"}}
+      {:noreply, updated_state} = handle_info(:update, existing_state)
+      Application.put_env(:realtime_signs, :trip_update_url, trip_update_url)
+      assert updated_state == existing_state
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug: Non 200 status codes reset the state](https://app.asana.com/0/584764604969369/647261922724879)

Handles the case where we get a non successful status code. Instead of reseting the state to `%{}` we preserve the existing state. 
#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
