### PR TITLE
Add Boylston, Symphony, and Prudential

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -4054,4 +4054,98 @@
       ]
     ]
   },
+  {
+    "id": "symphony_eastbound",
+    "pa_ess_loc": "GSYM",
+    "pa_ess_zone": "e",
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70242",
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ]
+    ]
+  },
+  {
+    "id": "symphony_westbound",
+    "pa_ess_loc": "GSYM",
+    "pa_ess_zone": "w",
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70241",
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ]
+    ]
+  },
+  {
+    "id": "prudential_eastbound",
+    "pa_ess_loc": "GPRU",
+    "pa_ess_zone": "e",
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70240",
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ]
+    ]
+  },
+  {
+    "id": "prudential_westbound",
+    "pa_ess_loc": "GPRU",
+    "pa_ess_zone": "w",
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70239",
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ]
+    ]
+  },
+  {
+    "id": "prudential_mezzanine",
+    "pa_ess_loc": "GPRU",
+    "pa_ess_zone": "m",
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70240",
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ],
+      [
+        {
+          "stop_id": "70239",
+          "direction_id": 0,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true
+        }
+      ]
+    ]
+  }
 ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add Prudential, Symphony, Boylston to all configs (realtime_signs and signs_ui)](https://app.asana.com/0/584764604969369/825265534827141)

Adds Boylston E/W, Symphony E/W, and Prudential, E/W/M signs.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
