### PR TITLE
Don't allow seconds_from_now in predictions to be negative

### DIFF
--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -8,7 +8,7 @@ defmodule Predictions.Prediction do
 
   @type t :: %__MODULE__{
     stop_id: String.t(),
-    seconds_until_arrival: integer(),
+    seconds_until_arrival: non_neg_integer(),
     direction_id: 0 | 1,
     route_id: String.t()
   }

--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -21,7 +21,7 @@ defmodule Predictions.Predictions do
     %Prediction{
       stop_id: stop_time_update.stop_id,
       direction_id: direction_id,
-      seconds_until_arrival: prediction_time.time - current_time_seconds,
+      seconds_until_arrival: max(0, prediction_time.time - current_time_seconds),
       route_id: route_id
     }
   end

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -77,6 +77,65 @@ defmodule Predictions.PredictionsTest do
       }
       assert get_all(feed_message,  @current_time) == expected
     end
+
+    test "does not let seconds_until_arrival be negative" do
+      feed_message = %GTFS.Realtime.FeedMessage{
+        entity: [
+          %GTFS.Realtime.FeedEntity{
+            alert: nil,
+            id: "1490783458_32568935",
+            is_deleted: false,
+            trip_update: %GTFS.Realtime.TripUpdate{
+              delay: nil,
+              stop_time_update: [
+                %GTFS.Realtime.TripUpdate.StopTimeUpdate{
+                  arrival: %GTFS.Realtime.TripUpdate.StopTimeEvent{
+                    delay: nil,
+                    time: Timex.to_unix(@current_time) - 100,
+                    uncertainty: nil
+                  },
+                  departure: nil,
+                  schedule_relationship: :SCHEDULED,
+                  stop_id: "70263",
+                  stop_sequence: 1
+                },
+              ],
+              timestamp: nil,
+              trip: %GTFS.Realtime.TripDescriptor{
+                direction_id: 0,
+                route_id: "Mattapan",
+                schedule_relationship: :SCHEDULED,
+                start_date: "20170329",
+                start_time: nil,
+                trip_id: "32568935"
+              },
+              vehicle: %GTFS.Realtime.VehicleDescriptor{
+                id: "G-10040",
+                label: "3260",
+                license_plate: nil
+              }
+            },
+            vehicle: nil
+          },
+        ],
+        header: %GTFS.Realtime.FeedHeader{
+          gtfs_realtime_version: "1.0",
+          incrementality: :FULL_DATASET,
+          timestamp: 1490783458
+        }
+      }
+
+      assert get_all(feed_message, @current_time) == %{
+        {"70263", 0} => [
+          %Predictions.Prediction{
+            stop_id: "70263",
+            seconds_until_arrival: 0,
+            direction_id: 0,
+            route_id: "Mattapan"
+          }
+        ]
+      }
+    end
   end
 
   describe "parse_pb_response/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Hotfix: Don't allow negative predictions](https://app.asana.com/0/584764604969369/660555912711969)

Saw a lot of these in the logs:

```
2018-05-04T13:34:12.560 [error] node=nonode@nohost GenServer #PID<0.316.0> terminating
2018-05-04T13:34:12.560 [error] node=nonode@nohost ** (stop) exited in: GenServer.call(PaEss.HttpUpdater, {:send_audio, {"MVAL", "s"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, minutes: 2, verb: :arrives}, 5, 60}, 5000)
2018-05-04T13:34:12.560 [error] node=nonode@nohost     ** (EXIT) an exception was raised:
2018-05-04T13:34:12.560 [error] node=nonode@nohost         ** (FunctionClauseError) no function clause matching in PaEss.Utilities.countdown_minutes_var/1
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (realtime_signs) lib/pa_ess/utilities.ex:20: PaEss.Utilities.countdown_minutes_var(0)
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (realtime_signs) lib/content/audio/next_train_countdown.ex:38: Content.Audio.Content.Audio.NextTrainCountdown.to_params/1
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (realtime_signs) lib/pa_ess/http_updater.ex:47: PaEss.HttpUpdater.handle_call/3
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (stdlib) gen_server.erl:615: :gen_server.try_handle_call/4
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (stdlib) gen_server.erl:647: :gen_server.handle_msg/5
2018-05-04T13:34:12.560 [error] node=nonode@nohost             (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
2018-05-04T13:34:12.560 [error] node=nonode@nohost     (elixir) lib/gen_server.ex:834: GenServer.call/3
2018-05-04T13:34:12.560 [error] node=nonode@nohost     (realtime_signs) lib/signs/countdown.ex:93: Signs.Countdown.handle_info/2
2018-05-04T13:34:12.560 [error] node=nonode@nohost     (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
2018-05-04T13:34:12.560 [error] node=nonode@nohost     (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
2018-05-04T13:34:12.560 [error] node=nonode@nohost     (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
2018-05-04T13:34:12.560 [error] node=nonode@nohost Last message: :read_sign
```

Traced it down, I think, to us allowing `seconds_until_arrival` to be negative, which then blew up the calculation of whether a message should say "arriving" (seconds: 0), "boarding" (seconds: 1-60), or "in x mins". What happened is if the `seconds_until_arrival` is -15 or so, then div(-15, 60) == 0, so we were trying to say "in 0 mins".

This PR fixes it so that predictions bottom out at 0.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
