### PR TITLE
Add ability to filter predictions by route list

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -29,6 +29,7 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.flat_map(fn source ->
       source.stop_id
       |> prediction_engine.for_stop(source.direction_id)
+      |> Enum.filter(&(source.routes == nil or &1.route_id in source.routes))
       |> Enum.map(&{source, &1})
     end)
     |> Enum.filter(fn {_, p} ->

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -40,11 +40,12 @@ defmodule Signs.Utilities.SourceConfig do
   """
 
   @enforce_keys [:stop_id, :direction_id, :platform, :terminal?, :announce_arriving?]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:routes]
 
   @type source :: %__MODULE__{
           stop_id: String.t(),
           direction_id: 0 | 1,
+          routes: [String.t()] | nil,
           platform: :ashmont | :braintree | nil,
           terminal?: boolean(),
           announce_arriving?: boolean()
@@ -64,13 +65,15 @@ defmodule Signs.Utilities.SourceConfig do
     }
   end
 
-  defp parse_source!(%{
-         "stop_id" => stop_id,
-         "direction_id" => direction_id,
-         "platform" => platform,
-         "terminal" => terminal?,
-         "announce_arriving" => announce_arriving?
-       }) do
+  defp parse_source!(
+         %{
+           "stop_id" => stop_id,
+           "direction_id" => direction_id,
+           "platform" => platform,
+           "terminal" => terminal?,
+           "announce_arriving" => announce_arriving?
+         } = source
+       ) do
     platform =
       case platform do
         nil -> nil
@@ -81,6 +84,7 @@ defmodule Signs.Utilities.SourceConfig do
     %__MODULE__{
       stop_id: stop_id,
       direction_id: direction_id,
+      routes: source["routes"],
       platform: platform,
       terminal?: terminal?,
       announce_arriving?: announce_arriving?

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -3752,6 +3752,7 @@
         {
           "stop_id": "70150",
           "direction_id": 1,
+          "routes": ["Green-B"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true
@@ -3769,6 +3770,7 @@
         {
           "stop_id": "70151",
           "direction_id": 0,
+          "routes": ["Green-B"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true
@@ -3786,6 +3788,7 @@
         {
           "stop_id": "70150",
           "direction_id": 1,
+          "routes": ["Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true
@@ -3803,6 +3806,7 @@
         {
           "stop_id": "70151",
           "direction_id": 0,
+          "routes": ["Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -174,6 +174,27 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
+    def for_stop("filterable_by_route", 0) do
+      [
+        %Predictions.Prediction{
+          stop_id: "filterable_by_route",
+          direction_id: 0,
+          route_id: "Green-B",
+          destination_stop_id: "123",
+          seconds_until_arrival: 100,
+          seconds_until_departure: 150
+        },
+        %Predictions.Prediction{
+          stop_id: "filterable_by_route",
+          direction_id: 0,
+          route_id: "Green-D",
+          destination_stop_id: "123",
+          seconds_until_arrival: 200,
+          seconds_until_departure: 250
+        }
+      ]
+    end
+
     def for_stop(_stop_id, _direction_id) do
       []
     end
@@ -398,6 +419,35 @@ defmodule Signs.Utilities.PredictionsTest do
                {nil, %Content.Message.Empty{}},
                {nil, %Content.Message.Empty{}}
              } = Signs.Utilities.Predictions.get_messages(sign, true)
+    end
+
+    test "Filters by route if present" do
+      s1 = %SourceConfig{
+        stop_id: "filterable_by_route",
+        direction_id: 0,
+        terminal?: false,
+        platform: nil,
+        routes: nil,
+        announce_arriving?: false
+      }
+
+      s2 = %{s1 | routes: ["Green-D"]}
+
+      config1 = {[s1]}
+      config2 = {[s2]}
+
+      sign1 = %{@sign | source_config: config1}
+      sign2 = %{@sign | source_config: config2}
+
+      assert {
+               {^s1, %Content.Message.Predictions{headsign: "Boston Col"}},
+               {^s1, %Content.Message.Predictions{headsign: "Riverside"}}
+             } = Signs.Utilities.Predictions.get_messages(sign1, true)
+
+      assert {
+               {^s2, %Content.Message.Predictions{headsign: "Riverside"}},
+               {nil, %Content.Message.Empty{}}
+             } = Signs.Utilities.Predictions.get_messages(sign2, true)
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Filter predictions by route](https://app.asana.com/0/584764604969369/822296355602571)

To allow Kenmore to have different predictions on the signs at the C/D berths vs the B berth, despite being the same GTFS stop ID.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
