### PR TITLE
HTTP timeout less than GenServer timeout

### DIFF
--- a/lib/bridge/request.ex
+++ b/lib/bridge/request.ex
@@ -10,7 +10,7 @@ defmodule Bridge.Request do
 
     @bridge_url
     |> Kernel.<>("#{id}")
-    |> http_client.get(headers, [timeout: 4500, recv_timeout: 4500])
+    |> http_client.get(headers, [timeout: 2000, recv_timeout: 2000])
     |> parse_response(current_time)
   end
 

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -80,7 +80,7 @@ defmodule Engine.Predictions do
   defp download_and_insert_data(last_modified, current_time, parse_fn, url) do
     http_client = Application.get_env(:realtime_signs, :http_client)
     full_url = Application.get_env(:realtime_signs, url)
-    case http_client.get(full_url, [{"If-Modified-Since", format_last_modified(last_modified)}], [timeout: 4500, recv_timeout: 4500]) do
+    case http_client.get(full_url, [{"If-Modified-Since", format_last_modified(last_modified)}], [timeout: 2000, recv_timeout: 2000]) do
       {:ok, %HTTPoison.Response{body: body, status_code: status}} when status >= 200 and status < 300 ->
         parse_fn.(body, current_time)
         current_time

--- a/lib/headway/request.ex
+++ b/lib/headway/request.ex
@@ -19,7 +19,7 @@ defmodule Headway.Request do
     http_client = Application.get_env(:realtime_signs, :http_client)
     station_ids
     |> ScheduleHeadway.build_request()
-    |> http_client.get([], [timeout: 4500, recv_timeout: 4500])
+    |> http_client.get([], [timeout: 2000, recv_timeout: 2000])
   end
 
   defp parse_body(body) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Timeouts of Bridge API cause crash](https://app.asana.com/0/629710038948323/747329135369952)

I reduced the timeout in HTTPoison.get calls to 4500 so that they will time out before the GenServer calls time out and Erlang won't crash. All three of these calls already had error handling so it should just work out of the box.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
