### PR TITLE
Change default duration to two minutes

### DIFF
--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -38,7 +38,7 @@ defmodule Signs.Headway do
     bridge_delay_duration: integer() | nil,
   }
 
-  @default_duration 60
+  @default_duration 120
 
   def start_link(%{"type" => "headway"} = config, opts \\ []) do
     sign_updater = opts[:sign_updater] || Application.get_env(:realtime_signs, :sign_updater_mod)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Increase timeout for static text messages](https://app.asana.com/0/584764604969369/635409080786718)

Increase the timeout to two minutes for headway sign. It's already two minutes for countdown and single.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
