### PR TITLE
Drop long headways from consideration

### DIFF
--- a/lib/headway/schedule_headway.ex
+++ b/lib/headway/schedule_headway.ex
@@ -8,6 +8,7 @@ defmodule Headway.ScheduleHeadway do
 
   @min_headway 5
   @headway_padding 2
+  @max_headway_to_consider 30
 
   @spec build_request({[String.t()], [GTFS.station_id()]}) :: String.t()
   def build_request({direction_ids, station_ids}) do
@@ -49,7 +50,7 @@ defmodule Headway.ScheduleHeadway do
   end
 
   defp do_headway_for_station({previous_times, later_times}) do
-    calculate_headway_range([List.last(previous_times) | Enum.take(later_times, 2)])
+    calculate_headway_range([List.last(previous_times) | Enum.take(later_times, 3)])
   end
 
   @spec calculate_headway_range([DateTime.t()]) :: headway_range
@@ -64,6 +65,33 @@ defmodule Headway.ScheduleHeadway do
        Timex.diff(second_upcoming_time, upcoming_time, :minutes)}
 
     pad_headway_range(actual_headway)
+  end
+
+  defp calculate_headway_range([
+         previous_time,
+         upcoming_time,
+         second_upcoming_time,
+         third_upcoming_time
+       ]) do
+    minute_headways = [
+      Timex.diff(upcoming_time, previous_time, :minutes),
+      Timex.diff(second_upcoming_time, upcoming_time, :minutes),
+      Timex.diff(third_upcoming_time, second_upcoming_time, :minutes)
+    ]
+
+    {_dropped?, usable_headways} =
+      Enum.reduce(minute_headways, {false, []}, fn headway, {dropped?, acc} ->
+        if headway <= @max_headway_to_consider or dropped? do
+          {dropped?, acc ++ [headway]}
+        else
+          {true, acc}
+        end
+      end)
+
+    usable_headways
+    |> Enum.take(2)
+    |> List.to_tuple()
+    |> pad_headway_range()
   end
 
   @spec schedule_time(map) :: [DateTime.t()]

--- a/test/headway/schedule_headway_test.exs
+++ b/test/headway/schedule_headway_test.exs
@@ -259,6 +259,64 @@ defmodule Headway.ScheduleHeadwayTest do
       {:first_departure, headway, _first_time} = Map.get(headways, "111")
       assert headway == {5, nil}
     end
+
+    test "excludes artificially-long headways from calculation" do
+      times = [
+        ~N[2017-07-04 08:55:00],
+        ~N[2017-07-04 09:05:00],
+        ~N[2017-07-04 09:50:00],
+        ~N[2017-07-04 10:05:00]
+      ]
+
+      schedules =
+        Enum.map(times, fn time ->
+          %{
+            "relationships" => %{"stop" => %{"data" => %{"id" => "111"}}},
+            "attributes" => %{
+              "departure_time" =>
+                Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")
+            }
+          }
+        end)
+
+      headways =
+        group_headways_for_stations(
+          schedules,
+          ["111"],
+          Timex.to_datetime(@current_time, "America/New_York")
+        )
+
+      assert headways == %{"111" => {10, 17}}
+    end
+
+    test "still uses long headways if there's more than one of them" do
+      times = [
+        ~N[2017-07-04 08:55:00],
+        ~N[2017-07-04 09:05:00],
+        ~N[2017-07-04 09:50:00],
+        ~N[2017-07-04 10:30:00]
+      ]
+
+      schedules =
+        Enum.map(times, fn time ->
+          %{
+            "relationships" => %{"stop" => %{"data" => %{"id" => "111"}}},
+            "attributes" => %{
+              "departure_time" =>
+                Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")
+            }
+          }
+        end)
+
+      headways =
+        group_headways_for_stations(
+          schedules,
+          ["111"],
+          Timex.to_datetime(@current_time, "America/New_York")
+        )
+
+      assert headways == %{"111" => {10, 42}}
+    end
   end
 
   describe "format_headway_range/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🎯 deal with GTFS shuttle-headway weirdness](https://app.asana.com/0/584764604969369/1129355555361336/f)

Drop headways of >30 minutes from consideration in the calculation.

Note that there are separate cases for when it's the first departure of the day (i.e. no previous departures) and all other cases. I've decided to be conservative and only apply this logic to the latter case, since this is a temporary fix that's meant to apply in a very specific case.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
