### PR TITLE
Ignore "enabled" field

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -106,7 +106,7 @@ defmodule Engine.Config do
   @spec parse_sign_config(map()) :: sign_config()
   defp parse_sign_config(config_json) do
     cond do
-      config_json["mode"] == "off" or config_json["enabled"] == false ->
+      config_json["mode"] == "off" ->
         :off
 
       config_json["mode"] == "static_text" or config_json["line1"] != nil or

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -9,10 +9,9 @@ defmodule Fake.ExternalConfig.Local do
   def get(_current_version) do
     {nil,
      %{
-       "chelsea_inbound" => %{"enabled" => true},
-       "chelsea_outbound" => %{"enabled" => false},
+       "chelsea_inbound" => %{"mode" => "auto"},
+       "chelsea_outbound" => %{"mode" => "off"},
        "custom_text_test" => %{
-         "enabled" => true,
          "line1" => "Test message",
          "line2" => "Please ignore",
          "expires" => "2017-07-04T12:00:00Z"


### PR DESCRIPTION
#### Summary of changes
**No ticket**

Signs_UI now generates the new configuration format, so we can start ignoring the `enabled` field for consistency with @losvedir 's approach over there.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
