### PR TITLE
Periodically log length of message queue

### DIFF
--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -63,6 +63,10 @@ defmodule MessageQueue do
       state.queue
     end
 
+    if state.length > 0 and rem(state.length, 30) == 0 do
+      Logger.info("MessageQueue queue_length=#{state.length}")
+    end
+
     queue = :queue.in(msg, queue)
 
     {:reply, {:ok, :sent}, %{state | queue: queue, length: min(@max_size, state.length + 1)}}

--- a/test/message_queue_test.exs
+++ b/test/message_queue_test.exs
@@ -1,5 +1,6 @@
 defmodule MessageQueueTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   describe "handle_call :queue_update" do
     test "adds message to the queue" do
@@ -19,6 +20,16 @@ defmodule MessageQueueTest do
       {:reply, {:ok, :sent}, state} = MessageQueue.handle_call({:queue_update, msg}, self(), state)
 
       assert {{:value, 2}, _queue} = :queue.out(state.queue)
+    end
+
+    test "logs if message size is multiple of 30" do
+      state = %{queue: :queue.new(), length: 30}
+
+      log = capture_log [level: :info], fn ->
+        MessageQueue.handle_call({:queue_update, :foo}, self(), state)
+      end
+
+      assert log =~ "queue_length=30"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Might help with [Bug: Delay on signs?](https://app.asana.com/0/584764604969369/730871459966638)

The delay on signs might be due to a large message queue. This should provide a bit of visibility into the queue, by logging at each multiple of 30. The queue grows and shrinks by one every time, so we're guaranteed to hit a multiple of 30 each time we cross it.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
