### PR TITLE
the message id is wrong

### DIFF
--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -45,7 +45,7 @@ defmodule Content.Audio.TrainIsBoarding do
         @is_now_boarding
       ]
 
-      {"109", vars, :audio}
+      {PaEss.Utilities.take_message_id(vars), vars, :audio}
     end
 
     @spec branch_letter(String.t()) :: String.t()

--- a/test/content/audio/train_is_boarding_test.exs
+++ b/test/content/audio/train_is_boarding_test.exs
@@ -7,7 +7,7 @@ defmodule Content.Audio.TrainIsBoardingTest do
       audio = %Content.Audio.TrainIsBoarding{destination: :riverside, route_id: "Green-D"}
 
       assert Content.Audio.to_params(audio) ==
-               {"109", ["501", "538", "507", "4084", "544"], :audio}
+               {"107", ["501", "538", "507", "4084", "544"], :audio}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
no ticket.

the message id was wrong, and we have a helper already defined that will make it right.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
