### PR TITLE
Add all Mattapan to V2 for testing

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -136,26 +136,6 @@
     "type": "countdown"
   },
   {
-    "gtfs_stop_id": "70275",
-    "pa_ess_loc": "MMAT",
-    "pa_ess_zone": "s",
-    "headsign": "Mattapan",
-    "direction_id": 0,
-    "id": "MMAT0",
-    "route_id": "Mattapan",
-    "type": "countdown"
-  },
-  {
-    "gtfs_stop_id": "70276",
-    "pa_ess_loc": "MMAT",
-    "pa_ess_zone": "n",
-    "headsign": "Ashmont",
-    "id": "MMAT1",
-    "direction_id": 1,
-    "route_id": "Mattapan",
-    "type": "countdown"
-  },
-  {
     "id": "SEAV0",
     "pa_ess_loc": "SEAV",
     "pa_ess_zone": "w",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [TICKET_NAME](TICKET_LINK)

Uses some of #58 but when reviewing it I got confused and saw some issues (MBUT incorrectly changed from a single line sign to a countdown, went from center to north/south, and lost its line number config). So I cut a fresh branch from v2, which is correct for the "tricky" ones (Ashmont, Butler), and then I added all the new stations (from Milton to Mattapan) from #58 into it. I also removed the SL3 stations, since we don't want to turn those on yet.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
