### PR TITLE
when the bottom line is boarding, instead it should be arriving

### DIFF
--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -139,14 +139,17 @@ defmodule Signs.Countdown do
 
     {
       Enum.at(messages, 0, Content.Message.Empty.new()),
-      messages |> Enum.at(1, Content.Message.Empty.new()) |> non_boarding
+      messages |> Enum.at(1, Content.Message.Empty.new()) |> non_boarding(sign.terminal)
     }
   end
 
-  defp non_boarding(%{minutes: :boarding} = msg) do
+  defp non_boarding(%{minutes: :boarding} = msg, true) do
     %{msg | minutes: 1}
   end
-  defp non_boarding(msg) do
+  defp non_boarding(%{minutes: :boarding} = msg, false) do
+    %{msg | minutes: :arriving}
+  end
+  defp non_boarding(msg, _) do
     msg
   end
 

--- a/test/signs/countdown_test.exs
+++ b/test/signs/countdown_test.exs
@@ -111,7 +111,39 @@ defmodule Signs.CountdownTest do
   }
 
   describe "update_content callback" do
-    test "when the bottom line is boarding, instead show 1 min" do
+    test "when the bottom line is boarding at a terminal, instead show arriving" do
+      top_content = %Content.Message.Predictions{
+        headsign: "Mattapan", minutes: :boarding
+      }
+
+      bottom_content = %Content.Message.Predictions{
+        headsign: "Mattapan", minutes: :boarding
+      }
+
+      sign = %Signs.Countdown{
+        id: "test-sign",
+        pa_ess_id: "123",
+        gtfs_stop_id: "two_boarding",
+        direction_id: 1,
+        route_id: "Mattapan",
+        headsign: "Mattapan",
+        current_content_bottom: bottom_content,
+        current_content_top: top_content,
+        countdown_verb: :arrives,
+        terminal: false,
+        sign_updater: FakeUpdater,
+        prediction_engine: FakePredictionsEngine,
+        read_sign_period_ms: 10_000,
+      }
+
+      expected_bottom = %Content.Message.Predictions{
+        headsign: "Mattapan", minutes: :arriving
+      }
+
+      assert {:noreply, %{current_content_bottom: ^expected_bottom}} = Signs.Countdown.handle_info(:update_content, sign)
+    end
+
+    test "when the bottom line is boarding at a terminal, instead show 1 min" do
       top_content = %Content.Message.Predictions{
         headsign: "Mattapan", minutes: :boarding
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: User never sees BRD on the bottom line](https://app.asana.com/0/584764604969369/712383758547503)

i was a little torn on where to make this change, because on the one hand it seems like its a `Content.Message.Predictions` thing, but on the other hand it seems weird that the content module would care what line of the sign the message is for.  I went with keeping it in the countdown module for that reason but i can be persuaded. 

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
