### PR TITLE
Don't display BRD on terminal signs until < 30 seconds before departure

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -85,34 +85,12 @@ defmodule Content.Message.Predictions do
   @spec terminal(Predictions.Prediction.t(), integer()) :: t()
   def terminal(prediction, width \\ 18)
 
-  def terminal(
-        %Predictions.Prediction{stops_away: 0} = prediction,
-        width
-      ) do
-    headsign =
-      case Content.Utilities.headsign_for_prediction(
-             prediction.route_id,
-             prediction.direction_id,
-             prediction.destination_stop_id
-           ) do
-        {:ok, dest} ->
-          dest
-
-        {:error, _} ->
-          Logger.warn("Could not find headsign for prediction #{inspect(prediction)}")
-          ""
-      end
-
-    %__MODULE__{
-      headsign: headsign,
-      minutes: :boarding,
-      width: width
-    }
-  end
-
   def terminal(prediction, width) do
+    stopped_at? = prediction.stops_away == 0
+
     minutes =
       case prediction.seconds_until_departure do
+        x when x <= 30 and stopped_at? -> :boarding
         x when x <= 30 -> 1
         x when x >= @thirty_one_minutes -> :thirty_plus
         x -> x |> Kernel./(60) |> round()

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -256,6 +256,7 @@ defmodule Content.Message.PredictionsTest do
 
     test "puts boarding on the sign when train is supposed to be boarding according to rtr" do
       prediction = %Predictions.Prediction{
+        seconds_until_departure: 15,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
@@ -267,6 +268,22 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
+    end
+
+    test "does not put boarding on the sign too early when train is stopped at terminal" do
+      prediction = %Predictions.Prediction{
+        seconds_until_departure: 120,
+        direction_id: 1,
+        route_id: "Mattapan",
+        destination_stop_id: "70261",
+        stopped?: false,
+        stops_away: 0,
+        boarding_status: "Stopped at station"
+      }
+
+      msg = Content.Message.Predictions.terminal(prediction)
+
+      assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
 
     test "does not put boarding if prediction is greater than 30 seconds" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Hotfix: Don't show BRD at terminals until < 30 seconds until departure](https://app.asana.com/0/584764604969369/840216037362898)

#171 changed the behavior for terminals to always show "BRD" if the train is 0 stops away. However, instead, we want to count down to boarding, and only show BRD when we predict the train is 30 seconds to departure (_and_ 0 stops away).

This reverts to the previous behavior.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
