### PR TITLE
fix wrong zone for SSOU

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -2587,7 +2587,7 @@
     "id": "south_station_silver_line_arrival_platform",
     "type": "realtime",
     "pa_ess_loc": "SSOU",
-    "pa_ess_zone": "m",
+    "pa_ess_zone": "w",
     "source_config": [
       [
         {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [SSOU MZ should be SSOU WB for silver arrivals](https://app.asana.com/0/584764604969369/795656212362936)

wrong zone

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
