### PR TITLE
Create arrival_times for predictions without them

### DIFF
--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -102,8 +102,8 @@ defmodule Signs.Utilities.PredictionsTest do
           stopped?: false,
           stops_away: 1,
           destination_stop_id: "123",
-          seconds_until_arrival: 240,
-          seconds_until_departure: 300
+          seconds_until_arrival: nil,
+          seconds_until_departure: 270
         },
         %Predictions.Prediction{
           stop_id: "5",
@@ -311,7 +311,7 @@ defmodule Signs.Utilities.PredictionsTest do
              } = Signs.Utilities.Predictions.get_messages(sign, true)
     end
 
-    test "sorts by arrival and departure depending on whether source is a terminal" do
+    test "sorts by created pseudo-arrival if non-terminal and arrival was nil" do
       s1 = %SourceConfig{
         stop_id: "5",
         direction_id: 1,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Handle stations that are both terminals and non-terminals](https://app.asana.com/0/584764604969369/840216037362896)

Another approach from #175 with less duplication. A little heavier handed, though.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
