### PR TITLE
Save and cancel expiration timers in Headway signs

### DIFF
--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -86,7 +86,7 @@ defmodule Signs.Headway do
         }
     end
 
-    send_update(sign, updated)
+    updated = send_update(sign, updated)
     {:noreply, updated}
   end
   def handle_info(:read_sign, sign) do
@@ -98,10 +98,10 @@ defmodule Signs.Headway do
     {:noreply, %{sign | current_content_top: Content.Message.Empty.new(), current_content_bottom: Content.Message.Empty.new()}}
   end
 
-  defp send_update(%{current_content_bottom: same} = sign, %{current_content_bottom: same}) do
+  defp send_update(%{current_content_bottom: same}, %{current_content_bottom: same} = sign) do
     sign
   end
-  defp send_update(sign, %{current_content_top: new_top, current_content_bottom: new_bottom}) do
+  defp send_update(_old_sign, %{current_content_top: new_top, current_content_bottom: new_bottom} = sign) do
     sign.sign_updater.update_sign(sign.pa_ess_id, "1", new_top, @default_duration, :now)
     sign.sign_updater.update_sign(sign.pa_ess_id, "2", new_bottom, @default_duration, :now)
     if sign.timer, do: Process.cancel_timer(sign.timer)

--- a/test/signs/headway_test.exs
+++ b/test/signs/headway_test.exs
@@ -20,7 +20,8 @@ defmodule Signs.HeadwayTest do
   describe "callback update_content" do
     test "updates the top and bottom contents" do
       log = capture_log [level: :info], fn ->
-        assert handle_info(:update_content, @sign) == {:noreply, %{@sign | current_content_top: %Content.Message.Headways.Top{headsign: "Chelsea", vehicle_type: :bus}, current_content_bottom: %Content.Message.Headways.Bottom{range: {1, 2}}}}
+        {:noreply, %{timer: timer, current_content_top: %Content.Message.Headways.Top{headsign: "Chelsea", vehicle_type: :bus}, current_content_bottom: %Content.Message.Headways.Bottom{range: {1, 2}}}} = handle_info(:update_content, @sign)
+        refute is_nil(timer)
       end
       assert log =~ "update_sign called"
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Possibly addresses [Possible Bug: Don't send as many messages to ARINC server](https://app.asana.com/0/584764604969369/669355084637860)

Basically the sign was doing `send_update` but ignoring the result. That function actually updates the `sign` struct, though, with the most recent expiration timer. So my hypothesis is that since we weren't keeping track of and canceling the expiration timers, we ended up with a lots of expirations per sign, and so the sign constantly found itself blank and felt the need to update the signs server.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
