### PR TITLE
Temporarily remove minutes from bridge messages

### DIFF
--- a/lib/signs/bridge_only.ex
+++ b/lib/signs/bridge_only.ex
@@ -56,8 +56,8 @@ defmodule Signs.BridgeOnly do
     schedule_bridge_check(self(), sign.bridge_check_period_ms)
 
     case sign.bridge_engine.status(sign.bridge_id) do
-      {"Raised", duration} ->
-        {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(duration)
+      {"Raised", _duration} ->
+        {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(nil)
 
         for audio <- [english, spanish] do
           if audio, do: sign.sign_updater.send_audio(sign.pa_ess_id, audio, 5, 120)

--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -206,8 +206,8 @@ defmodule Signs.Headway do
     end
   end
 
-  defp read_bridge_messages(%{bridge_delay_duration: duration} = sign) do
-    {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(duration)
+  defp read_bridge_messages(%{bridge_delay_duration: _duration} = sign) do
+    {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(nil)
 
     for audio <- [english, spanish] do
       if audio, do: sign.sign_updater.send_audio(sign.pa_ess_id, audio, 5, 120)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Only send audio for bridge with no minutes](https://app.asana.com/0/584764604969369/795656212362937)

There is an ongoing bug with the PA system where the bridge message sounds funny if you include the number of minutes, but sounds fine if you don't. So this PR removes the minutes until we can get that issue resolved.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
