### PR TITLE
Reorder StopsAway messages based on number of stops

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -21,6 +21,9 @@ defmodule Signs.Utilities.Predictions do
     get_predictions(sign.prediction_engine, both_lines_sources)
   end
 
+  @spec get_predictions(module(), [Signs.Utilities.SourceConfig.source()]) ::
+          {{SourceConfig.source() | nil, Content.Message.t()},
+           {SourceConfig.source() | nil, Content.Message.t()}}
   defp get_predictions(prediction_engine, source_list) do
     source_list
     |> Enum.flat_map(fn source ->
@@ -66,6 +69,7 @@ defmodule Signs.Utilities.Predictions do
           {source, Content.Message.Predictions.non_terminal(prediction)}
       end
     end)
+    |> sort_messages_by_stops_away()
     |> case do
       [] ->
         {{nil, Content.Message.Empty.new()}, {nil, Content.Message.Empty.new()}}
@@ -120,5 +124,20 @@ defmodule Signs.Utilities.Predictions do
 
   defp allowed_multi_berth_platform?(_, _) do
     false
+  end
+
+  @spec sort_messages_by_stops_away([{SourceConfig.source() | nil, Content.Message.t()}]) :: [
+          {SourceConfig.source() | nil, Content.Message.t()}
+        ]
+  defp sort_messages_by_stops_away([
+         {s1, %Content.Message.StopsAway{stops_away: stops_away1} = m1},
+         {s2, %Content.Message.StopsAway{stops_away: stops_away2} = m2}
+       ])
+       when stops_away2 < stops_away1 do
+    [{s2, m2}, {s1, m1}]
+  end
+
+  defp sort_messages_by_stops_away(msgs) do
+    msgs
   end
 end

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -429,6 +429,33 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
+    def for_stop("stops_away_message_reverse_order", 1) do
+      [
+        %Predictions.Prediction{
+          stop_id: "stops_away_message",
+          direction_id: 1,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 5,
+          boarding_status: nil,
+          destination_stop_id: "70061",
+          seconds_until_arrival: 800,
+          seconds_until_departure: 830
+        },
+        %Predictions.Prediction{
+          stop_id: "stops_away_message",
+          direction_id: 1,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 4,
+          boarding_status: nil,
+          destination_stop_id: "70061",
+          seconds_until_arrival: 900,
+          seconds_until_departure: 930
+        }
+      ]
+    end
+
     def for_stop(_stop_id, _direction_id) do
       []
     end
@@ -714,6 +741,26 @@ defmodule Signs.Utilities.PredictionsTest do
       assert {
                {^s, %Content.Message.Predictions{headsign: "Alewife"}},
                {nil, %Content.Message.Empty{}}
+             } = Signs.Utilities.Predictions.get_messages(sign)
+    end
+
+    test "Returns stops away messages reordered by number of stops" do
+      s = %SourceConfig{
+        stop_id: "stops_away_message_reverse_order",
+        headway_direction_name: "Alewife",
+        direction_id: 1,
+        terminal?: false,
+        platform: nil,
+        announce_arriving?: true,
+        announce_boarding?: false
+      }
+
+      config = {[s]}
+      sign = %{@sign | source_config: config}
+
+      assert {
+               {^s, %Content.Message.StopsAway{headsign: "Alewife", stops_away: 4}},
+               {^s, %Content.Message.StopsAway{headsign: "Alewife", stops_away: 5}}
              } = Signs.Utilities.Predictions.get_messages(sign)
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ Sort sign by "stops away" and not prediction time?](https://app.asana.com/0/584764604969369/1129518349630458/f)

If both lines show stops away, order them by stops away rather than minutes.

This should also work equally well for mezzanine signs (the lower number of stops will be sorted to the first position and therefore appear on the sign, while the other train a higher number of stops away doesn't show up).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
