### PR TITLE
add audio stuff for orange  line

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -9,7 +9,7 @@ defmodule Content.Audio.NextTrainCountdown do
   @type verb :: :arrives | :departs
 
   @type t :: %__MODULE__{
-    destination: :ashmont | :mattapan | :wonderland | :bowdoin,
+    destination: :ashmont | :mattapan | :wonderland | :bowdoin | :forest_hills | :oak_grove,
     verb: verb(),
     minutes: integer()
   }
@@ -32,6 +32,12 @@ defmodule Content.Audio.NextTrainCountdown do
   def from_predictions_message(%Content.Message.Predictions{minutes: n, headsign: "Bowdoin"}, verb) when is_integer(n) do
     %__MODULE__{destination: :bowdoin, minutes: n, verb: verb}
   end
+  def from_predictions_message(%Content.Message.Predictions{minutes: n, headsign: "Forest Hills"}, verb) when is_integer(n) do
+    %__MODULE__{destination: :forest_hills, minutes: n, verb: verb}
+  end
+  def from_predictions_message(%Content.Message.Predictions{minutes: n, headsign: "Oak Grove"}, verb) when is_integer(n) do
+    %__MODULE__{destination: :oak_grove, minutes: n, verb: verb}
+  end
   def from_predictions_message(%Content.Message.Predictions{minutes: n, headsign: headsign}, _verb) when is_integer(n) do
     Logger.warn("Content.Audio.NextTrainCountdown.from_predictions_message: unknown headsign: #{headsign}")
     nil
@@ -51,6 +57,8 @@ defmodule Content.Audio.NextTrainCountdown do
     defp destination_var(%{destination: :mattapan}), do: "4100"
     defp destination_var(%{destination: :bowdoin}), do: "4055"
     defp destination_var(%{destination: :wonderland}), do: "4044"
+    defp destination_var(%{destination: :forest_hills}), do: "4043"
+    defp destination_var(%{destination: :oak_grove}), do: "4022"
 
     defp verb_var(%{verb: :arrives}), do: "503"
     defp verb_var(%{verb: :departs}), do: "502"

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -38,6 +38,24 @@ defmodule Content.Audio.NextTrainCountdownTest do
       }
       assert Content.Audio.to_params(audio) == {"90", ["4044", "503", "5005"], :audio}
     end
+
+    test "Next train to Forest Hills" do
+      audio = %Content.Audio.NextTrainCountdown{
+        destination: :forest_hills,
+        verb: :arrives,
+        minutes: 5,
+      }
+      assert Content.Audio.to_params(audio) == {"90", ["4043", "503", "5005"], :audio}
+    end
+
+    test "Next train to Oak Grove" do
+      audio = %Content.Audio.NextTrainCountdown{
+        destination: :oak_grove,
+        verb: :arrives,
+        minutes: 5,
+      }
+      assert Content.Audio.to_params(audio) == {"90", ["4022", "503", "5005"], :audio}
+    end
   end
 
   describe "from_predictions_message/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [audio headsigns for orange line](https://app.asana.com/0/584764604969369/714677169096846)

relevant signengine.cpp segment: 
<img width="947" alt="screen shot 2018-06-18 at 3 48 37 pm" src="https://user-images.githubusercontent.com/2266961/41558551-26a01f44-730f-11e8-803d-4df75dc0dabc.png">

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
