### PR TITLE
Revert default arg hack, now that Elixir is updated

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -19,22 +19,12 @@ defmodule PaEss.HttpUpdater do
   end
 
   @impl PaEss.Updater
-  def update_sign(pa_ess_id, line_no, msg, duration, start_secs) do
-    update_sign(__MODULE__, pa_ess_id, line_no, msg, duration, start_secs)
-  end
-
-  # TODO: Elixir 1.6, consolidate into one function with default argument
-  def update_sign(pid, pa_ess_id, line_no, msg, duration, start_secs) do
+  def update_sign(pid \\ __MODULE__, pa_ess_id, line_no, msg, duration, start_secs) do
     GenServer.call(pid, {:update_sign, pa_ess_id, line_no, msg, duration, start_secs})
   end
 
   @impl PaEss.Updater
-  def send_audio(pa_ess_id, audio, priority, timeout) do
-    send_audio(__MODULE__, pa_ess_id, audio, priority, timeout)
-  end
-
-  # TODO: Elixir 1.6, consolidate into one function with default argument
-  def send_audio(pid, pa_ess_id, audio, priority, timeout) do
+  def send_audio(pid \\ __MODULE__, pa_ess_id, audio, priority, timeout) do
     GenServer.call(pid, {:send_audio, pa_ess_id, audio, priority, timeout})
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update Elixir](https://app.asana.com/0/584764604969369/643239970132396)

Now that we're on 1.6, don't need this workaround to satisfy dialyzer.

(Not going to merge until opstech3 is on Elixir 1.6, which I'll do on Monday.)

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
