### PR TITLE
Add 'Following Train' message

### DIFF
--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -109,16 +109,28 @@ defmodule Signs.Utilities.Audio do
         ) :: {[Content.Audio.t()], Signs.Realtime.t()}
   defp announce_next_trains(
          {top_src, %{headsign: same_headsign, minutes: _top_minutes} = top_msg},
-         {_bottom_src, %{headsign: same_headsign, minutes: _bottom_minutes} = _bottom_msg},
+         {bottom_src, %{headsign: same_headsign, minutes: _bottom_minutes} = bottom_msg},
          sign
        ) do
-    case Content.Audio.NextTrainCountdown.from_predictions_message(top_msg, top_src) do
-      %Content.Audio.NextTrainCountdown{} = audio ->
-        {[audio], sign}
+    {next_train_audio, sign} =
+      case Content.Audio.NextTrainCountdown.from_predictions_message(top_msg, top_src) do
+        %Content.Audio.NextTrainCountdown{} = audio ->
+          {[audio], sign}
 
-      nil ->
-        {[], sign}
-    end
+        nil ->
+          {[], sign}
+      end
+
+    {following_train_audio, sign} =
+      case Content.Audio.FollowingTrain.from_predictions_message(bottom_msg, bottom_src) do
+        %Content.Audio.FollowingTrain{} = audio ->
+          {[audio], sign}
+
+        nil ->
+          {[], sign}
+      end
+
+    {next_train_audio ++ following_train_audio, sign}
   end
 
   defp announce_next_trains({top_src, top_msg}, {bottom_src, bottom_msg}, sign) do

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -46,17 +46,17 @@ defmodule Signs.Utilities.AudioTest do
               }, ^sign} = from_sign(sign)
     end
 
-    test "Countdowns don't say second line if same headsign" do
+    test "Countdowns says 'following' if second line is same headsign" do
       sign = %{
         @sign
         | current_content_top: {@src, %Message.Predictions{headsign: "Ashmont", minutes: 3}},
           current_content_bottom: {@src, %Message.Predictions{headsign: "Ashmont", minutes: 4}}
       }
 
-      assert {
-               %Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
-               ^sign
-             } = from_sign(sign)
+      assert {{
+                %Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
+                %Audio.FollowingTrain{destination: :ashmont, minutes: 4}
+              }, ^sign} = from_sign(sign)
     end
 
     test "Countdowns use departs or arrives depending if source is terminal" do

--- a/test/signs/utilities/updater_test.exs
+++ b/test/signs/utilities/updater_test.exs
@@ -355,7 +355,7 @@ defmodule Signs.Utilities.UpdaterTest do
       Updater.update_sign(sign, top, bottom)
 
       assert_received(
-        {:send_audio, _, %Content.Audio.TrainIsArriving{destination: :ashmont}, _dur, _start}
+        {:send_audio, _, {%Content.Audio.TrainIsArriving{destination: :ashmont}, _}, _dur, _start}
       )
     end
 
@@ -455,8 +455,8 @@ defmodule Signs.Utilities.UpdaterTest do
 
       assert_received(
         {:send_audio, _,
-         %Content.Audio.TrackChange{destination: :heath_st, track: 2, route_id: "Green-E"}, _dur,
-         _start}
+         {%Content.Audio.TrackChange{destination: :heath_st, track: 2, route_id: "Green-E"}, _},
+         _dur, _start}
       )
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Add Following Train message back in](https://app.asana.com/0/584764604969369/1109783879268353)

Puts back in the functionality from [this commit](https://github.com/mbta/realtime_signs/pull/228/commits/7d09f4774f9994f643210292dd228e86dbb3080e).

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
