### PR TITLE
Handle cases when number_var/2 is passed a value out of range

### DIFF
--- a/lib/content/audio/bridge_is_up.ex
+++ b/lib/content/audio/bridge_is_up.ex
@@ -48,7 +48,10 @@ defmodule Content.Audio.BridgeIsUp do
     defp vars(%{language: _language, time_estimate_mins: nil}), do: []
 
     defp vars(%{language: language, time_estimate_mins: mins}) do
-      [Utilities.number_var(mins, language)]
+      case Utilities.number_var(mins, language) do
+        nil -> []
+        var -> [var]
+      end
     end
   end
 end

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -96,7 +96,14 @@ defmodule Content.Audio.VehiclesToDestination do
     alias PaEss.Utilities
 
     def to_params(audio) do
-      {message_id(audio), vars(audio), :audio}
+      case vars(audio) do
+        nil ->
+          Logger.warn("no_audio_for_headway_range #{inspect(audio)}")
+          nil
+
+        vars ->
+          {message_id(audio), vars, :audio}
+      end
     end
 
     @spec message_id(Content.Audio.VehiclesToDestination.t()) :: String.t()
@@ -128,8 +135,16 @@ defmodule Content.Audio.VehiclesToDestination do
     defp message_id(%{language: :spanish, destination: :chelsea}), do: "150"
     defp message_id(%{language: :spanish, destination: :south_station}), do: "151"
 
+    @spec vars(Content.Audio.VehiclesToDestination.t()) :: [String.t()] | nil
     defp vars(%{language: language, next_trip_mins: next, later_trip_mins: later}) do
-      [Utilities.number_var(next, language), Utilities.number_var(later, language)]
+      next_trip_var = Utilities.number_var(next, language)
+      later_trip_var = Utilities.number_var(later, language)
+
+      if next_trip_var && later_trip_var do
+        [next_trip_var, later_trip_var]
+      else
+        nil
+      end
     end
   end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -19,16 +19,20 @@ defmodule PaEss.Utilities do
     language == :english or destination in [:chelsea, :south_station]
   end
 
-  @spec number_var(integer(), Content.Audio.language()) :: String.t() | no_return()
+  @spec number_var(integer(), Content.Audio.language()) :: String.t() | nil
   def number_var(n, :english) do
-    cond do
-      valid_range?(n, :english) -> Integer.to_string(5500 + n)
+    if valid_range?(n, :english) do
+      Integer.to_string(5500 + n)
+    else
+      nil
     end
   end
 
   def number_var(n, :spanish) do
-    cond do
-      valid_range?(n, :spanish) -> Integer.to_string(37000 + n)
+    if valid_range?(n, :spanish) do
+      Integer.to_string(37000 + n)
+    else
+      nil
     end
   end
 

--- a/test/content/audio/bridge_is_up_test.exs
+++ b/test/content/audio/bridge_is_up_test.exs
@@ -39,6 +39,15 @@ defmodule Content.Audio.BridgeIsUpTest do
     assert Content.Audio.to_params(audio) == {"152", ["37005"], :audio_visual}
   end
 
+  test "When bridge is up with an estimate of 21 minutes, exclude time in Spanish audio" do
+    audio = %Content.Audio.BridgeIsUp{
+      language: :spanish,
+      time_estimate_mins: 21
+    }
+
+    assert Content.Audio.to_params(audio) == {"152", [], :audio_visual}
+  end
+
   describe "create_bridge_messages/1" do
     test "returns an audio message from a headway message to chelsea" do
       assert {

--- a/test/content/audio/vehicles_to_destination_test.exs
+++ b/test/content/audio/vehicles_to_destination_test.exs
@@ -48,6 +48,22 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     assert Content.Audio.to_params(audio) == {"151", ["37007", "37010"], :audio}
   end
 
+  test "Buses to South Station in Spanish, headway out of range" do
+    audio = %Content.Audio.VehiclesToDestination{
+      destination: :south_station,
+      language: :spanish,
+      next_trip_mins: 7,
+      later_trip_mins: 21
+    }
+
+    log =
+      capture_log([level: :warn], fn ->
+        assert Content.Audio.to_params(audio) == nil
+      end)
+
+    assert log =~ "no_audio_for_headway_range"
+  end
+
   describe "from_headway_message/2" do
     @msg %Content.Message.Headways.Bottom{range: {5, 7}}
 

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -19,6 +19,8 @@ defmodule Content.Audio.UtilitiesTest do
   test "number_var/2" do
     assert number_var(10, :english) == "5510"
     assert number_var(10, :spanish) == "37010"
+    assert number_var(61, :english) == nil
+    assert number_var(21, :spanish) == nil
   end
 
   test "time_var/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ Signs crash when bridge is up 21+ mins](https://app.asana.com/0/584764604969369/1131256194964049/f)

Updated `number_var/2` to return `nil` if no audio is available, rather than crashing. Updated the two places that use `number_var/2`, namely the bridge up audio and the vehicles to destination audio. In the former case, do what the ticket says and just play the normal bridge up announcement without any accompanying time. For vehicles to destination there isn't really a sensible alternative so I had it just not do audio in that case.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
