### PR TITLE
remove references to 'enabled: true'

### DIFF
--- a/lib/fake/ex_aws.ex
+++ b/lib/fake/ex_aws.ex
@@ -27,7 +27,7 @@ defmodule Fake.ExAws do
   def request({_bucket, _path, _opts}) do
     {:ok,
      %{
-       body: "{\"chelsea_inbound\":{\"enabled\":true}}",
+       body: "{\"chelsea_inbound\":{\"mode\":\"headway\"}}",
        headers: [
          {"x-amz-id-2", "id1235"},
          {"x-amz-request-id", "REQUEST1235"},

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -19,7 +19,7 @@ defmodule Fake.ExternalConfig.Local do
        "off_test" => %{"mode" => "off"},
        "auto_test" => %{"mode" => "auto"},
        "headway_test" => %{"mode" => "headway"},
-       "MVAL0" => %{"enabled" => false}
+       "MVAL0" => %{"mode" => "auto"}
      }}
   end
 end

--- a/priv/config.json
+++ b/priv/config.json
@@ -1,11 +1,11 @@
 {
   "chelsea_inbound": {
-    "enabled": true
+    "mode": "headway"
   },
   "chelsea_outbound": {
-    "enabled": true
+    "mode": "off"
   },
   "MVAL0": {
-    "enabled": true
+    "mode": "auto"
   }
 }

--- a/test/external_config/local_test.exs
+++ b/test/external_config/local_test.exs
@@ -4,26 +4,26 @@ defmodule ExternalConfig.LocalTest do
   describe "get/1" do
     test "loads config from a local json file" do
       assert ExternalConfig.Local.get("version") ==
-               {"34956243",
+               {"47052743",
                 %{
-                  "chelsea_inbound" => %{"enabled" => true},
-                  "chelsea_outbound" => %{"enabled" => true},
-                  "MVAL0" => %{"enabled" => true}
+                  "chelsea_inbound" => %{"mode" => "headway"},
+                  "chelsea_outbound" => %{"mode" => "off"},
+                  "MVAL0" => %{"mode" => "auto"}
                 }}
     end
 
     test "uses a hash of the file as a version id" do
       assert ExternalConfig.Local.get(nil) ==
-               {"34956243",
+               {"47052743",
                 %{
-                  "chelsea_inbound" => %{"enabled" => true},
-                  "chelsea_outbound" => %{"enabled" => true},
-                  "MVAL0" => %{"enabled" => true}
+                  "chelsea_inbound" => %{"mode" => "headway"},
+                  "chelsea_outbound" => %{"mode" => "off"},
+                  "MVAL0" => %{"mode" => "auto"}
                 }}
     end
 
     test "if the file is unchanged, returns :unchanged" do
-      assert ExternalConfig.Local.get("34956243") == :unchanged
+      assert ExternalConfig.Local.get("47052743") == :unchanged
     end
   end
 end

--- a/test/external_config/s3_test.exs
+++ b/test/external_config/s3_test.exs
@@ -4,7 +4,7 @@ defmodule ExternalConfig.S3Test do
   describe "get/1" do
     test "loads config from an external http request" do
       assert ExternalConfig.S3.get("version") ==
-               {"deadbeef1234", %{"chelsea_inbound" => %{"enabled" => true}}}
+               {"deadbeef1234", %{"chelsea_inbound" => %{"mode" => "headway"}}}
     end
 
     test "when it fails to get the config, uses an empty config" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1 - extra special] Remove "enabled" backwards compatibility from signs-ui / realtime_signs](https://app.asana.com/0/584764604969369/1102262869498026)

remove these references to "enabled: true"

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
