### PR TITLE
Say "No train service" instead of "No service" during suspension

### DIFF
--- a/lib/signs/headway.ex
+++ b/lib/signs/headway.ex
@@ -110,7 +110,7 @@ defmodule Signs.Headway do
         alert_status in [:suspension, :station_closure] ->
           %{
             sign
-            | current_content_top: %Content.Message.Alert.NoService{mode: :none},
+            | current_content_top: %Content.Message.Alert.NoService{mode: :train},
               current_content_bottom: Content.Message.Empty.new()
           }
 

--- a/test/signs/headway_test.exs
+++ b/test/signs/headway_test.exs
@@ -341,7 +341,7 @@ defmodule Signs.HeadwayTest do
 
       {:noreply, sign} = handle_info(:update_content, sign)
 
-      assert sign.current_content_top == %Content.Message.Alert.NoService{mode: :none}
+      assert sign.current_content_top == %Content.Message.Alert.NoService{mode: :train}
       assert sign.current_content_bottom == %Content.Message.Empty{}
     end
 
@@ -369,7 +369,7 @@ defmodule Signs.HeadwayTest do
 
       {:noreply, sign} = handle_info(:update_content, sign)
 
-      assert sign.current_content_top == %Content.Message.Alert.NoService{mode: :none}
+      assert sign.current_content_top == %Content.Message.Alert.NoService{mode: :train}
       assert sign.current_content_bottom == %Content.Message.Empty{}
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Change wording from "No service" to "No train service" for Suspensions](https://app.asana.com/0/584764604969369/1108881758639126)

A suspension or station-closure alert should say "No train service" rather than "no service," which was confusing some riders.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
