### PR TITLE
Add handle_info defaults

### DIFF
--- a/lib/engine/bridge.ex
+++ b/lib/engine/bridge.ex
@@ -39,7 +39,8 @@ defmodule Engine.Bridge do
 
     {:noreply, %{"1" => bridge_status}}
   end
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -40,7 +40,8 @@ defmodule Engine.Config do
 
     {:noreply, latest_version}
   end
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/engine/headways.ex
+++ b/lib/engine/headways.ex
@@ -46,7 +46,8 @@ defmodule Engine.Headways do
     |> Map.keys
     |> update(state)
   end
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -51,7 +51,8 @@ defmodule Engine.Predictions do
     last_modified_positions = download_and_insert_data(last_modified_positions, current_time, &update_positions/2, :vehicle_positions_url)
     {:noreply, {last_modified_predictions, last_modified_positions}}
   end
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/signs/bridge_only.ex
+++ b/lib/signs/bridge_only.ex
@@ -8,6 +8,7 @@ defmodule Signs.BridgeOnly do
   """
 
   use GenServer
+  require Logger
 
   @enforce_keys [
     :id,
@@ -66,7 +67,8 @@ defmodule Signs.BridgeOnly do
 
     {:noreply, sign}
   end
-  def handle_info(_msg, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} #{inspect(state.id)} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -115,7 +115,8 @@ defmodule Signs.Countdown do
     {:noreply, %{sign | current_content_bottom: Content.Message.Empty.new()}}
   end
 
-  def handle_info(_, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} #{inspect(state.id)} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 

--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -113,7 +113,7 @@ defmodule Signs.Headway do
     {:noreply, sign}
   end
   def handle_info(msg, sign) do
-    Logger.warn("Signs.Headway #{inspect(sign.id)} unknown message: #{inspect msg}")
+    Logger.warn("#{__MODULE__} #{inspect(sign.id)} unknown message: #{inspect msg}")
     {:noreply, sign}
   end
 

--- a/lib/signs/single.ex
+++ b/lib/signs/single.ex
@@ -103,7 +103,8 @@ defmodule Signs.Single do
     {:noreply, %{sign | current_content: Content.Message.Empty.new()}}
   end
 
-  def handle_info(_, state) do
+  def handle_info(msg, state) do
+    Logger.warn("#{__MODULE__} #{inspect(state.id)} unknown message: #{inspect msg}")
     {:noreply, state}
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Sentry error REALTIME-SIGNS-PROD-12](https://app.asana.com/0/584764604969369/board)

It's recommended to always add a default to `handle_info` when you are overwriting the function in a GenServer. `handle_info` can receive junk messages about processes that aren't relevant, so we should have a default set up to handle them. Otherwise, the process can crash.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
