### PR TITLE
dont read audio for stopped 0 stops away

### DIFF
--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -14,7 +14,8 @@ defmodule Content.Audio.StoppedTrain do
         }
 
   @spec from_message(Content.Message.t()) :: t() | nil
-  def from_message(%Content.Message.StoppedTrain{headsign: headsign, stops_away: stops_away}) do
+  def from_message(%Content.Message.StoppedTrain{headsign: headsign, stops_away: stops_away})
+      when stops_away > 0 do
     case PaEss.Utilities.headsign_to_terminal_station(headsign) do
       {:ok, terminal} ->
         %__MODULE__{destination: terminal, stops_away: stops_away}

--- a/test/content/audio/stopped_train_test.exs
+++ b/test/content/audio/stopped_train_test.exs
@@ -41,5 +41,11 @@ defmodule Content.Audio.StoppedTrainTest do
       msg = %Content.Message.Empty{}
       assert Content.Audio.StoppedTrain.from_message(msg) == nil
     end
+
+    test "when the trian is stopped 0 stops away, does not announce that it is stopped 0 stops away" do
+      msg = %Content.Message.StoppedTrain{headsign: "Frst Hills", stops_away: 0}
+
+      assert Content.Audio.StoppedTrain.from_message(msg) == nil
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [S: Don't send audio for "stopped 0 stops away"](https://app.asana.com/0/584764604969369/791736351488033)

just dont announce when we are stopped 0 stops away.   we dont currently do boarding announcements so no need for that.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
