### PR TITLE
no rounding errors allowed

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -12,7 +12,7 @@ defmodule Content.Message.Predictions do
 
   require Logger
 
-  @thirty_one_minutes 31 * 60
+  @thirty_plus_minutes 30 * 60
 
   @enforce_keys [:headsign, :minutes]
   defstruct [:headsign, :minutes, width: 18]
@@ -60,7 +60,7 @@ defmodule Content.Message.Predictions do
       cond do
         can_be_arriving? && predicted_time <= 30 -> :arriving
         predicted_time <= 30 -> 1
-        predicted_time >= @thirty_one_minutes -> :thirty_plus
+        predicted_time >= @thirty_plus_minutes -> :thirty_plus
         true -> predicted_time |> Kernel./(60) |> round()
       end
 
@@ -95,7 +95,7 @@ defmodule Content.Message.Predictions do
       case prediction.seconds_until_departure do
         x when x <= 30 and stopped_at? -> :boarding
         x when x <= 30 -> 1
-        x when x >= @thirty_one_minutes -> :thirty_plus
+        x when x >= @thirty_plus_minutes -> :thirty_plus
         x -> x |> Kernel./(60) |> round()
       end
 

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -81,7 +81,7 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
 
-    test "Says 30+ min when train is more than 30 minutes away" do
+    test "Says 30+ min when train is 30 or more minutes away" do
       prediction = %Predictions.Prediction{
         seconds_until_arrival: 45 * 60,
         direction_id: 0,
@@ -94,21 +94,6 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.non_terminal(prediction, true)
 
       assert Content.Message.to_string(msg) == "Mattapan   30+ min"
-    end
-
-    test "Says 30 min when train is exactly 30 minutes away" do
-      prediction = %Predictions.Prediction{
-        seconds_until_arrival: 30 * 60,
-        direction_id: 0,
-        route_id: "Mattapan",
-        stopped?: false,
-        stops_away: 10,
-        destination_stop_id: "70275"
-      }
-
-      msg = Content.Message.Predictions.non_terminal(prediction, true)
-
-      assert Content.Message.to_string(msg) == "Mattapan    30 min"
     end
 
     test "can use a shorter line length" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bug: 31 min on sign](https://app.asana.com/0/584764604969369/812181821170628)

when we were between 30:30 and 31:00 we would round up, but not be caught by the 31+ catch.
#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
