### PR TITLE
Stop spamming SEAV with announcements when the bridge is up

### DIFF
--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -120,10 +120,10 @@ defmodule Signs.Headway do
   defp send_update(%{current_content_bottom: same}, %{current_content_bottom: same} = sign) do
     sign
   end
-  defp send_update(_old_sign, %{current_content_top: new_top, current_content_bottom: new_bottom} = sign) do
+  defp send_update(old_sign, %{current_content_top: new_top, current_content_bottom: new_bottom} = sign) do
     sign.sign_updater.update_sign(sign.pa_ess_id, new_top, new_bottom, @default_duration, :now)
 
-    if new_top == %Content.Message.Bridge.Up{} do
+    if bridge_is_newly_up?(old_sign, sign) do
       read_bridge_messages(sign)
       schedule_bridge_announcement_update(self())
     end
@@ -160,6 +160,12 @@ defmodule Signs.Headway do
   end
   defp bottom_content(range) do
     %Content.Message.Headways.Bottom{range: range}
+  end
+
+  defp bridge_is_newly_up?(old_sign, new_sign) do
+    (new_sign.current_content_top == %Content.Message.Bridge.Up{})
+    and (old_sign.current_content_top != %Content.Message.Bridge.Up{})
+    and (old_sign.current_content_top != Content.Message.Empty.new()) # e.g. from message expiration
   end
 
   defp read_headway(%{current_content_bottom: msg} = sign) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug: Bridge messages playing over and over again](https://app.asana.com/0/584764604969369/730251246567344)

When the bridge goes up we kick off an every-5-minutes loop to check if the bridge is still up and make an announcement if so. But the logic to check if the bridge just went up was flawed: we were checking to see if the previous content (e.g. "Buses to Chelsea") is different from the current content ("Bridge is up"), but in fact because the top content expires every minute, it was also firing on the Empty -> "Bridge is up" transition.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
