### PR TITLE
remove ashmont special case

### DIFF
--- a/lib/signs/single.ex
+++ b/lib/signs/single.ex
@@ -119,7 +119,7 @@ defmodule Signs.Single do
 
     sign.gtfs_stop_id
     |> sign.prediction_engine.for_stop(sign.direction_id)
-    |> Predictions.Predictions.sort()
+    |> Predictions.Predictions.sort(:arrival)
     |> Enum.map(& Content.Message.Predictions.non_terminal(&1, @sign_width, boarding?))
     |> Enum.at(0, Content.Message.Empty.new())
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: Remove the special handling of spacing on the Ashmont MZ sign](https://app.asana.com/0/584764604969369/736517565205154)

remove the special case.  should merge such that the next deploy releases the red line so that we dont get a weird behavior at ashmont in the interim.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
