### PR TITLE
dont show stops away at a temrinal

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -40,7 +40,7 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.take(2)
     |> Enum.map(fn {source, prediction} ->
       cond do
-        red_line_stops_away?(prediction) ->
+        !source.terminal? && red_line_stops_away?(prediction) ->
           {source, Content.Message.StopsAway.from_prediction(prediction)}
 
         stopped_train?(prediction) ->

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -414,6 +414,22 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
+    def for_stop("stops_away_message_terminal", 1) do
+      [
+        %Predictions.Prediction{
+          stop_id: "stops_away_message",
+          direction_id: 1,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 2,
+          boarding_status: nil,
+          destination_stop_id: "70061",
+          seconds_until_arrival: 800,
+          seconds_until_departure: 2020
+        }
+      ]
+    end
+
     def for_stop("no_stops_away_message_short", 1) do
       [
         %Predictions.Prediction{
@@ -867,6 +883,26 @@ defmodule Signs.Utilities.PredictionsTest do
         headway_direction_name: "Alewife",
         direction_id: 1,
         terminal?: false,
+        platform: nil,
+        announce_arriving?: true,
+        announce_boarding?: false
+      }
+
+      config = {[s]}
+      sign = %{@sign | source_config: config}
+
+      assert {
+               {^s, %Content.Message.Predictions{headsign: "Alewife"}},
+               {nil, %Content.Message.Empty{}}
+             } = Signs.Utilities.Predictions.get_messages(sign)
+    end
+
+    test "Does not return stops away message at terminals" do
+      s = %SourceConfig{
+        stop_id: "stops_away_message_terminal",
+        headway_direction_name: "Alewife",
+        direction_id: 1,
+        terminal?: true,
         platform: nil,
         announce_arriving?: true,
         announce_boarding?: false


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Don't display "n stops" at terminals](https://app.asana.com/0/584764604969369/1133563979422490)

when its a terminal, just dont do that.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
