### PR TITLE
Revert "Temporarily remove minutes from bridge messages"

### DIFF
--- a/lib/signs/bridge_only.ex
+++ b/lib/signs/bridge_only.ex
@@ -56,8 +56,8 @@ defmodule Signs.BridgeOnly do
     schedule_bridge_check(self(), sign.bridge_check_period_ms)
 
     case sign.bridge_engine.status(sign.bridge_id) do
-      {"Raised", _duration} ->
-        {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(nil)
+      {"Raised", duration} ->
+        {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(duration)
 
         for audio <- [english, spanish] do
           if audio, do: sign.sign_updater.send_audio(sign.pa_ess_id, audio, 5, 120)

--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -206,8 +206,8 @@ defmodule Signs.Headway do
     end
   end
 
-  defp read_bridge_messages(%{bridge_delay_duration: _duration} = sign) do
-    {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(nil)
+  defp read_bridge_messages(%{bridge_delay_duration: duration} = sign) do
+    {english, spanish} = Content.Audio.BridgeIsUp.create_bridge_messages(duration)
 
     for audio <- [english, spanish] do
       if audio, do: sign.sign_updater.send_audio(sign.pa_ess_id, audio, 5, 120)


### PR DESCRIPTION
Reverts mbta/realtime_signs#155 because ARINC has now fixed the issue sufficiently that we can turn this back on.