### PR TITLE
make audio visual messages instead of just audio

### DIFF
--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -70,7 +70,7 @@ defmodule Content.Audio.TrackChange do
         track(audio.track)
       ]
 
-      {"109", vars, :audio}
+      {"109", vars, :audio_visual}
     end
 
     defp track(1), do: @on_track_1

--- a/test/content/audio/track_change_test.exs
+++ b/test/content/audio/track_change_test.exs
@@ -10,7 +10,7 @@ defmodule Content.Audio.TrackChangeTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {"109", ["540", "501", "536", "507", "4202", "544", "541"], :audio}
+               {"109", ["540", "501", "536", "507", "4202", "544", "541"], :audio_visual}
     end
 
     test "correctly changes tracks for c/e" do
@@ -21,7 +21,7 @@ defmodule Content.Audio.TrackChangeTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {"109", ["540", "501", "539", "507", "4204", "544", "541"], :audio}
+               {"109", ["540", "501", "539", "507", "4204", "544", "541"], :audio_visual}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1 - extra special] When a GL train is appearing on the opposite track at Park, need to display the arriving message on the board](https://app.asana.com/0/584764604969369/978940173792990)

visual message too.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
