### PR TITLE
Bridge IDs are strings!

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -140,7 +140,7 @@
     "pa_ess_loc": "SCHS",
     "pa_ess_zone": "w",
     "headsign": "South Station",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74630",
     "route_id": "743",
     "type": "headway"
@@ -150,7 +150,7 @@
     "pa_ess_loc": "SBSQ",
     "pa_ess_zone": "w",
     "headsign": "South Station",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74632",
     "route_id": "743",
     "type": "headway"
@@ -160,7 +160,7 @@
     "pa_ess_loc": "SBSQ",
     "pa_ess_zone": "e",
     "headsign": "Chelsea",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74633",
     "route_id": "743",
     "type": "headway"
@@ -170,7 +170,7 @@
     "pa_ess_loc": "SBOX",
     "pa_ess_zone": "w",
     "headsign": "South Station",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74634",
     "route_id": "743",
     "type": "headway"
@@ -180,7 +180,7 @@
     "pa_ess_loc": "SBOX",
     "pa_ess_zone": "e",
     "headsign": "Chelsea",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74635",
     "route_id": "743",
     "type": "headway"
@@ -190,7 +190,7 @@
     "pa_ess_loc": "SEAV",
     "pa_ess_zone": "w",
     "headsign": "South Station",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74636",
     "route_id": "743",
     "type": "headway"
@@ -200,7 +200,7 @@
     "pa_ess_loc": "SEAV",
     "pa_ess_zone": "e",
     "headsign": "Chelsea",
-    "bridge_id": 1,
+    "bridge_id": "1",
     "gtfs_stop_id": "74637",
     "route_id": "743",
     "type": "headway"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Next time bridge is up, see why we're not sending audio messages](https://app.asana.com/0/584764604969369/672235254032828)

When the bridge was up today, we weren't seeing any messages being sent to the signs. I believe this is the issue. The signs were configured with integer IDs, while the Engine has the ID as a string. The type spec has it as a string, and most IDs in our system are strings, so I updated the config to go that way.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
