### PR TITLE
Make arriving announcement configurable boolean

### DIFF
--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -30,6 +30,7 @@ defmodule Signs.Countdown do
     :current_content_top,
     :bottom_timer,
     :top_timer,
+    announce_arriving?: true
   ]
 
   @type t :: %{
@@ -48,6 +49,7 @@ defmodule Signs.Countdown do
     bottom_timer: reference() | nil,
     top_timer: reference() | nil,
     read_sign_period_ms: integer(),
+    announce_arriving?: boolean
   }
 
   @default_duration 120
@@ -72,6 +74,7 @@ defmodule Signs.Countdown do
       sign_updater: sign_updater,
       prediction_engine: prediction_engine,
       read_sign_period_ms: 4 * 60 * 1000,
+      announce_arriving?: Map.get(config, "announce_arriving", true)
     }
 
     GenServer.start_link(__MODULE__, sign)
@@ -176,6 +179,7 @@ defmodule Signs.Countdown do
     %{sign | current_content_bottom: new_bottom, bottom_timer: timer}
   end
 
+  defp announce_arrival(_msg, %{announce_arriving?: false}), do: nil
   defp announce_arrival(msg, sign) do
     case Content.Audio.TrainIsArriving.from_predictions_message(msg) do
       %Content.Audio.TrainIsArriving{} = audio ->


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Make Arriving announcements configurable](https://app.asana.com/0/584764604969369/702211093617935)

Added this a configurable value. Defaults to true. 

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
