### PR TITLE
Send empty message when no headway present

### DIFF
--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -27,6 +27,9 @@ defmodule Signs.Utilities.Headways do
       :none ->
         {{config, %Content.Message.Empty{}}, {config, %Content.Message.Empty{}}}
 
+      {nil, nil} ->
+        {{config, %Content.Message.Empty{}}, {config, %Content.Message.Empty{}}}
+
       {:first_departure, _, _} ->
         {{config, %Content.Message.Empty{}}, {config, %Content.Message.Empty{}}}
 

--- a/test/signs/utilities/headways_test.exs
+++ b/test/signs/utilities/headways_test.exs
@@ -2,15 +2,19 @@ defmodule Signs.Utilities.HeadwaysTest do
   use ExUnit.Case
 
   defmodule FakeHeadways do
-    def get_headways("123") do
+    def get_headways("a") do
       {1, 5}
     end
 
-    def get_headways("456") do
+    def get_headways("b") do
       :none
     end
 
-    def get_headways("789") do
+    def get_headways("c") do
+      {nil, nil}
+    end
+
+    def get_headways("d") do
       {:first_departure, {1, 5}, DateTime.utc_now()}
     end
   end
@@ -31,6 +35,19 @@ defmodule Signs.Utilities.HeadwaysTest do
     read_period_seconds: 240
   }
 
+  @spec source_config_for_stop_id(String.t()) :: %Signs.Utilities.SourceConfig{}
+  defp source_config_for_stop_id(stop_id) do
+    %Signs.Utilities.SourceConfig{
+      stop_id: stop_id,
+      headway_direction_name: "Southbound",
+      direction_id: 0,
+      platform: nil,
+      terminal?: false,
+      announce_arriving?: false,
+      multi_berth?: false
+    }
+  end
+
   describe "get_messages/1" do
     test "generates blank messages when the source config has multiple sources" do
       assert Signs.Utilities.Headways.get_messages(@sign) ==
@@ -40,121 +57,46 @@ defmodule Signs.Utilities.HeadwaysTest do
     test "generates top and bottom messages to display the headway at a stop" do
       sign = %{
         @sign
-        | source_config:
-            {[
-               %Signs.Utilities.SourceConfig{
-                 stop_id: "123",
-                 headway_direction_name: "Southbound",
-                 direction_id: 0,
-                 platform: nil,
-                 terminal?: false,
-                 announce_arriving?: false,
-                 multi_berth?: false
-               }
-             ]}
+        | source_config: {[source_config_for_stop_id("a")]}
       }
 
       assert Signs.Utilities.Headways.get_messages(sign) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "123",
-                   terminal?: false
-                 }, %Content.Message.Headways.Top{headsign: "Southbound", vehicle_type: :train}},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "123",
-                   terminal?: false
-                 }, %Content.Message.Headways.Bottom{range: {1, 5}}}}
+               {{source_config_for_stop_id("a"),
+                 %Content.Message.Headways.Top{headsign: "Southbound", vehicle_type: :train}},
+                {source_config_for_stop_id("a"), %Content.Message.Headways.Bottom{range: {1, 5}}}}
     end
 
     test "generates blank messages to display when no headway information present" do
       sign = %{
         @sign
-        | source_config:
-            {[
-               %Signs.Utilities.SourceConfig{
-                 stop_id: "456",
-                 headway_direction_name: "Southbound",
-                 direction_id: 0,
-                 platform: nil,
-                 terminal?: false,
-                 announce_arriving?: false,
-                 multi_berth?: false
-               }
-             ]}
+        | source_config: {[source_config_for_stop_id("b")]}
       }
 
       assert Signs.Utilities.Headways.get_messages(sign) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "456",
-                   terminal?: false
-                 }, %Content.Message.Empty{}},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "456",
-                   terminal?: false
-                 }, %Content.Message.Empty{}}}
+               {{source_config_for_stop_id("b"), %Content.Message.Empty{}},
+                {source_config_for_stop_id("b"), %Content.Message.Empty{}}}
+    end
+
+    test "generates blank messages for {nil, nil} headways" do
+      sign = %{
+        @sign
+        | source_config: {[source_config_for_stop_id("c")]}
+      }
+
+      assert Signs.Utilities.Headways.get_messages(sign) ==
+               {{source_config_for_stop_id("c"), %Content.Message.Empty{}},
+                {source_config_for_stop_id("c"), %Content.Message.Empty{}}}
     end
 
     test "generates blank messages to display prior to first departure of the day" do
       sign = %{
         @sign
-        | source_config:
-            {[
-               %Signs.Utilities.SourceConfig{
-                 stop_id: "789",
-                 headway_direction_name: "Southbound",
-                 direction_id: 0,
-                 platform: nil,
-                 terminal?: false,
-                 announce_arriving?: false,
-                 multi_berth?: false
-               }
-             ]}
+        | source_config: {[source_config_for_stop_id("d")]}
       }
 
       assert Signs.Utilities.Headways.get_messages(sign) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "789",
-                   terminal?: false
-                 }, %Content.Message.Empty{}},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   direction_id: 0,
-                   headway_direction_name: "Southbound",
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "789",
-                   terminal?: false
-                 }, %Content.Message.Empty{}}}
+               {{source_config_for_stop_id("d"), %Content.Message.Empty{}},
+                {source_config_for_stop_id("d"), %Content.Message.Empty{}}}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Hotfix: Don't let headway signs display "Trains to X" overnight.](https://app.asana.com/0/584764604969369/967714101033139/f)

So that we don't display "Trains fo Govt Center" or whatever and no second line overnight.

#### Reviewer Checklist
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
