### PR TITLE
Correct routes to Mattapan in signs.json

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -48,7 +48,7 @@
       [
         {
           "stop_id": "70266",
-          "routes": ["Mattpan"],
+          "routes": ["Mattapan"],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -60,7 +60,7 @@
       [
         {
           "stop_id": "70265",
-          "routes": ["Mattpan"],
+          "routes": ["Mattapan"],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -3508,7 +3508,7 @@
       [
         {
           "stop_id": "70261",
-          "routes": ["Red"],
+          "routes": ["Mattapan"],
           "direction_id": 0,
           "headway_direction_name": "Alewife",
           "platform": null,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Bug: Ashmont sign not showing Mattapan predictions on bottom line](https://app.asana.com/0/881264583703207/1104657015105417)

Changed a couple of routes in `signs.json`. One was `Red` when it should have been `Mattapan`, two others had typos.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
