### PR TITLE
add ashmont and jfk stops to the headsign picker because they are not…

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -79,8 +79,8 @@ defmodule Content.Message.Predictions do
   defp headsign_for_prediction("Blue", 0, _), do: {:ok, "Bowdoin"}
   defp headsign_for_prediction("Blue", 1, _), do: {:ok, "Wonderland"}
   defp headsign_for_prediction("Red", 1, _), do: {:ok, "Alewife"}
-  defp headsign_for_prediction("Red", 0, last_stop_id) when last_stop_id in ["70087", "70089", "70091", "70093"], do: {:ok, "Ashmont"}
-  defp headsign_for_prediction("Red", 0, last_stop_id) when last_stop_id in ["70097", "70101", "70103", "70105"], do: {:ok, "Braintree"}
+  defp headsign_for_prediction("Red", 0, last_stop_id) when last_stop_id in ["70085", "70086", "70087", "70089", "70091", "70093"], do: {:ok, "Ashmont"}
+  defp headsign_for_prediction("Red", 0, last_stop_id) when last_stop_id in ["70095", "70096", "70097", "70101", "70103", "70105"], do: {:ok, "Braintree"}
   defp headsign_for_prediction("Green-B", 0, _), do: {:ok, "Boston Col"}
   defp headsign_for_prediction("Green-C", 0, _), do: {:ok, "Clvlnd Cir"}
   defp headsign_for_prediction("Green-D", 0, _), do: {:ok, "Riverside"}


### PR DESCRIPTION
… the same

#### Summary of changes
**Asana Ticket:** [default to ashmont on ashmont side adn braintree on braintree side](https://app.asana.com/0/584764604969369/743214766223067)

add the ashmont/braintree sides of jfk into the selector.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [ ] Any added functionality works properly
