### PR TITLE
add .formatter.exs file

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "lib/**/*.{ex,exs}", "test/**/*.{ex,exs}"],
+  rename_deprecated_at: "1.6.0"
+]


### PR DESCRIPTION
#### Summary of changes
No Asana ticket.

Add `.formatter.exs` file which allows you to run `mix format` without specifying which files to format.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
