### PR TITLE
Revert "dont use empty state when the api gives us something bad (#299)"

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -107,28 +107,14 @@ defmodule Engine.ScheduledHeadways do
   defp update_schedule_data(state) do
     schedule_updater = state[:fetcher]
 
-    new_schedule_raw =
+    Map.put(
+      state,
+      :schedule_data,
       state.stop_ids
       |> Enum.chunk_every(20)
       |> Enum.map(&schedule_updater.get_schedules(&1))
-
-    new_schedule =
-      case Enum.any?(new_schedule_raw, &(&1 == [])) do
-        true -> []
-        false -> Enum.concat(new_schedule_raw)
-      end
-
-    case new_schedule do
-      [] ->
-        state
-
-      schedule ->
-        Map.put(
-          state,
-          :schedule_data,
-          schedule
-        )
-    end
+      |> Enum.concat()
+    )
   end
 
   @spec update_headway_data(state()) :: state()

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -33,10 +33,6 @@ defmodule Engine.ScheduledHeadwaysTest do
       ~N[2017-07-04 09:20:00]
     ]
 
-    def get_schedules(["bad_response"]) do
-      []
-    end
-
     def get_schedules(_station_ids) do
       Enum.map(@times, fn time ->
         %{
@@ -114,78 +110,6 @@ defmodule Engine.ScheduledHeadwaysTest do
         id_path = ["relationships", "stop", "data", "id"]
         assert get_in(schedule, id_path) == get_in(state_schedule, id_path)
       end
-    end
-
-    test "when the schedule fetch does not get new data, keeps the old data" do
-      schedules =
-        Enum.map(FakeScheduleFetcher.get_test_times(), fn time ->
-          %{
-            "relationships" => %{"stop" => %{"data" => %{"id" => "123"}}},
-            "attributes" => %{
-              "departure_time" =>
-                Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")
-            }
-          }
-        end)
-
-      state = %{
-        schedule_data: %{"123" => schedules},
-        fetcher: FakeScheduleFetcher,
-        fetch_ms: 30_000,
-        stop_ids: ["bad_response"]
-      }
-
-      {:noreply, updated_state} = Engine.ScheduledHeadways.handle_info(:data_update, state)
-      updated_schedule = updated_state.schedule_data
-
-      assert updated_schedule["123"] == schedules
-    end
-
-    test "when the schedule fetch only gets some new data, keeps the old data" do
-      schedules =
-        Enum.map(FakeScheduleFetcher.get_test_times(), fn time ->
-          %{
-            "relationships" => %{"stop" => %{"data" => %{"id" => "123"}}},
-            "attributes" => %{
-              "departure_time" =>
-                Timex.format!(Timex.to_datetime(time, "America/New_York"), "{ISO:Extended}")
-            }
-          }
-        end)
-
-      state = %{
-        schedule_data: %{"123" => schedules},
-        fetcher: FakeScheduleFetcher,
-        fetch_ms: 30_000,
-        stop_ids: [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15",
-          "16",
-          "17",
-          "18",
-          "19",
-          "20",
-          "bad_response"
-        ]
-      }
-
-      {:noreply, updated_state} = Engine.ScheduledHeadways.handle_info(:data_update, state)
-      updated_schedule = updated_state.schedule_data
-
-      assert updated_schedule["123"] == schedules
     end
   end
 end


### PR DESCRIPTION
This reverts commit 23ae702995c2b94fcd171418f988204151930f8b.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
