### PR TITLE
Add GenServer init stubs

### DIFF
--- a/lib/fake/updater.ex
+++ b/lib/fake/updater.ex
@@ -5,6 +5,10 @@ defmodule Fake.Sign.Updater do
     GenServer.start_link(__MODULE__, [], opts)
   end
 
+  def init(args) do
+    {:ok, args}
+  end
+
   def request(pid \\ __MODULE__, payload, current_time) do
     GenServer.cast(pid, {:request, payload, current_time})
   end

--- a/lib/sign/updater.ex
+++ b/lib/sign/updater.ex
@@ -7,6 +7,10 @@ defmodule Sign.Updater do
     GenServer.start_link(__MODULE__, uid, opts)
   end
 
+  def init(args) do
+    {:ok, args}
+  end
+
   def host, do: Application.get_env(:realtime_signs, :sign_head_end_host)
   def url, do: "http://#{host()}/mbta/cgi-bin/RemoteMsgsCgi.exe"
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket

This failed on semaphore from --warnings-as-errors. In Elixir 1.6 it warns now if you rely on the generated `GenServer` `init` callback. This PR just fills in explicitly what Elixir was already generating, in order to quiet the warnings.

This change was already made on the v2 branch.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
