### PR TITLE
Increase API schedule request timeout

### DIFF
--- a/lib/headway/request.ex
+++ b/lib/headway/request.ex
@@ -10,7 +10,7 @@ defmodule Headway.Request do
     Enum.group_by(station_ids, &directions_for_station_id/1)
     |> Enum.map(&ScheduleHeadway.build_request/1)
     |> Enum.map(
-      &http_client.get(&1, api_key_header(api_v3_key), timeout: 2000, recv_timeout: 2000)
+      &http_client.get(&1, api_key_header(api_v3_key), timeout: 5000, recv_timeout: 5000)
     )
     |> Enum.map(&validate_and_parse_response/1)
     |> Enum.concat()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔍 Why is realtime_signs dev consistently failing to fetch API data?](https://app.asana.com/0/584764604969369/1134546946943246/f)

The old timeout was 2 seconds, which is a bit too low for some of the requests we're making. Since `Headway.ScheduleHeadway` stores all of its data in an ETS table, and only accepts `handle_info`s without any GenServer calls that might timeout directed at it, we should try just allowing more time for the request to go through.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
