### PR TITLE
Periodically read headway signs in English and Spanish

### DIFF
--- a/lib/content/audio/buses_to_destination.ex
+++ b/lib/content/audio/buses_to_destination.ex
@@ -45,6 +45,7 @@ defmodule Content.Audio.BusesToDestination do
   defp get_mins({x, x}), do: {x, x+2}
   defp get_mins({x, y}) when x < y, do: {x, y}
   defp get_mins({y, x}), do: {x, y}
+  defp get_mins(_), do: :error
 
   defimpl Content.Audio do
     alias PaEss.Utilities

--- a/test/content/audio/buses_to_destination_test.exs
+++ b/test/content/audio/buses_to_destination_test.exs
@@ -69,6 +69,11 @@ defmodule Content.Audio.BusesToDestinationTest do
       assert from_headway_message(msg, "Chelsea") == nil
     end
 
+    test "returns nil when range is unexpected" do
+      msg = %{@msg | range: {:a, :b, :c}}
+      assert from_headway_message(msg, "Chelsea") == nil
+    end
+
     test "returns a padded range when one value is missing or values are the same" do
       msg1 = %{@msg | range: {10, nil}}
       msg2 = %{@msg | range: {nil, 10}}

--- a/test/signs/headway_test.exs
+++ b/test/signs/headway_test.exs
@@ -37,7 +37,7 @@ defmodule Signs.HeadwayTest do
     end
 
     test "when the first departure is in the future, does not send an update" do
-      sign = %{@sign | gtfs_stop_id: "first_departure"}
+      sign = %{@sign | current_content_bottom: Content.Message.Empty.new(), gtfs_stop_id: "first_departure"}
 
       log = capture_log [level: :info], fn ->
         handle_info(:update_content, sign)
@@ -91,7 +91,7 @@ defmodule FakeHeadwayEngine do
     {:first_departure, {8, 10}, future_departure}
   end
   def get_headways("first_departure") do
-    future_departure = Timex.shift(Timex.now(), minutes: 10)
+    future_departure = Timex.shift(Timex.now(), minutes: 20)
     {:first_departure, {1, 2}, future_departure}
   end
   def get_headways(_stop_id) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [M: Audio plays periodically giving headway info](https://app.asana.com/0/584764604969369/629710038948326)

Reads the bottom of the headway sign every 5 minutes, first in English, then in Spanish.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
