### PR TITLE
increase GenServer call timeout

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -20,17 +20,17 @@ defmodule PaEss.HttpUpdater do
 
   @impl PaEss.Updater
   def update_single_line(pid \\ __MODULE__, pa_ess_id, line_no, msg, duration, start_secs) do
-    GenServer.call(pid, {:update_single_line, pa_ess_id, line_no, msg, duration, start_secs})
+    GenServer.call(pid, {:update_single_line, pa_ess_id, line_no, msg, duration, start_secs}, 6000)
   end
 
   @impl PaEss.Updater
   def update_sign(pid \\ __MODULE__, pa_ess_id, top_line, bottom_line, duration, start_secs) do
-    GenServer.call(pid, {:update_sign, pa_ess_id, top_line, bottom_line, duration, start_secs})
+    GenServer.call(pid, {:update_sign, pa_ess_id, top_line, bottom_line, duration, start_secs}, 6000)
   end
 
   @impl PaEss.Updater
   def send_audio(pid \\ __MODULE__, pa_ess_id, audio, priority, timeout) do
-    GenServer.call(pid, {:send_audio, pa_ess_id, audio, priority, timeout})
+    GenServer.call(pid, {:send_audio, pa_ess_id, audio, priority, timeout}, 6000)
   end
 
   @impl GenServer


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket, but sentry issue: https://sentry.io/mbta-rtr/realtime-signs-prod/issues/584634416/?query=is:unresolved

The timeout for the HTTP request and GenServer call are both 5000 ms. If the HTTP request times out, the Genserver call will timeout before it gets the `timeout` response, and crash anyways. This should more gracefully handle these timeouts

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
