### PR TITLE
show 30+ when the train is stopped far away and the prediction is long

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -68,7 +68,7 @@ defmodule Content.Audio.Predictions do
               platform: src.platform
             }
 
-          predictions.minutes == :thirty_plus ->
+          predictions.minutes == :max_time ->
             %NextTrainCountdown{
               destination: headsign,
               minutes: 30,

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -11,8 +11,9 @@ defmodule Content.Message.Predictions do
   """
 
   require Logger
+  require Content.Utilities
 
-  @max_time 30 * 60
+  @max_time Content.Utilities.max_time_seconds()
   @terminal_brd_seconds 45
 
   @enforce_keys [:headsign, :minutes]
@@ -20,7 +21,7 @@ defmodule Content.Message.Predictions do
 
   @type t :: %__MODULE__{
           headsign: String.t(),
-          minutes: integer() | :boarding | :arriving | :approaching | :thirty_plus,
+          minutes: integer() | :boarding | :arriving | :approaching | :max_time,
           route_id: String.t(),
           stop_id: String.t(),
           trip_id: Predictions.Prediction.trip_id() | nil,
@@ -39,7 +40,7 @@ defmodule Content.Message.Predictions do
         prediction.stops_away == 0 -> :boarding
         predicted_time <= 30 -> :arriving
         predicted_time <= 60 -> :approaching
-        predicted_time >= @max_time -> :thirty_plus
+        predicted_time >= @max_time -> :max_time
         true -> predicted_time |> Kernel./(60) |> round()
       end
 
@@ -77,7 +78,7 @@ defmodule Content.Message.Predictions do
       case prediction.seconds_until_departure do
         x when x <= @terminal_brd_seconds and stopped_at? -> :boarding
         x when x <= @terminal_brd_seconds -> 1
-        x when x >= @max_time -> :thirty_plus
+        x when x >= @max_time -> :max_time
         x -> x |> Kernel./(60) |> round()
       end
 
@@ -118,7 +119,7 @@ defmodule Content.Message.Predictions do
           :boarding -> @boarding
           :arriving -> @arriving
           :approaching -> "1 min"
-          :thirty_plus -> @max_time
+          :max_time -> @max_time
           n -> "#{n} min"
         end
 

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -1,6 +1,10 @@
 defmodule Content.Utilities do
   @type track_number :: non_neg_integer()
 
+  defmacro max_time_seconds do
+    quote do: 30 * 60
+  end
+
   def width_padded_string(left, right, width) do
     max_left_length = width - (String.length(right) + 1)
     left = String.slice(left, 0, max_left_length)

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -5,6 +5,7 @@ defmodule Signs.Utilities.Predictions do
   for the top and bottom lines.
   """
 
+  require Content.Utilities
   alias Signs.Utilities.SourceConfig
 
   @spec get_messages(Signs.Realtime.t()) ::
@@ -89,7 +90,8 @@ defmodule Signs.Utilities.Predictions do
          seconds_until_arrival: arrival_seconds,
          seconds_until_departure: departure_seconds
        })
-       when arrival_seconds >= 1800 or departure_seconds >= 1800 do
+       when arrival_seconds >= Content.Utilities.max_time_seconds() or
+              departure_seconds >= Content.Utilities.max_time_seconds() do
     false
   end
 

--- a/test/content/audio/predictions_test.exs
+++ b/test/content/audio/predictions_test.exs
@@ -238,7 +238,7 @@ defmodule Content.Audio.PredictionsTest do
              } = from_sign_content({src, predictions}, :top, false)
     end
 
-    test "returns a NextTrainCountdown with 30 mins if predictions is :thirty_plus" do
+    test "returns a NextTrainCountdown with 30 mins if predictions is :max_time" do
       src = %{
         @src
         | stop_id: "70065",
@@ -249,7 +249,7 @@ defmodule Content.Audio.PredictionsTest do
 
       predictions = %Message.Predictions{
         headsign: "Ashmont",
-        minutes: :thirty_plus,
+        minutes: :max_time,
         route_id: "Red",
         stop_id: "70065"
       }

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -503,7 +503,7 @@ defmodule Signs.Utilities.PredictionsTest do
       sign = %{@sign | source_config: config}
 
       assert {
-               {^src, %Content.Message.Predictions{headsign: "Mattapan", minutes: :thirty_plus}},
+               {^src, %Content.Message.Predictions{headsign: "Mattapan", minutes: :max_time}},
                {nil, %Content.Message.Empty{}}
              } = Signs.Utilities.Predictions.get_messages(sign)
     end
@@ -523,7 +523,7 @@ defmodule Signs.Utilities.PredictionsTest do
       sign = %{@sign | source_config: config}
 
       assert {
-               {^src, %Content.Message.Predictions{headsign: "Mattapan", minutes: :thirty_plus}},
+               {^src, %Content.Message.Predictions{headsign: "Mattapan", minutes: :max_time}},
                {nil, %Content.Message.Empty{}}
              } = Signs.Utilities.Predictions.get_messages(sign)
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[2] If a train is "stopped" far away just say "30+ min"](https://app.asana.com/0/584764604969369/1110675620726445)

when the time is long, consider the train not stopped anymore for the purposes of decidign what content to show.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
