### PR TITLE
Update signs.json with new GL stop IDs

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5234,16 +5234,6 @@
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true
-        },
-	{
-          "stop_id": "Government Center-Brattle",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": false,
-          "announce_boarding": true
         }
       ]
     ]
@@ -5277,16 +5267,6 @@
       [
         {
           "stop_id": "70201",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-	{
-          "stop_id": "Government Center-Brattle",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
           "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update realtime_signs to handle new Green Line stop IDs](https://app.asana.com/0/584764604969369/1108284295116235/f)

Add the new stop IDs to the configuration. There will be some minor cleanup in a [future ticket](https://app.asana.com/0/881264583703207/1110868830335872/f) once we enable the feature flag on RTR to actually publish these stop IDs.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
