### PR TITLE
Don't let ARR be on the bottom line of single-source signs

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -23,12 +23,13 @@ defmodule Content.Message.Predictions do
           width: integer()
         }
 
-  @spec non_terminal(Predictions.Prediction.t(), boolean) :: t()
-  def non_terminal(prediction, width \\ 18, stopped_at?) do
+  @spec non_terminal(Predictions.Prediction.t(), integer(), boolean, boolean()) :: t()
+  def non_terminal(prediction, width \\ 18, stopped_at?, can_be_arriving?) do
     minutes =
       cond do
         stopped_at? -> :boarding
-        prediction.seconds_until_arrival <= 30 -> :arriving
+        can_be_arriving? && prediction.seconds_until_arrival <= 30 -> :arriving
+        prediction.seconds_until_arrival <= 30 -> 1
         prediction.seconds_until_arrival >= @thirty_one_minutes -> :thirty_plus
         true -> prediction.seconds_until_arrival |> Kernel./(60) |> round()
       end

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -44,6 +44,7 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.with_index()
     |> Enum.map(fn {{source, prediction}, i} ->
       stopped_at? = i == 0 and prediction_engine.stopped_at?(source.stop_id)
+      can_be_arriving? = i == 0
 
       cond do
         stopped_train?(prediction) ->
@@ -53,7 +54,8 @@ defmodule Signs.Utilities.Predictions do
           {source, Content.Message.Predictions.terminal(prediction, stopped_at?)}
 
         true ->
-          {source, Content.Message.Predictions.non_terminal(prediction, stopped_at?)}
+          {source,
+           Content.Message.Predictions.non_terminal(prediction, stopped_at?, can_be_arriving?)}
       end
     end)
     |> case do

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -13,7 +13,7 @@ defmodule Content.Message.PredictionsTest do
 
       log =
         capture_log([level: :warn], fn ->
-          Content.Message.Predictions.non_terminal(prediction, false)
+          Content.Message.Predictions.non_terminal(prediction, false, true)
         end)
 
       assert log =~ "Could not find headsign for prediction"
@@ -27,7 +27,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -40,7 +40,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, true)
+      msg = Content.Message.Predictions.non_terminal(prediction, true, true)
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -53,7 +53,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Mattapan       ARR"
     end
@@ -66,7 +66,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
@@ -79,7 +79,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Mattapan   30+ min"
     end
@@ -92,7 +92,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Mattapan    30 min"
     end
@@ -105,7 +105,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, 15, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, 15, false, true)
       assert Content.Message.to_string(msg) == "Mattapan  9 min"
     end
 
@@ -117,7 +117,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
     end
@@ -130,7 +130,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
@@ -143,7 +143,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -156,7 +156,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, true)
+      msg = Content.Message.Predictions.non_terminal(prediction, true, true)
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -169,9 +169,22 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, false)
+      msg = Content.Message.Predictions.non_terminal(prediction, false, true)
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
+    end
+
+    test "Doesn't put ARR on second line even if < 30 seconds" do
+      prediction = %Predictions.Prediction{
+        seconds_until_arrival: 20,
+        route_id: "Mattapan",
+        direction_id: 1,
+        destination_stop_id: "70261"
+      }
+
+      msg = Content.Message.Predictions.non_terminal(prediction, false, false)
+
+      assert Content.Message.to_string(msg) == "Ashmont      1 min"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Only show "ARR" for the next train (no two ARRs in the same direction)](https://app.asana.com/0/584764604969369/830738236675402)

For single source signs, will artificially bump the second line to "1 min" to prevent multiple ARR's in the same direction from displaying.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
