### PR TITLE
If the lines of a countdown have different headsigns announce both

### DIFF
--- a/lib/signs/countdown.ex
+++ b/lib/signs/countdown.ex
@@ -216,9 +216,11 @@ defmodule Signs.Countdown do
     end
   end
 
-  defp read_countdown(%{current_content_top: %{headsign: _headsign} = top_msg, current_content_bottom: %{headsign: _different_headsign} = bottom_msg} = sign) do
+  defp read_countdown(%{current_content_top: %{headsign: top_headsign} = top_msg, current_content_bottom: %{headsign: bottom_headsign} = bottom_msg} = sign) do
     do_read_countdown(top_msg, sign)
-    do_read_countdown(bottom_msg, sign)
+    if top_headsign != bottom_headsign do
+      do_read_countdown(bottom_msg, sign)
+    end
   end
   defp read_countdown(%{current_content_top: top_msg} = sign) do
     do_read_countdown(top_msg, sign)

--- a/test/signs/countdown_test.exs
+++ b/test/signs/countdown_test.exs
@@ -354,19 +354,25 @@ defmodule Signs.CountdownTest do
         0 -> false
       end)
       assert(receive do
-        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :braintree, verb: :arrives, minutes: 3}, 5, 60}} -> true
+        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{}, 5, 60}} -> true
       after
         0 -> false
       end)
     end
 
-    test "sends an audio request when the top line is a minutes-away prediction" do
+    test "sends one audio request when the top line has the same headsign as the bottom line" do
       sign = %{@audio_sign | current_content_top: %Content.Message.Predictions{headsign: "Mattapan", minutes: 2},
+                            current_content_bottom: %Content.Message.Predictions{headsign: "Mattapan", minutes: 3},
                             gtfs_stop_id: "not-arriving"}
 
       assert {:noreply, %Signs.Countdown{}} = Signs.Countdown.handle_info(:read_sign, sign)
       assert(receive do
         {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 2}, 5, 60}} -> true
+      after
+        0 -> false
+      end)
+      refute(receive do
+        {:send_audio, {{"ABCD", "n"}, %Content.Audio.NextTrainCountdown{destination: :mattapan, verb: :arrives, minutes: 3}, 5, 60}} -> true
       after
         0 -> false
       end)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Announce minutes away for both lines if different headsigns](https://app.asana.com/0/107495983514632/740561292363448)

If the top and bottom lines of a countdown sign have difference headsigns on them, we need to announce both. I'm not 100% sure if my test is the right way to test this but it seems to work?

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
