### PR TITLE
10 seconds per update

### DIFF
--- a/lib/engine/bridge.ex
+++ b/lib/engine/bridge.ex
@@ -50,6 +50,6 @@ defmodule Engine.Bridge do
   end
 
   defp schedule_update(pid) do
-    Process.send_after(pid, :update, 60 * 1_000)
+    Process.send_after(pid, :update, 60 * 10_000)
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug: REALTIME-SIGNS-PROD-1X](https://app.asana.com/0/584764604969369/811744926246487)

reduce the update rate of the headway signs and hope that they dont timeout anymore.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
