### PR TITLE
Bump BRD out to 45 seconds

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -13,6 +13,7 @@ defmodule Content.Message.Predictions do
   require Logger
 
   @thirty_plus_minutes 30 * 60
+  @terminal_brd_seconds 45
 
   @enforce_keys [:headsign, :minutes]
   defstruct [:headsign, :minutes, :route_id, :stop_id, width: 18]
@@ -71,8 +72,8 @@ defmodule Content.Message.Predictions do
 
     minutes =
       case prediction.seconds_until_departure do
-        x when x <= 30 and stopped_at? -> :boarding
-        x when x <= 30 -> 1
+        x when x <= @terminal_brd_seconds and stopped_at? -> :boarding
+        x when x <= @terminal_brd_seconds -> 1
         x when x >= @thirty_plus_minutes -> :thirty_plus
         x -> x |> Kernel./(60) |> round()
       end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -242,28 +242,13 @@ defmodule Content.Message.PredictionsTest do
 
     test "does not put boarding on the sign too early when train is stopped at terminal" do
       prediction = %Predictions.Prediction{
-        seconds_until_departure: 120,
+        seconds_until_departure: 50,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
         stopped?: false,
         stops_away: 0,
         boarding_status: "Stopped at station"
-      }
-
-      msg = Content.Message.Predictions.terminal(prediction)
-
-      assert Content.Message.to_string(msg) == "Ashmont      2 min"
-    end
-
-    test "does not put boarding if prediction is greater than 30 seconds" do
-      prediction = %Predictions.Prediction{
-        seconds_until_departure: 45,
-        direction_id: 1,
-        route_id: "Mattapan",
-        stopped?: false,
-        stops_away: 1,
-        destination_stop_id: "70261"
       }
 
       msg = Content.Message.Predictions.terminal(prediction)
@@ -284,21 +269,6 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
-    end
-
-    test "puts the time on the sign when train's departure is more than 30 seconds away" do
-      prediction = %Predictions.Prediction{
-        seconds_until_departure: 60,
-        direction_id: 0,
-        route_id: "Mattapan",
-        stopped?: false,
-        stops_away: 1,
-        destination_stop_id: "70275"
-      }
-
-      msg = Content.Message.Predictions.terminal(prediction)
-
-      assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Bump terminal predictions by 30 seconds](https://app.asana.com/0/584764604969369/1115422642508058/f)

We need to raise the threshold for BRD above 30 seconds, but probably not quite to 60 since that would result in signs going straight from 2 minutes to BRD. There were also several unit tests in the accompanying test file testing exactly the same thing, so I removed some of those.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
