### PR TITLE
Allow for non-terminal stations that have trips beginning there

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -53,12 +53,15 @@ defmodule Content.Message.Predictions do
   end
 
   def non_terminal(prediction, width, can_be_arriving?) do
+    # e.g., North Station which is non-terminal but has trips that begin there
+    predicted_time = prediction.seconds_until_arrival || prediction.seconds_until_departure
+
     minutes =
       cond do
-        can_be_arriving? && prediction.seconds_until_arrival <= 30 -> :arriving
-        prediction.seconds_until_arrival <= 30 -> 1
-        prediction.seconds_until_arrival >= @thirty_one_minutes -> :thirty_plus
-        true -> prediction.seconds_until_arrival |> Kernel./(60) |> round()
+        can_be_arriving? && predicted_time <= 30 -> :arriving
+        predicted_time <= 30 -> 1
+        predicted_time >= @thirty_one_minutes -> :thirty_plus
+        true -> predicted_time |> Kernel./(60) |> round()
       end
 
     headsign =

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -35,9 +35,9 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.filter(fn {_, p} ->
       p.seconds_until_departure
     end)
-    |> Enum.sort(fn {s1, p1}, {s2, p2} ->
-      p1_time = if s1.terminal?, do: p1.seconds_until_departure, else: p1.seconds_until_arrival
-      p2_time = if s2.terminal?, do: p2.seconds_until_departure, else: p2.seconds_until_arrival
+    |> Enum.sort(fn {_s1, p1}, {_s2, p2} ->
+      p1_time = p1.seconds_until_arrival || p1.seconds_until_departure
+      p2_time = p2.seconds_until_arrival || p2.seconds_until_departure
       p1_time < p2_time
     end)
     |> Enum.take(2)

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -93,10 +93,10 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
-    def for_stop("5", 1) do
+    def for_stop("arrival_vs_departure_time", 1) do
       [
         %Predictions.Prediction{
-          stop_id: "5",
+          stop_id: "arrival_vs_departure_time",
           direction_id: 1,
           route_id: "Red",
           stopped?: false,
@@ -106,29 +106,14 @@ defmodule Signs.Utilities.PredictionsTest do
           seconds_until_departure: 300
         },
         %Predictions.Prediction{
-          stop_id: "5",
+          stop_id: "arrival_vs_departure_time",
           direction_id: 1,
           route_id: "Red",
           stopped?: false,
           stops_away: 1,
           destination_stop_id: "123",
-          seconds_until_arrival: 500,
+          seconds_until_arrival: nil,
           seconds_until_departure: 600
-        }
-      ]
-    end
-
-    def for_stop("6", 1) do
-      [
-        %Predictions.Prediction{
-          stop_id: "6",
-          direction_id: 1,
-          route_id: "Red",
-          stopped?: false,
-          stops_away: 1,
-          destination_stop_id: "123",
-          seconds_until_arrival: 0,
-          seconds_until_departure: 300
         }
       ]
     end
@@ -311,29 +296,21 @@ defmodule Signs.Utilities.PredictionsTest do
              } = Signs.Utilities.Predictions.get_messages(sign, true)
     end
 
-    test "sorts by arrival and departure depending on whether source is a terminal" do
-      s1 = %SourceConfig{
-        stop_id: "5",
+    test "sorts by arrival or departure depending on which is present" do
+      src = %SourceConfig{
+        stop_id: "arrival_vs_departure_time",
         direction_id: 1,
         terminal?: false,
         platform: nil,
         announce_arriving?: false
       }
 
-      s2 = %SourceConfig{
-        stop_id: "6",
-        direction_id: 1,
-        terminal?: true,
-        platform: nil,
-        announce_arriving?: false
-      }
-
-      config = {[s1, s2]}
+      config = {[src]}
       sign = %{@sign | source_config: config}
 
       assert {
-               {^s1, %Content.Message.Predictions{headsign: "Alewife", minutes: 4}},
-               {^s2, %Content.Message.Predictions{headsign: "Alewife", minutes: 5}}
+               {^src, %Content.Message.Predictions{headsign: "Alewife", minutes: 4}},
+               {^src, %Content.Message.Predictions{headsign: "Alewife", minutes: 10}}
              } = Signs.Utilities.Predictions.get_messages(sign, true)
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Handle stations that are both terminals and non-terminals](https://app.asana.com/0/584764604969369/840216037362896)

Fixes the issue we were seeing at North Station. We were ignoring trips that began there, since it was configured as a "non-terminal" station (for the purposes of announcing "arrives" rather than "departs" as well as the "BRD" sign behavior) and such stations we used the prediction's arrival time, rather than departure time.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
