### PR TITLE
Add announce_arriving config option for Single signs

### DIFF
--- a/lib/signs/single.ex
+++ b/lib/signs/single.ex
@@ -23,6 +23,7 @@ defmodule Signs.Single do
     :sign_updater,
     :read_sign_period_ms,
     :countdown_verb,
+    :announce_arriving?,
   ]
 
   defstruct @enforce_keys ++ [
@@ -44,6 +45,7 @@ defmodule Signs.Single do
     timer: reference() | nil,
     read_sign_period_ms: integer(),
     countdown_verb: Content.Audio.NextTrainCountdown.verb(),
+    announce_arriving?: boolean(),
   }
 
   @default_duration 120
@@ -66,6 +68,7 @@ defmodule Signs.Single do
       prediction_engine: prediction_engine,
       read_sign_period_ms: 4 * 60 * 1000,
       countdown_verb: config |> Map.fetch!("countdown_verb") |> String.to_atom(),
+      announce_arriving?: Map.fetch!(config, "announce_arriving"),
     }
 
     GenServer.start_link(__MODULE__, sign)
@@ -134,6 +137,9 @@ defmodule Signs.Single do
     %{sign | current_content: new_text, timer: timer}
   end
 
+  defp announce_arrival(_msg, %{announce_arriving?: false}) do
+    nil
+  end
   defp announce_arrival(msg, sign) do
     case Content.Audio.TrainIsArriving.from_predictions_message(msg) do
       %Content.Audio.TrainIsArriving{} = audio ->

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -9,6 +9,7 @@
     "headsign": "Mattapan",
     "route_id": "Mattapan",
     "countdown_verb": "departs",
+    "announce_arriving": true,
     "type": "single"
   },
   {
@@ -45,6 +46,7 @@
     "headsign": "Mattapan",
     "route_id": "Mattapan",
     "countdown_verb": "arrives",
+    "announce_arriving": true,
     "type": "single"
   },
   {
@@ -57,6 +59,7 @@
     "headsign": "Ashmont",
     "route_id": "Mattapan",
     "countdown_verb": "arrives",
+    "announce_arriving": true,
     "type": "single"
   },
   {

--- a/test/signs/single_test.exs
+++ b/test/signs/single_test.exs
@@ -82,7 +82,8 @@ defmodule  Signs.SingleTest do
     sign_updater: FakeUpdater,
     prediction_engine: FakePredictionsEngine,
     read_sign_period_ms: 30_000,
-    countdown_verb: :departs
+    countdown_verb: :departs,
+    announce_arriving?: true,
   }
 
   describe "update_content callback" do
@@ -102,6 +103,13 @@ defmodule  Signs.SingleTest do
       sign = %{@sign | gtfs_stop_id: "audio-arriving"}
       assert {:noreply, %Signs.Single{}} = Signs.Single.handle_info(:update_content, sign)
       assert_received {:send_audio, {{"RASH", "n"}, %Content.Audio.TrainIsArriving{destination: :mattapan}, 5, 60}}
+    end
+
+    test "Does not send arriving audio message if sign is configured to not arriving announcements" do
+      Process.register(self(), :single_test_fake_updater_listener)
+      sign = %{@sign | gtfs_stop_id: "audio-arriving", announce_arriving?: false}
+      assert {:noreply, %Signs.Single{}} = Signs.Single.handle_info(:update_content, sign)
+      refute_received {:send_audio, {{"RASH", "n"}, %Content.Audio.TrainIsArriving{destination: :mattapan}, 5, 60}}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [TICKET_NAME](TICKET_LINK)

[Please include a brief description of what was changed]

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
