### PR TITLE
Bump read loop if <2 minutes away instead of <1

### DIFF
--- a/lib/signs/utilities/reader.ex
+++ b/lib/signs/utilities/reader.ex
@@ -27,7 +27,7 @@ defmodule Signs.Utilities.Reader do
   def interrupting_read(sign) do
     case send_audio_update(sign) do
       {true, sign} ->
-        if sign.tick_read < 60 do
+        if sign.tick_read < 120 do
           %{sign | tick_read: sign.tick_read + sign.read_period_seconds}
         else
           sign

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -233,5 +233,16 @@ defmodule Signs.Utilities.ReaderTest do
         {:send_audio, _id, %A{destination: :ashmont, minutes: 3, verb: :arrives}, _p, _t}
       )
     end
+
+    test "bumps sign's read loop if interrupted with under 120 seconds to go" do
+      sign_under = %{@sign | tick_read: 119, read_period_seconds: 20}
+      sign_over = %{@sign | tick_read: 120, read_period_seconds: 20}
+
+      new_sign_under = Reader.interrupting_read(sign_under)
+      new_sign_over = Reader.interrupting_read(sign_over)
+
+      assert new_sign_under.tick_read == 139
+      assert new_sign_over.tick_read == 120
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bump read loop if < 2 minutes away](https://app.asana.com/0/584764604969369/1110486863513459)

Currently we bump the read loop if it's interrupted with less than one minute to go. Bump that up to 2 minutes.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
