### PR TITLE
Fix ETS race condition in Headways engine

### DIFF
--- a/lib/engine/headways.ex
+++ b/lib/engine/headways.ex
@@ -129,7 +129,8 @@ defmodule Engine.Headways do
       )
 
     headways =
-      Enum.map(state.stop_ids, fn x -> {x, :none} end)
+      state.stop_ids
+      |> Enum.map(fn x -> {x, :none} end)
       |> Map.new()
       |> Map.merge(headways)
 


### PR DESCRIPTION
#### Summary of changes
Fixing an issue with **Asana Ticket:** [Switch Engine.Headways to store data in ETS instead of map in state](https://app.asana.com/0/0/938617355403311/f)

Instead of doing `:ets.delete_all_objects` we should just use `:ets.insert` and take advantage of the fact that it overwrites old things.

#### Checklist
- [x] New functions have typespecs, changed functions' typespecs were updated
- [x] New modules and functions have documentation, changed modules/functions' documentation was updated
- [x] Tests were added or updated to cover changes
- [x] All tests pass locally:
  - [x] `mix compile --force --warnings-as-errors`
  - [x] `mix test`
  - [x] `mix dialyzer`
- [x] This branch has been deployed to the staging environment
  - [x] No increase in warnings/errors
  - [x] Any added functionality works properly
