### PR TITLE
moove the offset to a separate config value so that we can have the s…

### DIFF
--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -24,7 +24,6 @@ defmodule Signs.Countdown do
     :prediction_engine,
     :sign_updater,
     :read_sign_period_ms,
-    :initial_offset,
   ]
 
   defstruct @enforce_keys ++ [
@@ -51,7 +50,6 @@ defmodule Signs.Countdown do
     bottom_timer: reference() | nil,
     top_timer: reference() | nil,
     read_sign_period_ms: integer(),
-    initial_offset: integer(),
     announce_arriving?: boolean
   }
 
@@ -61,15 +59,6 @@ defmodule Signs.Countdown do
   def start_link(%{"type" => "countdown"} = config, opts \\ []) do
     sign_updater = opts[:sign_updater] || Application.get_env(:realtime_signs, :sign_updater_mod)
     prediction_engine = opts[:prediction_engine] || Engine.Predictions
-    offset_seed = case config |> Map.fetch!("gtfs_stop_id") |> Integer.parse do
-      {num, _} -> num
-      _ -> 0
-    end
-    read_offset = if Integer.is_even(offset_seed) do
-      30 * 1_000
-    else
-      0
-    end
 
     sign = %__MODULE__{
       id: Map.fetch!(config, "id"),
@@ -87,7 +76,6 @@ defmodule Signs.Countdown do
       sign_updater: sign_updater,
       prediction_engine: prediction_engine,
       read_sign_period_ms: 4 * 60 * 1000,
-      initial_offset: read_offset,
       announce_arriving?: Map.get(config, "announce_arriving", true)
     }
 
@@ -96,7 +84,7 @@ defmodule Signs.Countdown do
 
   def init(sign) do
     schedule_update(self())
-    schedule_reading_sign(self(), sign.read_sign_period_ms + sign.initial_offset)
+    schedule_reading_sign(self(), sign.read_sign_period_ms + initial_offset(sign))
     {:ok, sign}
   end
 
@@ -212,6 +200,18 @@ defmodule Signs.Countdown do
         sign.sign_updater.send_audio(sign.pa_ess_id, audio, 5, 60)
       nil ->
         nil
+    end
+  end
+
+  def initial_offset(sign) do
+    offset_seed = case sign.gtfs_stop_id |> Integer.parse do
+      {num, _} -> num
+      _ -> 0
+    end
+    if Integer.is_even(offset_seed) do
+      30 * 1_000
+    else
+      0
     end
   end
 

--- a/test/signs/countdown_test.exs
+++ b/test/signs/countdown_test.exs
@@ -127,7 +127,6 @@ defmodule Signs.CountdownTest do
     sign_updater: FakeUpdater,
     prediction_engine: FakePredictionsEngine,
     read_sign_period_ms: 10_000,
-    initial_offset: 0,
   }
 
   @empty_sign %{@content_sign | gtfs_stop_id: "many_predictions", current_content_bottom: nil, current_content_top: nil, terminal: true}
@@ -146,7 +145,6 @@ defmodule Signs.CountdownTest do
     sign_updater: FakeUpdater,
     prediction_engine: FakePredictionsEngine,
     read_sign_period_ms: 10_000,
-    initial_offset: 0
   }
 
   describe "update_content callback" do
@@ -173,7 +171,6 @@ defmodule Signs.CountdownTest do
         sign_updater: FakeUpdater,
         prediction_engine: FakePredictionsEngine,
         read_sign_period_ms: 10_000,
-        initial_offset: 0
       }
 
       expected_bottom = %Content.Message.Predictions{
@@ -206,7 +203,6 @@ defmodule Signs.CountdownTest do
         sign_updater: FakeUpdater,
         prediction_engine: FakePredictionsEngine,
         read_sign_period_ms: 10_000,
-        initial_offset: 0
       }
 
       expected_bottom = %Content.Message.Predictions{
@@ -360,7 +356,7 @@ defmodule Signs.CountdownTest do
     test "callback is invoked periodically" do
       Process.register(self(), :fake_updater_listener)
       sign = %{@audio_sign | current_content_top: %Content.Message.Predictions{headsign: "Mattapan", minutes: 2},
-                            gtfs_stop_id: "not-arriving", read_sign_period_ms: 1_000}
+                            gtfs_stop_id: "1", read_sign_period_ms: 1_000}
 
       {:ok, _pid} = GenServer.start_link(Signs.Countdown, sign)
 
@@ -423,40 +419,13 @@ defmodule Signs.CountdownTest do
       state = :sys.get_state(pid)
       assert %{id: "sign_1", gtfs_stop_id: "1", pa_ess_id: {"SIGN", "m"}} = state
     end
+  end
 
+  describe "initial_offset/1" do
     test "when the stop id is even, offset is 30 seconds later than if its odd" do
-      odd_config = %{
-        "id" => "sign_1",
-        "gtfs_stop_id" => "1",
-        "pa_ess_loc" => "SIGN",
-        "pa_ess_zone" => "m",
-        "direction_id" => 0,
-        "route_id" => "Mattapan",
-        "headsign" => "Mattapan",
-        "terminal" => false,
-        "countdown_verb" => "arrives",
-        "type" => "countdown"
-      }
-      opts = [sign_updater: __MODULE__, prediction_engine: __MODULE__]
-      {:ok, pid} = Signs.Countdown.start_link(odd_config, opts)
-      odd_state = :sys.get_state(pid)
-
-      even_config = %{
-        "id" => "sign_1",
-        "gtfs_stop_id" => "2",
-        "pa_ess_loc" => "SIGN",
-        "pa_ess_zone" => "m",
-        "direction_id" => 0,
-        "route_id" => "Mattapan",
-        "headsign" => "Mattapan",
-        "terminal" => false,
-        "countdown_verb" => "arrives",
-        "type" => "countdown"
-      }
-      opts = [sign_updater: __MODULE__, prediction_engine: __MODULE__]
-      {:ok, pid} = Signs.Countdown.start_link(even_config, opts)
-      even_state = :sys.get_state(pid)
-      assert even_state.initial_offset == odd_state.initial_offset + 30_000
+      odd_sign = %{@content_sign | gtfs_stop_id: "1"}
+      even_sign = %{@content_sign | gtfs_stop_id: "2"}
+      assert Signs.Countdown.initial_offset(even_sign) == Signs.Countdown.initial_offset(odd_sign) + 30_000
     end
   end
 end


### PR DESCRIPTION
…ame period still

#### Summary of changes
**Asana Ticket:** [even-numbered signs sleep for 30 seconds on init](https://app.asana.com/0/629710038948323/720053801252179)

have an initial offset 
#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
