### PR TITLE
Change skipping_arriving_audio to info, not warn

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -27,12 +27,14 @@ defmodule Signs.Realtime do
 
   defstruct @enforce_keys ++ [announced_arrivals: MapSet.new()]
 
+  @type line_content :: {Utilities.SourceConfig.source() | nil, Content.Message.t()}
+
   @type t :: %__MODULE__{
           id: String.t(),
           pa_ess_id: PaEss.id(),
           source_config: Utilities.SourceConfig.config(),
-          current_content_top: {Utilities.SourceConfig.source() | nil, Content.Message.t()},
-          current_content_bottom: {Utilities.SourceConfig.source() | nil, Content.Message.t()},
+          current_content_top: line_content(),
+          current_content_bottom: line_content(),
           prediction_engine: module(),
           headway_engine: module(),
           sign_updater: module(),

--- a/lib/signs/utilities/updater.ex
+++ b/lib/signs/utilities/updater.ex
@@ -11,8 +11,8 @@ defmodule Signs.Utilities.Updater do
 
   @spec update_sign(
           Signs.Realtime.t(),
-          {SourceConfig.config() | nil, Content.Message.t()},
-          {SourceConfig.config() | nil, Content.Message.t()}
+          Signs.Realtime.line_content(),
+          Signs.Realtime.line_content()
         ) :: Signs.Realtime.t()
   def update_sign(sign, {_top_src, top_msg} = top, {_bottom_src, bottom_msg} = bottom) do
     sign =
@@ -223,6 +223,7 @@ defmodule Signs.Utilities.Updater do
     end
   end
 
+  @spec announce_arrival(Signs.Realtime.line_content(), Signs.Realtime.t()) :: Signs.Realtime.t()
   defp announce_arrival({%SourceConfig{announce_arriving?: false}, _msg}, sign), do: sign
 
   defp announce_arrival({_src, msg}, sign) do
@@ -245,8 +246,7 @@ defmodule Signs.Utilities.Updater do
     end
   end
 
-  @spec announce_boarding({SourceConfig.source(), Signs.Realtime.t()}, Signs.Realtime.t()) ::
-          Signs.Realtime.t()
+  @spec announce_boarding(Signs.Realtime.line_content(), Signs.Realtime.t()) :: Signs.Realtime.t()
   defp announce_boarding({%SourceConfig{announce_boarding?: false}, _msg}, sign), do: sign
 
   defp announce_boarding({_src, msg}, sign) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1 - extra] downgrade `skipping_arriving_audio` warning to info](https://app.asana.com/0/881264583703207/986120321366572)

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
