### PR TITLE
Change EB 'Reservoir' headsign to 'Park St' per PIO request

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -39,7 +39,7 @@ defmodule Content.Utilities do
   def headsign_for_prediction(_, 1, "70201"), do: {:ok, "Govt Ctr"}
   def headsign_for_prediction(_, 1, "70200"), do: {:ok, "Park St"}
   def headsign_for_prediction(_, 1, "70150"), do: {:ok, "Kenmore"}
-  def headsign_for_prediction(_, 1, "70174"), do: {:ok, "Reservoir"}
+  def headsign_for_prediction(_, 1, "70174"), do: {:ok, "Park St"}
 
   def headsign_for_prediction("Green-B", 0, _), do: {:ok, "Boston Col"}
   def headsign_for_prediction("Green-C", 0, _), do: {:ok, "Clvlnd Cir"}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** none

Small tweak per PIO request - EB trains whose final destination is Reservoir should instead display "Park St".

#### Checklist
- [ ] New functions have typespecs, changed functions' typespecs were updated
- [ ] New modules and functions have documentation, changed modules/functions' documentation was updated
- [ ] Tests were added or updated to cover changes
- [ ] All tests pass locally:
  - [ ] `mix compile --force --warnings-as-errors`
  - [ ] `mix test`
  - [ ] `mix dialyzer`
- [ ] This branch has been deployed to the staging environment
  - [ ] No increase in warnings/errors
  - [ ] Any added functionality works properly
