### PR TITLE
Make terminal BRD display earlier

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -14,7 +14,8 @@ defmodule Content.Message.Predictions do
   require Content.Utilities
 
   @max_time Content.Utilities.max_time_seconds()
-  @terminal_brd_seconds 45
+  @terminal_brd_seconds 30
+  @terminal_prediction_offset_seconds -60
 
   @enforce_keys [:headsign, :minutes]
   defstruct [:headsign, :minutes, :route_id, :stop_id, :trip_id, width: 18]
@@ -75,7 +76,7 @@ defmodule Content.Message.Predictions do
     stopped_at? = prediction.stops_away == 0
 
     minutes =
-      case prediction.seconds_until_departure do
+      case prediction.seconds_until_departure + @terminal_prediction_offset_seconds do
         x when x <= @terminal_brd_seconds and stopped_at? -> :boarding
         x when x <= @terminal_brd_seconds -> 1
         x when x >= @max_time -> :max_time

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -220,7 +220,7 @@ defmodule Content.Message.PredictionsTest do
   describe "terminal/3" do
     test "logs a warning when we cant find a headsign, even if it should be boarding" do
       prediction = %Predictions.Prediction{
-        seconds_until_arrival: 0,
+        seconds_until_departure: 0,
         direction_id: 1,
         route_id: "NON-ROUTE",
         destination_stop_id: "70261",
@@ -239,7 +239,7 @@ defmodule Content.Message.PredictionsTest do
 
     test "logs a warning when we cant find a headsign" do
       prediction = %Predictions.Prediction{
-        seconds_until_arrival: 0,
+        seconds_until_departure: 0,
         direction_id: 1,
         route_id: "NON-ROUTE",
         stopped?: false,
@@ -257,7 +257,7 @@ defmodule Content.Message.PredictionsTest do
 
     test "puts boarding on the sign when train is supposed to be boarding according to rtr" do
       prediction = %Predictions.Prediction{
-        seconds_until_departure: 15,
+        seconds_until_departure: 75,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
@@ -273,7 +273,7 @@ defmodule Content.Message.PredictionsTest do
 
     test "does not put boarding on the sign too early when train is stopped at terminal" do
       prediction = %Predictions.Prediction{
-        seconds_until_departure: 50,
+        seconds_until_departure: 95,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
@@ -287,9 +287,25 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
     end
 
-    test "puts 1 min on the sign when train is not boarding, but is predicted to depart in less than a minute" do
+    test "offsets the prediction by 60 seconds" do
       prediction = %Predictions.Prediction{
-        seconds_until_departure: 10,
+        seconds_until_departure: 209,
+        direction_id: 1,
+        route_id: "Mattapan",
+        destination_stop_id: "70261",
+        stopped?: false,
+        stops_away: 0,
+        boarding_status: "Stopped at station"
+      }
+
+      msg = Content.Message.Predictions.terminal(prediction)
+
+      assert Content.Message.to_string(msg) == "Ashmont      2 min"
+    end
+
+    test "puts 1 min on the sign when train is not boarding, but is predicted to depart in less than a minute when offset" do
+      prediction = %Predictions.Prediction{
+        seconds_until_departure: 70,
         direction_id: 1,
         route_id: "Mattapan",
         stopped?: false,
@@ -305,7 +321,7 @@ defmodule Content.Message.PredictionsTest do
     test "pages track information when available" do
       prediction = %Predictions.Prediction{
         stop_id: "Forest Hills-02",
-        seconds_until_departure: 120,
+        seconds_until_departure: 180,
         direction_id: 1,
         route_id: "Orange",
         stopped?: false,
@@ -322,7 +338,7 @@ defmodule Content.Message.PredictionsTest do
 
     test "Includes the prediction's trip_id" do
       prediction = %Predictions.Prediction{
-        seconds_until_arrival: 91,
+        seconds_until_departure: 91,
         route_id: "Mattapan",
         direction_id: 1,
         stopped?: false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[1] Make terminal BRD display earlier](https://app.asana.com/0/584764604969369/1124015569449005/f)

- Added a new `@terminal_prediction_offset_seconds` and add it to predictions.
- Reduced `@terminal_brd_seconds` back down to 30.
- Updated tests to account for the offset.
- Also updated some tests that were passing in `seconds_until_arrival` but not `seconds_until_departure`, when all predictions we get will include the latter.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
