### PR TITLE
sort boarding first

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -87,6 +87,22 @@ defmodule Predictions.Predictions do
     )
   end
 
+  defp compare_predictions(
+         %{stops_away: 0, seconds_until_arrival: time_one},
+         %{stops_away: 0, seconds_until_arrival: time_two},
+         :arrival
+       ) do
+    time_one < time_two
+  end
+
+  defp compare_predictions(
+         %{stops_away: 0, seconds_until_departure: time_one},
+         %{stops_away: 0, seconds_until_departure: time_two},
+         :departure
+       ) do
+    time_one < time_two
+  end
+
   defp compare_predictions(%{stops_away: 0}, _time_two, _) do
     true
   end

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -396,5 +396,21 @@ defmodule Predictions.PredictionsTest do
 
       assert sort([p1, p2, p3, p4], :departure) == [p4, p3, p2, p1]
     end
+
+    test "when multiple predictions are 0 stops away, sorts by arrival or departure depending on the type of predictions" do
+      p1 = %Prediction{stops_away: 0, seconds_until_departure: 500, seconds_until_arrival: 180}
+      p2 = %Prediction{stops_away: 0, seconds_until_departure: 120, seconds_until_arrival: 120}
+      p3 = %Prediction{stops_away: 0, seconds_until_departure: 45, seconds_until_arrival: 500}
+      p4 = %Prediction{stops_away: 0, seconds_until_departure: 180, seconds_until_arrival: 45}
+
+      assert sort([p1, p2, p3, p4], :arrival) == [p4, p2, p1, p3]
+
+      p1 = %Prediction{stops_away: 0, seconds_until_departure: 500, seconds_until_arrival: 180}
+      p2 = %Prediction{stops_away: 0, seconds_until_departure: 120, seconds_until_arrival: 120}
+      p3 = %Prediction{stops_away: 0, seconds_until_departure: 45, seconds_until_arrival: 500}
+      p4 = %Prediction{stops_away: 0, seconds_until_departure: 180, seconds_until_arrival: 45}
+
+      assert sort([p1, p2, p3, p4], :departure) == [p3, p2, p4, p1]
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [BRD trains need to sort to the top](https://app.asana.com/0/584764604969369/845605816877183)

when its 0 stops away, put it at the top.  if its greater than 0 stops away then go by the arrival/departure time as normal

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
