### PR TITLE
Handle case that without unnecessary warn

### DIFF
--- a/lib/content/audio/buses_to_destination.ex
+++ b/lib/content/audio/buses_to_destination.ex
@@ -16,9 +16,9 @@ defmodule Content.Audio.BusesToDestination do
   }
 
   @spec from_headway_message(Content.Message.t(), String.t) :: t() | nil
-  def from_headway_message(msg, dest) do
-    with %Content.Message.Headways.Bottom{range: range} <- msg,
-         {:ok, destination} <- convert_destination(dest),
+  def from_headway_message(%Content.Message.Headways.Bottom{range: range} = msg, dest)
+  when range != {nil, nil} do
+    with {:ok, destination} <- convert_destination(dest),
          {x, y} <- get_mins(range) do
       english = %__MODULE__{
         language: :english,
@@ -34,12 +34,14 @@ defmodule Content.Audio.BusesToDestination do
         nil
     end
   end
+  def from_headway_message(_msg, _dest) do
+    nil
+  end
 
   defp convert_destination("Chelsea"), do: {:ok, :chelsea}
   defp convert_destination("South Station"), do: {:ok, :south_station}
   defp convert_destination(_), do: {:error, :unknown_destination}
 
-  defp get_mins({nil, nil}), do: :nil
   defp get_mins({x, nil}), do: {x, x+2}
   defp get_mins({nil, x}), do: {x, x+2}
   defp get_mins({x, x}), do: {x, x+2}

--- a/test/content/audio/buses_to_destination_test.exs
+++ b/test/content/audio/buses_to_destination_test.exs
@@ -1,5 +1,6 @@
 defmodule Content.Audio.BusesToDestinationTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+  import ExUnit.CaptureLog
 
   import Content.Audio.BusesToDestination
 
@@ -64,9 +65,14 @@ defmodule Content.Audio.BusesToDestinationTest do
       assert from_headway_message(@msg, "Unknown") == nil
     end
 
-    test "returns nil when range is all nil" do
+    test "returns nil when range is all nil, but doesn't warn" do
       msg = %{@msg | range: {nil, nil}}
-      assert from_headway_message(msg, "Chelsea") == nil
+
+      log = capture_log [level: :warn], fn ->
+        assert from_headway_message(msg, "Chelsea") == nil
+      end
+
+      refute log =~ "from_headway_message"
     end
 
     test "returns nil when range is unexpected" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: Unnecessary warnings overnight](https://app.asana.com/0/584764604969369/671100017618307)

Overnight, the headways end up as `{nil, nil}`, as expected. However, when the every-5-minutes loop tries to read it, it can't convert it to an audio message and logs a warning, triggering our warning email. But it's expected that it can't turn that into an audio message. So this updates the function to warn only when it really should: when we don't know the destination, or the range is malformed. Other messages (like `{nil, nil}` or bridge messages) get silently turned into `nil`.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
