### PR TITLE
dont use empty state when the api gives us something bad

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -107,11 +107,16 @@ defmodule Engine.ScheduledHeadways do
   defp update_schedule_data(state) do
     schedule_updater = state[:fetcher]
 
-    new_schedule =
+    new_schedule_raw =
       state.stop_ids
       |> Enum.chunk_every(20)
       |> Enum.map(&schedule_updater.get_schedules(&1))
-      |> Enum.concat()
+
+    new_schedule =
+      case Enum.any?(new_schedule_raw, &(&1 == [])) do
+        true -> []
+        false -> Enum.concat(new_schedule_raw)
+      end
 
     case new_schedule do
       [] ->

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -116,7 +116,7 @@ defmodule Engine.ScheduledHeadwaysTest do
       end
     end
 
-    test "when the schedule fetch does not get new data, keeps th eold data" do
+    test "when the schedule fetch does not get new data, keeps the old data" do
       schedules =
         Enum.map(FakeScheduleFetcher.get_test_times(), fn time ->
           %{
@@ -133,6 +133,53 @@ defmodule Engine.ScheduledHeadwaysTest do
         fetcher: FakeScheduleFetcher,
         fetch_ms: 30_000,
         stop_ids: ["bad_response"]
+      }
+
+      {:noreply, updated_state} = Engine.ScheduledHeadways.handle_info(:data_update, state)
+      updated_schedule = updated_state.schedule_data
+
+      assert updated_schedule["123"] == schedules
+    end
+
+    test "when the schedule fetch only gets some new data, keeps the old data" do
+      schedules =
+        Enum.map(FakeScheduleFetcher.get_test_times(), fn time ->
+          %{
+            "relationships" => %{"stop" => %{"data" => %{"id" => "123"}}},
+            "attributes" => %{
+              "departure_time" =>
+                Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")
+            }
+          }
+        end)
+
+      state = %{
+        schedule_data: %{"123" => schedules},
+        fetcher: FakeScheduleFetcher,
+        fetch_ms: 30_000,
+        stop_ids: [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18",
+          "19",
+          "20",
+          "bad_response"
+        ]
       }
 
       {:noreply, updated_state} = Engine.ScheduledHeadways.handle_info(:data_update, state)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ Keep old GTFS schedule in realtime_signs if API fetch fails](https://app.asana.com/0/584764604969369/1134108215239992)

dontn delete the state when we get a bad response.
#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
