### PR TITLE
Update problematic signs to be realtime again

### DIFF
--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -12,7 +12,7 @@ defmodule Signs.Utilities.SourceConfig do
   }
 
   where "stop_id" is the GTFS Stop ID, "direction_id" is either 0 or 1 and corresponds to north/south,
-  east/west, inbound/outbound, platform is "ashmont", "braintree" (for JFK/UMass weirdness) or null, and
+  west/east, inbound/outbound, platform is "ashmont", "braintree" (for JFK/UMass weirdness) or null, and
   "terminal" is whether the stop is considered a terminal (whether we should use the arrival or departure
   prediction times, and whether we should announce "arrives" or "departs" on the speakers).
 

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -4243,19 +4243,41 @@
     "id": "riverside_track_1",
     "pa_ess_loc": "GRIV",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70160",
-    "route_id": "Green-D",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70160",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "riverside_track_2",
     "pa_ess_loc": "GRIV",
     "pa_ess_zone": "w",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70160",
-    "route_id": "Green-D",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70160",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "woodland_eastbound",
@@ -4281,10 +4303,21 @@
     "id": "woodland_westbound",
     "pa_ess_loc": "GWOO",
     "pa_ess_zone": "w",
-    "headsign": "Riverside",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70163",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70163",
+          "direction_id": 0,
+          "headway_direction_name": "Riverside",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "waban_eastbound",
@@ -4310,10 +4343,21 @@
     "id": "waban_westbound",
     "pa_ess_loc": "GWAB",
     "pa_ess_zone": "w",
-    "headsign": "Riverside",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70165",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70165",
+          "direction_id": 0,
+          "headway_direction_name": "Riverside",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "eliot_eastbound",
@@ -4339,10 +4383,21 @@
     "id": "eliot_westbound",
     "pa_ess_loc": "GELI",
     "pa_ess_zone": "w",
-    "headsign": "Riverside",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70167",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70167",
+          "direction_id": 0,
+          "headway_direction_name": "Riverside",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "newton_highlands_eastbound",
@@ -4368,10 +4423,21 @@
     "id": "newton_highlands_westbound",
     "pa_ess_loc": "GNEH",
     "pa_ess_zone": "w",
-    "headsign": "Riverside",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70169",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70169",
+          "direction_id": 0,
+          "headway_direction_name": "Riverside",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "newton_centre_eastbound",
@@ -4397,19 +4463,41 @@
     "id": "newton_centre_westbound",
     "pa_ess_loc": "GNEC",
     "pa_ess_zone": "w",
-    "headsign": "Riverside",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70171",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70171",
+          "direction_id": 0,
+          "headway_direction_name": "Riverside",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "chestnut_hill_eastbound",
     "pa_ess_loc": "GCHE",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70172",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70172",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "chestnut_hill_westbound",
@@ -4435,10 +4523,21 @@
     "id": "reservoir_eastbound",
     "pa_ess_loc": "GRES",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70174",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70174",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "reservoir_westbound",
@@ -4464,10 +4563,21 @@
     "id": "beaconsfield_eastbound",
     "pa_ess_loc": "GBEA",
     "pa_ess_zone": "e",
-    "route_id": "Green-D",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70176",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70176",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "beaconsfield_westbound",
@@ -4493,10 +4603,21 @@
     "id": "brookline_hills_eastbound",
     "pa_ess_loc": "GBRH",
     "pa_ess_zone": "e",
-    "route_id": "Green-D",
-    "gtfs_stop_id": "70178",
-    "headsign": "Govt Ctr",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70178",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "brookline_hills_westbound",
@@ -4522,10 +4643,21 @@
     "id": "brookline_village_eastbound",
     "pa_ess_loc": "GBRV",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70180",
-    "route_id": "Green-D",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70180",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "brookline_village_westbound",
@@ -4551,10 +4683,21 @@
     "id": "longwood_eastbound",
     "pa_ess_loc": "GLON",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70182",
-    "route_id": "Green-D",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70182",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "longwood_westbound",
@@ -4580,10 +4723,21 @@
     "id": "fenway_eastbound",
     "pa_ess_loc": "GFEN",
     "pa_ess_zone": "e",
-    "headsign": "Govt Ctr",
-    "gtfs_stop_id": "70186",
-    "route_id": "Green-D",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70186",
+          "direction_id": 1,
+          "headway_direction_name": "Govt Ctr",
+          "routes": ["Green-D"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    ]
   },
   {
     "id": "fenway_westbound",
@@ -5480,9 +5634,20 @@
     "id": "lechmere_green_line",
     "pa_ess_loc": "GLEC",
     "pa_ess_zone": "w",
-    "headsign": "Heath St",
-    "gtfs_stop_id": "70210",
-    "route_id": "Green-E",
-    "type": "headway"
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70210",
+          "direction_id": 0,
+          "headway_direction_name": "Heath St",
+          "routes": ["Green-E"],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[3] RTR never publishes predictions for a configurable list of stops](https://app.asana.com/0/584764604969369/1108116647787091)

This is the `realtime_signs` part of this ticket, in which we change the affected signs back from `headway` to `realtime`. See also https://github.com/mbta/rtr/pull/583.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
