### PR TITLE
Make no audio announcement for trains one minute away

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -17,6 +17,9 @@ defmodule Content.Audio.NextTrainCountdown do
   require Logger
 
   @spec from_predictions_message(Content.Message.t(), verb()) :: t() | nil
+  def from_predictions_message(%Content.Message.Predictions{minutes: 1}, _verb) do
+    nil
+  end
   def from_predictions_message(%Content.Message.Predictions{minutes: n, headsign: "Ashmont"}, verb) when is_integer(n) do
     %__MODULE__{destination: :ashmont, minutes: n, verb: verb}
   end

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -75,6 +75,12 @@ defmodule Content.Audio.NextTrainCountdownTest do
       assert log =~ "unknown headsign"
     end
 
+    test "Does not announce train one minute away" do
+      message = %Content.Message.Predictions{headsign: "Ashmont", minutes: 1}
+      assert Content.Audio.NextTrainCountdown.from_predictions_message(message, :arrives) == nil
+      assert Content.Audio.NextTrainCountdown.from_predictions_message(message, :departs) == nil
+    end
+
     test "Ignores non-integer messages" do
       message = %Content.Message.Predictions{headsign: "Ashmont", minutes: :arriving}
       assert Content.Audio.NextTrainCountdown.from_predictions_message(message, :arrives) == nil

--- a/test/signs/single_test.exs
+++ b/test/signs/single_test.exs
@@ -108,9 +108,9 @@ defmodule  Signs.SingleTest do
   describe "read sign callback" do
     test "sends an audio request when the top line is a minutes-away prediction" do
       Process.register(self(), :single_test_fake_updater_listener)
-      sign = %{@sign | current_content: %Content.Message.Predictions{headsign: "Mattapan", minutes: 1}}
+      sign = %{@sign | current_content: %Content.Message.Predictions{headsign: "Mattapan", minutes: 2}}
       assert {:noreply, %Signs.Single{}} = Signs.Single.handle_info(:read_sign, sign)
-      assert_received({:send_audio, {{"RASH", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :departs, minutes: 1}, 5, 60}})
+      assert_received({:send_audio, {{"RASH", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :departs, minutes: 2}, 5, 60}})
     end
 
     test "does not send an audio request for a boarding prediction" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug: "next train arriving in one minutes"](https://app.asana.com/0/584764604969369/682847610764519)

Don't create an announcement when the train is one minute away.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
