### PR TITLE
Ash shuttle endpoints

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -23,9 +23,6 @@ defmodule Signs.Utilities.Messages do
       !enabled? ->
         {{nil, Content.Message.Empty.new()}, {nil, Content.Message.Empty.new()}}
 
-      alert_status == :suspension ->
-        {{nil, %Content.Message.Alert.NoService{mode: :none}}, {nil, Content.Message.Empty.new()}}
-
       true ->
         case Signs.Utilities.Predictions.get_messages(sign) do
           {{nil, %Content.Message.Empty{}}, {nil, %Content.Message.Empty{}}} ->
@@ -36,6 +33,10 @@ defmodule Signs.Utilities.Messages do
               :shuttles_closed_station ->
                 {{nil, %Content.Message.Alert.NoService{mode: :train}},
                  {nil, %Content.Message.Alert.UseShuttleBus{}}}
+
+              :suspension ->
+                {{nil, %Content.Message.Alert.NoService{mode: :none}},
+                 {nil, Content.Message.Empty.new()}}
 
               _ ->
                 Signs.Utilities.Headways.get_messages(sign)

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -261,15 +261,76 @@ defmodule Signs.Utilities.MessagesTest do
                  }}}
     end
 
-    test "when sign is at a station closed due to suspension, it says so" do
+    test "when sign is at a station closed due to suspension and there are no departure predictions, it says so" do
+      src = %{@src | stop_id: "no_departures", direction_id: 0}
+
+      sign = %{
+        @sign
+        | source_config: {[src]},
+          current_content_top: {src, Content.Message.Empty.new()},
+          current_content_bottom: {src, Content.Message.Empty.new()}
+      }
+
       alert_status = :suspension
-      sign = @sign
       enabled? = true
       custom_text = nil
 
       assert Messages.get_messages(sign, enabled?, alert_status, custom_text) ==
                {{nil, %Content.Message.Alert.NoService{mode: :none}},
                 {nil, Content.Message.Empty.new()}}
+    end
+
+    test "when sign is at a station closed due to suspension and there are departure predictions, it shows them" do
+      src = %{@src | stop_id: "1", direction_id: 0}
+
+      sign = %{
+        @sign
+        | source_config: {[src]},
+          current_content_top: {src, Content.Message.Empty.new()},
+          current_content_bottom: {src, Content.Message.Empty.new()}
+      }
+
+      alert_status = :suspension
+      enabled? = true
+      custom_text = nil
+
+      assert Messages.get_messages(sign, enabled?, alert_status, custom_text) ==
+               {{%Signs.Utilities.SourceConfig{
+                   announce_arriving?: false,
+                   announce_boarding?: false,
+                   direction_id: 0,
+                   headway_direction_name: "Mattapan",
+                   multi_berth?: false,
+                   platform: nil,
+                   routes: nil,
+                   stop_id: "1",
+                   terminal?: false
+                 },
+                 %Content.Message.Predictions{
+                   headsign: "Ashmont",
+                   minutes: 2,
+                   route_id: "Red",
+                   stop_id: "1",
+                   width: 18
+                 }},
+                {%Signs.Utilities.SourceConfig{
+                   announce_arriving?: false,
+                   announce_boarding?: false,
+                   direction_id: 0,
+                   headway_direction_name: "Mattapan",
+                   multi_berth?: false,
+                   platform: nil,
+                   routes: nil,
+                   stop_id: "1",
+                   terminal?: false
+                 },
+                 %Content.Message.Predictions{
+                   headsign: "Ashmont",
+                   minutes: 4,
+                   route_id: "Red",
+                   stop_id: "1",
+                   width: 18
+                 }}}
     end
 
     test "when there are predictions, puts predictions on the sign" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3] Kenmore goes blank during Kenmore-Reservoir shuttle](https://app.asana.com/0/584764604969369/949515990114227)

when checking for the shuttle endpoints we should see if there are predictions at the station.  if there are, we should show them instead of intentionally blanking the sign out.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
