### PR TITLE
Bug fix: we were sorting on arrival_time always

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -43,9 +43,12 @@ defmodule Predictions.Predictions do
     GTFS.Realtime.FeedMessage.decode(body)
   end
 
-  @spec sort([Predictions.Prediction.t]) :: [Predictions.Prediction.t]
-  def sort(predictions) do
+  @spec sort([Predictions.Prediction.t], :arrival | :departure) :: [Predictions.Prediction.t]
+  def sort(predictions, :arrival) do
     Enum.sort(predictions, & &1.seconds_until_arrival < &2.seconds_until_arrival)
+  end
+  def sort(predictions, :departure) do
+    Enum.sort(predictions, & &1.seconds_until_departure < &2.seconds_until_departure)
   end
 
   @spec headsign_for_prediction(String.t(), 0 | 1, String.t()) :: {:ok, String.t()} | {:error, :not_found}

--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -120,10 +120,15 @@ defmodule Signs.Countdown do
 
   defp get_messages(sign) do
     stopped_at? = sign.prediction_engine.stopped_at?(sign.gtfs_stop_id)
+    sort_type = if sign.terminal do
+      :departure
+    else
+      :arrival
+    end
     predictions =
       sign.gtfs_stop_id
       |> sign.prediction_engine.for_stop(sign.direction_id)
-      |> Predictions.Predictions.sort()
+      |> Predictions.Predictions.sort(sort_type)
       |> Enum.take(2)
 
     [p1, p2 | _rest] = predictions ++ [nil, nil]

--- a/lib/signs/single.ex
+++ b/lib/signs/single.ex
@@ -119,7 +119,7 @@ defmodule Signs.Single do
 
     sign.gtfs_stop_id
     |> sign.prediction_engine.for_stop(sign.direction_id)
-    |> Predictions.Predictions.sort()
+    |> Predictions.Predictions.sort(:arrival)
     |> Enum.map(& Content.Message.Predictions.non_terminal(&1, sign_width, boarding?))
     |> Enum.at(0, Content.Message.Empty.new())
   end

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -150,12 +150,21 @@ defmodule Predictions.PredictionsTest do
 
   describe "sort/1" do
     test "Sorts predictions in ascending order of seconds_until_arrival" do
-      p1 = %Prediction{seconds_until_arrival: 500}
-      p2 = %Prediction{seconds_until_arrival: 120}
-      p3 = %Prediction{seconds_until_arrival: 45}
-      p4 = %Prediction{seconds_until_arrival: 180}
+      p1 = %Prediction{seconds_until_arrival: 500, seconds_until_departure: 180}
+      p2 = %Prediction{seconds_until_arrival: 120, seconds_until_departure: 120}
+      p3 = %Prediction{seconds_until_arrival: 45, seconds_until_departure: 500}
+      p4 = %Prediction{seconds_until_arrival: 180, seconds_until_departure: 45}
 
-      assert sort([p1, p2, p3, p4]) == [p3, p2, p4, p1]
+      assert sort([p1, p2, p3, p4], :arrival) == [p3, p2, p4, p1]
+    end
+
+    test "Sorts predictions in ascending order of seconds_until_departure" do
+      p1 = %Prediction{seconds_until_departure: 500, seconds_until_arrival: 180}
+      p2 = %Prediction{seconds_until_departure: 120, seconds_until_arrival: 120}
+      p3 = %Prediction{seconds_until_departure: 45, seconds_until_arrival: 500}
+      p4 = %Prediction{seconds_until_departure: 180, seconds_until_arrival: 45}
+
+      assert sort([p1, p2, p3, p4], :departure) == [p3, p2, p4, p1]
     end
   end
 end


### PR DESCRIPTION
Now that we have both arrival times and departure times we need separate sorts.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
