### PR TITLE
Ash log arinc times

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -49,10 +49,10 @@ defmodule PaEss.HttpUpdater do
   def process({:update_single_line, [{station, zone}, line_no, msg, duration, start_secs]}, state) do
     cmd = to_command(msg, duration, start_secs, zone, line_no)
     encoded = URI.encode_query(MsgType: "SignContent", uid: state.uid, sta: station, c: cmd)
-    Logger.info(["update_single_line: ", encoded])
+    {timer, result} = send_post(state.http_poster, encoded)
+    Logger.info(["update_single_line: ", encoded, " head_end_ms=#{timer / 1_000} ms"])
 
     update_ui(state.http_poster, encoded)
-    {_timer, result} = send_post(state.http_poster, encoded)
     result
   end
 
@@ -72,10 +72,10 @@ defmodule PaEss.HttpUpdater do
         c: bottom_cmd
       )
 
-    Logger.info(["update_sign: ", encoded])
+    {timer, result} = send_post(state.http_poster, encoded)
+    Logger.info(["update_sign: ", encoded, " head_end_ms=#{timer / 1_000} ms"])
 
     update_ui(state.http_poster, encoded)
-    {_timer, result} = send_post(state.http_poster, encoded)
     result
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] Log the response time from ARINC head-end server](https://app.asana.com/0/584764604969369/962003886500438)

log the time it takes to post.  timer.tc returns microseconds.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
