### PR TITLE
Add rest of green line stations

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -4123,7 +4123,7 @@
     ]
   },
   {
-    "id": "park_st_east_platform_eastbound",
+    "id": "park_st_eastbound",
     "pa_ess_loc": "GPRKE",
     "pa_ess_zone": "e",
     "type": "realtime",
@@ -4140,7 +4140,7 @@
     ]
   },
   {
-    "id": "park_st_east_platform_mezzanine",
+    "id": "park_st_winter_st_concourse",
     "pa_ess_loc": "GPRKE",
     "pa_ess_zone": "m",
     "type": "realtime",
@@ -4157,28 +4157,14 @@
     ]
   },
   {
-    "id": "park_st_west_platform_westbound",
+    "id": "park_st_westbound_wall_track",
     "pa_ess_loc": "GPRKW",
     "pa_ess_zone": "w",
     "type": "realtime",
     "source_config": [
       [
         {
-          "stop_id": "70196",
-          "direction_id": 0,
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true
-        },
-        {
           "stop_id": "70197",
-          "direction_id": 0,
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true
-        },
-        {
-          "stop_id": "70198",
           "direction_id": 0,
           "platform": null,
           "terminal": false,
@@ -4195,9 +4181,9 @@
     ]
   },
   {
-    "id": "park_st_west_platform_mezzanine",
+    "id": "park_st_westbound_fence_track",
     "pa_ess_loc": "GPRKW",
-    "pa_ess_zone": "m",
+    "pa_ess_zone": "n",
     "type": "realtime",
     "source_config": [
       [
@@ -4209,26 +4195,13 @@
           "announce_arriving": true
         },
         {
-          "stop_id": "70197",
-          "direction_id": 0,
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true
-        },
-        {
           "stop_id": "70198",
           "direction_id": 0,
           "platform": null,
           "terminal": false,
           "announce_arriving": true
-        },
-        {
-          "stop_id": "70199",
-          "direction_id": 0,
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true
-        }      ]
+        }
+      ]
     ]
   },
 
@@ -4363,7 +4336,7 @@
     ]
   },
   {
-    "id": "green_north_station_mezzanine",
+    "id": "green_north_station_commuter_rail_exit",
     "pa_ess_loc": "GNST",
     "pa_ess_zone": "m",
     "type": "realtime",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Set up config for all remaining GL stations](https://app.asana.com/0/584764604969369/833335625740529)

The realtime_signs side of the rest of the green line signs.

The ticket mentions this for Park St:

> Park Street - do it like the SignEngine.cpp does - the side with B and D trains gets the next two of those, and the one with C and E gets the next two of those

I'm stumped from the SignEngine code about Park St.'s B/D vs. C/E trains. I _think_ that GPRKW-w and GPRKW-m correspond to those two berths (while GPRKE-e and GPRKE-m should both just be the one eastbound GTFS stop?), but I can't immediately tell which is which. The code references its internal stop IDs (e.g. 13014), but I don't have that mapping file to know which stop that corresponds to.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
