### PR TITLE
Fix Capen Street

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -210,28 +210,6 @@
     ]
   },
   {
-    "id": "capen_street_outbound",
-    "type": "realtime",
-    "pa_ess_loc": "MCAP",
-    "read_loop_offset": 60,
-    "text_zone": "s",
-    "audio_zones": ["s"],
-    "source_config": [
-      [
-        {
-          "stop_id": "70273",
-          "routes": ["Mattapan"],
-          "direction_id": 0,
-          "headway_direction_name": "Mattapan",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
-    ]
-  },
-  {
     "id": "capen_street_inbound",
     "type": "realtime",
     "pa_ess_loc": "MCAP",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Bug fix: Capen Street only has a sign on the NB side](https://app.asana.com/0/584764604969369/1113190554115752/f)

There's no sign in the outbound direction, so just remove it from the config.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
