### PR TITLE
Remove period from "Use shuttle bus" message

### DIFF
--- a/lib/content/message/alert/use_shuttle_bus.ex
+++ b/lib/content/message/alert/use_shuttle_bus.ex
@@ -9,7 +9,7 @@ defmodule Content.Message.Alert.UseShuttleBus do
 
   defimpl Content.Message do
     def to_string(_) do
-      "Use shuttle bus."
+      "Use shuttle bus"
     end
   end
 end

--- a/test/content/messages/alert/use_shuttle_bus_test.exs
+++ b/test/content/messages/alert/use_shuttle_bus_test.exs
@@ -1,0 +1,10 @@
+defmodule Content.Message.Alert.UseShuttleBusTest do
+  use ExUnit.Case, async: true
+
+  describe "to_string" do
+    test "serializes modes correctly" do
+      msg = %Content.Message.Alert.UseShuttleBus{}
+      assert Content.Message.to_string(msg) == "Use shuttle bus"
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Remove period from "Use shuttle bus" message](https://app.asana.com/0/584764604969369/1131869394190119/f)

We were sending a period in the "use shuttle bus" message. This wouldn't display on the signs and we wouldn't notice because nothing after the period would be truncated, but the fancy new parser in Signs UI didn't recognize it, so the second line of the message wouldn't show up at all.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
