### PR TITLE
Handle canceled trips in TripUpdates feed

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -8,6 +8,7 @@ defmodule Predictions.Predictions do
   def get_all(feed_message, current_time) do
     feed_message["entity"]
     |> Enum.map(& &1["trip_update"])
+    |> Enum.reject(&(&1["trip"]["schedule_relationship"] == "CANCELED"))
     |> Enum.flat_map(&transform_stop_time_updates/1)
     |> Enum.filter(fn {update, _, _, _, _, _} ->
       update["arrival"] || update["departure"] || update["passthrough_time"]

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -123,7 +123,7 @@ defmodule Predictions.PredictionsTest do
       assert get_all(@feed_message, @current_time) == expected
     end
 
-    test "finds predictions for multiple trips" do
+    test "finds predictions for multiple trips, excluding canceled trips" do
       feed_message = %{
         "entity" => [
           %{
@@ -232,6 +232,31 @@ defmodule Predictions.PredictionsTest do
               "vehicle" => %{
                 "id" => "vehicle_2",
                 "label" => "3261",
+                "license_plate" => nil
+              }
+            },
+            "vehicle" => nil
+          },
+          %{
+            "alert" => nil,
+            "id" => "1566418052_40826503",
+            "is_deleted" => false,
+            "trip_update" => %{
+              "delay" => nil,
+              "stop_time_update" => [],
+              "timestamp" => nil,
+              "trip" => %{
+                "direction_id" => nil,
+                "route_id" => nil,
+                "schedule_relationship" => "CANCELED",
+                "start_date" => "20190821",
+                "start_time" => nil,
+                "trip_id" => "40826503"
+              },
+              "vehicle" => %{
+                "consist" => [],
+                "id" => nil,
+                "label" => nil,
                 "license_plate" => nil
               }
             },


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] realtime_signs change to handle canceled trips in feed](https://app.asana.com/0/584764604969369/1136728970890897/f)

We're going to start publishing canceled trips shortly, and the realtime_signs app seemed to have some trouble with those. We should simply drop them from the feed before other processing as they aren't relevant for in-station displays.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
