### PR TITLE
Less padding on Ashmont sign

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -20,7 +20,7 @@ defmodule Content.Message.Predictions do
   }
 
   @spec new(Predictions.Prediction.t(), String.t()) :: t()
-  def new(%Predictions.Prediction{} = prediction, headsign) do
+  def new(%Predictions.Prediction{} = prediction, headsign, width \\ 18) do
     minutes = case prediction.seconds_until_arrival do
       0 -> :boarding
       x when x in 1..60 -> :arriving
@@ -30,6 +30,7 @@ defmodule Content.Message.Predictions do
     %__MODULE__{
       headsign: headsign,
       minutes: minutes,
+      width: width,
     }
   end
 

--- a/lib/signs/single.ex
+++ b/lib/signs/single.ex
@@ -108,10 +108,12 @@ defmodule Signs.Single do
   end
 
   defp get_message(sign) do
+    sign_width = if sign.pa_ess_id == {"RASH", "m"}, do: 15, else: 18
+
     sign.gtfs_stop_id
     |> sign.prediction_engine.for_stop(sign.direction_id)
     |> Predictions.Predictions.sort()
-    |> Enum.map(& Content.Message.Predictions.new(&1, sign.headsign))
+    |> Enum.map(& Content.Message.Predictions.new(&1, sign.headsign, sign_width))
     |> Enum.at(0, Content.Message.Empty.new())
   end
 

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -20,6 +20,12 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Mattapan       ARR"
     end
 
+    test "can use a shorter line length" do
+      prediction = %Predictions.Prediction{seconds_until_arrival: 550}
+      msg = Content.Message.Predictions.new(prediction, "Mattapan", 15)
+      assert Content.Message.to_string(msg) == "Mattapan  9 min"
+    end
+
     test "1 minute (singular) prediction" do
       prediction = %Predictions.Prediction{
         seconds_until_arrival: 65


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: Fix the padding on the Ashmont sign to match the old system](https://app.asana.com/0/584764604969369/657296736503214)

Most of this was changing the hardcoded `@width` module attribute to being configurable, but with a default of 18 (the original width). So in most cases it would behave the same. Then, for the `{"RASH", "m"}` sign, specifically, it sends its shorter length of 15 (which is what the picture looks like to me).

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
