### PR TITLE
Add rest of SL3 signs to config

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -138,7 +138,7 @@
   {
     "id": "chelsea_inbound",
     "pa_ess_loc": "SCHS",
-    "pa_ess_zone": "w",
+    "pa_ess_zone": "e",
     "headsign": "South Station",
     "bridge_id": 1,
     "gtfs_stop_id": "74630",
@@ -148,7 +148,7 @@
   {
     "id": "chelsea_outbound",
     "pa_ess_loc": "SCHS",
-    "pa_ess_zone": "e",
+    "pa_ess_zone": "w",
     "headsign": "Chelsea",
     "bridge_id": 1,
     "gtfs_stop_id": "74631",
@@ -158,7 +158,7 @@
   {
     "id": "bellingham_square_inbound",
     "pa_ess_loc": "SBQS",
-    "pa_ess_zone": "w",
+    "pa_ess_zone": "e",
     "headsign": "South Station",
     "bridge_id": 1,
     "gtfs_stop_id": "74632",
@@ -168,7 +168,7 @@
   {
     "id": "bellingham_square_outbound",
     "pa_ess_loc": "SBQS",
-    "pa_ess_zone": "e",
+    "pa_ess_zone": "w",
     "headsign": "Chelsea",
     "bridge_id": 1,
     "gtfs_stop_id": "74633",
@@ -198,7 +198,7 @@
   {
     "id": "eastern_ave_inbound",
     "pa_ess_loc": "SEAV",
-    "pa_ess_zone": "w",
+    "pa_ess_zone": "e",
     "headsign": "South Station",
     "bridge_id": 1,
     "gtfs_stop_id": "74636",
@@ -208,7 +208,7 @@
   {
     "id": "eastern_ave_outbound",
     "pa_ess_loc": "SEAV",
-    "pa_ess_zone": "e",
+    "pa_ess_zone": "w",
     "headsign": "Chelsea",
     "bridge_id": 1,
     "gtfs_stop_id": "74637",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [M: Riders see signs and hear audio powered by the V2 codebase](https://app.asana.com/0/584764604969369/666228659493514)

I pulled in the data mostly from the old `config/stations.json`. I'm not sure if there are more stations lingering somewhere else that I should have added?

I followed the convention that "inbound" = "w" = "headsign South Station", and "outbound" = "e" = "headsign Chelsea". I don't know if the sign zones operate differently from that. It's kind of hard to tell from the old config how it works, since every stop ID lists both eastbound and westbound.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
