### PR TITLE
Configure additional signs for programatic headways

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -3952,6 +3952,7 @@
     "read_loop_offset": 0,
     "text_zone": "n",
     "audio_zones": ["n"],
+    "headway_terminal_ids": ["ashmont"],
     "source_config": [
       [
         {
@@ -4030,6 +4031,7 @@
     "read_loop_offset": 0,
     "text_zone": "n",
     "audio_zones": ["n"],
+    "headway_terminal_ids": ["ashmont"],
     "source_config": [
       [
         {
@@ -4364,6 +4366,7 @@
     "read_loop_offset": 150,
     "text_zone": "c",
     "audio_zones": ["c"],
+    "headway_terminal_ids": ["braintree"],
     "source_config": [
       [
         {
@@ -4407,6 +4410,7 @@
     "read_loop_offset": 120,
     "text_zone": "m",
     "audio_zones": ["m"],
+    "headway_terminal_ids": ["braintree"],
     "source_config": [
       [
         {

--- a/test/engine/observed_headways_test.exs
+++ b/test/engine/observed_headways_test.exs
@@ -28,7 +28,10 @@ defmodule Engine.ObservedHeadwaysTest do
         "70086" => ["ashmont"],
         "70088" => ["ashmont"],
         "70090" => ["ashmont"],
-        "70096" => ["braintree"]
+        "70096" => ["braintree"],
+        "70092" => ["ashmont"],
+        "70094" => ["ashmont"],
+        "70105" => ["braintree"]
       }
 
       actual_recent_headways = :ets.lookup_element(:initial_state_table, :recent_headways, 2)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Configure additional signs for programmatic headways](https://app.asana.com/0/584764604969369/1130249505036676/f)

Adding additional signs that are currently off that the PIOs might want to use programmatic headways for.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
