### PR TITLE
Handle empty messages

### DIFF
--- a/lib/content/message/custom.ex
+++ b/lib/content/message/custom.ex
@@ -14,6 +14,10 @@ defmodule Content.Message.Custom do
         }
 
   @spec new(String.t(), :top | :bottom) :: t()
+  def new("", _) do
+    Content.Message.Empty.new()
+  end
+
   def new(message, line) do
     if is_valid_message?(message, line) do
       %__MODULE__{
@@ -36,7 +40,7 @@ defmodule Content.Message.Custom do
 
     cond do
       String.length(message) > max_length -> false
-      Regex.match?(~r/^[a-zA-Z0-9,.!@' ]+$/, message) -> true
+      Regex.match?(~r/^[a-zA-Z0-9,.!@' ]*$/, message) -> true
       true -> false
     end
   end

--- a/test/content/messages/custom_test.exs
+++ b/test/content/messages/custom_test.exs
@@ -8,6 +8,11 @@ defmodule Content.Message.CustomTest do
     assert Content.Message.to_string(msg) == "Test message"
   end
 
+  test "deserializes back to empty string" do
+    msg = Content.Message.Custom.new("", :top)
+    assert Content.Message.to_string(msg) == ""
+  end
+
   test "rejects string that is too long" do
     log =
       capture_log([level: :error], fn ->


### PR DESCRIPTION
#### Summary of changes
**No ticket**

Don't error out if an empty message is passed in. Also, return a `Content.Message.Empty` struct instead.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
