### PR TITLE
increase rate limit by 2/second

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -10,7 +10,7 @@ defmodule PaEss.HttpUpdater do
           uid: integer()
         }
 
-  @max_send_rate_per_sec 13
+  @max_send_rate_per_sec 15
   @avg_ms_between_sends round(1000 / @max_send_rate_per_sec)
 
   use GenServer


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bump up rate limit before launch at Park Street](https://app.asana.com/0/584764604969369/851348617121588)

gabes slack math suggests 2/second is good.

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
