### PR TITLE
Change train-is-now-arriving messages to be both audio+visual

### DIFF
--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -29,7 +29,7 @@ defmodule Content.Audio.TrainIsArriving do
 
   defimpl Content.Audio do
     def to_params(audio) do
-      {message_id(audio), [], :audio}
+      {message_id(audio), [], :audio_visual}
     end
 
     defp message_id(%{destination: :ashmont}), do: "90129"

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -33,9 +33,9 @@ defmodule Fake.HTTPoison do
         {:ok, %HTTPoison.Response{status_code: 200}}
       body =~ "MsgType=Canned&uid=1004&mid=90&var=4016%2C503%2C5004&typ=1&sta=MCED001000&pri=5&tim=60" ->
         {:ok, %HTTPoison.Response{status_code: 200}}
-      body =~ "MsgType=Canned&uid=1005&mid=90128&var=&typ=1&sta=MCED000100&pri=5&tim=60" ->
+      body =~ "MsgType=Canned&uid=1005&mid=90128&var=&typ=0&sta=MCED000100&pri=5&tim=60" ->
         {:ok, %HTTPoison.Response{status_code: 200}}
-      body =~ "MsgType=Canned&uid=1006&mid=90129&var=&typ=1&sta=MCAP001000&pri=5&tim=60" ->
+      body =~ "MsgType=Canned&uid=1006&mid=90129&var=&typ=0&sta=MCAP001000&pri=5&tim=60" ->
         {:ok, %HTTPoison.Response{status_code: 200}}
     end
   end

--- a/test/content/audio/train_is_arriving_test.exs
+++ b/test/content/audio/train_is_arriving_test.exs
@@ -5,12 +5,12 @@ defmodule Content.Audio.TrainIsArrivingTest do
   describe "Content.Audio.to_params protocol" do
     test "Next train to Ashmont is now arriving" do
       audio = %Content.Audio.TrainIsArriving{destination: :ashmont}
-      assert Content.Audio.to_params(audio) == {"90129", [], :audio}
+      assert Content.Audio.to_params(audio) == {"90129", [], :audio_visual}
     end
 
     test "Next train to Mattapan is now arriving" do
       audio = %Content.Audio.TrainIsArriving{destination: :mattapan}
-      assert Content.Audio.to_params(audio) == {"90128", [], :audio}
+      assert Content.Audio.to_params(audio) == {"90128", [], :audio_visual}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: Change "Train is now arriving" to be A/V](https://app.asana.com/0/584764604969369/660555912711972)

The "next train is now arriving" messages should have been `:audio_visual` instead.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
