### PR TITLE
Use round instead of div for minutes away

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -24,7 +24,7 @@ defmodule Content.Message.Predictions do
     minutes = case prediction.seconds_until_arrival do
       0 -> :boarding
       x when x in 1..60 -> :arriving
-      x -> div(x, 60)
+      x -> x |> Kernel./(60) |> round()
     end
 
     %__MODULE__{

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -57,5 +57,12 @@ defmodule Content.Message.PredictionsTest do
 
       assert Content.Message.to_string(msg) == ""
     end
+
+    test "Rounds to the nearest minute" do
+      prediction = %Predictions.Prediction{seconds_until_arrival: 91}
+      msg = Content.Message.Predictions.new(prediction, "Ashmont")
+
+      assert Content.Message.to_string(msg) == "Ashmont      2 min"
+    end
   end
 end

--- a/test/signs/countdown_test.exs
+++ b/test/signs/countdown_test.exs
@@ -272,7 +272,7 @@ defmodule Signs.CountdownTest do
       :timer.sleep(1000)
 
       assert(receive do
-        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 1}, 5, 60}} -> true
+        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 2}, 5, 60}} -> true
       after
         0 -> false
       end)
@@ -280,7 +280,7 @@ defmodule Signs.CountdownTest do
       :timer.sleep(1000)
 
       assert(receive do
-        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 1}, 5, 60}} -> true
+        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 2}, 5, 60}} -> true
       after
         0 -> false
       end)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [For calculating "mins" away, use round() not div()](https://app.asana.com/0/584764604969369/671100017618308)

Updated the minutes away functionality to use `round`. This will pick the minute value closest to the actual number of seconds.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
