### PR TITLE
Increase RL stops away threshold to 12 minutes

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -9,6 +9,8 @@ defmodule Signs.Utilities.Predictions do
   require Content.Utilities
   alias Signs.Utilities.SourceConfig
 
+  @red_line_stops_away_mins 12
+
   @spec get_messages(Signs.Realtime.t()) ::
           {{SourceConfig.source() | nil, Content.Message.t()},
            {SourceConfig.source() | nil, Content.Message.t()}}
@@ -141,8 +143,8 @@ defmodule Signs.Utilities.Predictions do
   @spec red_line_stops_away?(Predictions.Prediction.t()) :: boolean()
   defp red_line_stops_away?(prediction) do
     prediction.route_id == "Red" and
-      (prediction.seconds_until_arrival || prediction.seconds_until_departure) > 60 * 8 and
-      prediction.stops_away > 0
+      (prediction.seconds_until_arrival || prediction.seconds_until_departure) >
+        60 * @red_line_stops_away_mins and prediction.stops_away > 0
   end
 
   defp allowed_multi_berth_platform?(

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -440,8 +440,8 @@ defmodule Signs.Utilities.PredictionsTest do
           stops_away: 2,
           boarding_status: nil,
           destination_stop_id: "70061",
-          seconds_until_arrival: 80,
-          seconds_until_departure: 100
+          seconds_until_arrival: 660,
+          seconds_until_departure: 700
         }
       ]
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ℹ️ increase threshold for stops away on RL](https://app.asana.com/0/584764604969369/1138481747674909/f)

Put the threshold value into a module attribute and also increase it to 12 minutes from 8. The old tests passed with either 8 or 12 minutes as the value so I updated one of them.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
