### PR TITLE
Sort departures when some trains have arrival times and some don't

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -36,8 +36,10 @@ defmodule Signs.Utilities.Predictions do
       p.seconds_until_departure
     end)
     |> Enum.sort_by(fn {_source_config, prediction} ->
-      {prediction.stops_away, prediction.seconds_until_departure,
-       prediction.seconds_until_arrival}
+      {case prediction.stops_away do
+         0 -> 0
+         _ -> 1
+       end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
     |> Enum.take(2)
     |> Enum.map(fn {source, prediction} ->

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -498,6 +498,31 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
+    def for_stop("stops_away_ordering_different_from_minutes", 1) do
+      [
+        %Predictions.Prediction{
+          stop_id: "stops_away_ordering_different_from_minutes",
+          direction_id: 1,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 4,
+          destination_stop_id: "70061",
+          seconds_until_arrival: 60,
+          seconds_until_departure: 70
+        },
+        %Predictions.Prediction{
+          stop_id: "stops_away_ordering_different_from_minutes",
+          direction_id: 1,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 3,
+          destination_stop_id: "70061",
+          seconds_until_arrival: 120,
+          seconds_until_departure: 130
+        }
+      ]
+    end
+
     def for_stop(_stop_id, _direction_id) do
       []
     end
@@ -971,6 +996,27 @@ defmodule Signs.Utilities.PredictionsTest do
       assert {
                {^s1, %Content.Message.Predictions{headsign: "Riverside", minutes: :boarding}},
                {^s2, %Content.Message.Predictions{headsign: "Boston Col", minutes: :boarding}}
+             } = Signs.Utilities.Predictions.get_messages(sign)
+    end
+
+    test "Sorts by minutes rather than stops away when minutes will be displayed" do
+      s = %SourceConfig{
+        stop_id: "stops_away_ordering_different_from_minutes",
+        headway_direction_name: "Alewife",
+        direction_id: 1,
+        terminal?: false,
+        platform: nil,
+        routes: nil,
+        announce_arriving?: true,
+        announce_boarding?: false
+      }
+
+      config = {[s]}
+      sign = %{@sign | source_config: config}
+
+      assert {
+               {^s, %Content.Message.Predictions{headsign: "Alewife", minutes: :approaching}},
+               {^s, %Content.Message.Predictions{headsign: "Alewife", minutes: 2}}
              } = Signs.Utilities.Predictions.get_messages(sign)
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ [extra] Change how we sort predictions on signs](https://app.asana.com/0/584764604969369/1132718132682768/f)

Keep the existing logic to sort by stops away before anything else. When sorting by time, follow the ticket. All predictions we're sorting by will have a departure time, so no need to worry about that. For sorting by arrival time, `nil` is considered greater than any number by the builtin Elixir comparison functions, so we can take advantage of that to sort `nil`s to the end. This also takes advantage of the fact that tuples are sorted element-by-element.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
