### PR TITLE
Don't sort predictions with 0 stops away to the front for terminals

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -33,10 +33,14 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.filter(fn {_, p} ->
       p.seconds_until_departure
     end)
-    |> Enum.sort_by(fn {_source_config, prediction} ->
-      {case prediction.stops_away do
-         0 -> 0
-         _ -> 1
+    |> Enum.sort_by(fn {source, prediction} ->
+      {if source.terminal? do
+         0
+       else
+         case prediction.stops_away do
+           0 -> 0
+           _ -> 1
+         end
        end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
     |> Enum.take(2)

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -540,6 +540,33 @@ defmodule Signs.Utilities.PredictionsTest do
       ]
     end
 
+    def for_stop("terminal_dont_sort_0_stops_first", 0) do
+      [
+        %Predictions.Prediction{
+          stop_id: "terminal_dont_sort_0_stops_first",
+          direction_id: 0,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 1,
+          destination_stop_id: "70105",
+          seconds_until_arrival: nil,
+          seconds_until_departure: 120,
+          trip_id: "123"
+        },
+        %Predictions.Prediction{
+          stop_id: "terminal_dont_sort_0_stops_first",
+          direction_id: 0,
+          route_id: "Red",
+          stopped?: false,
+          stops_away: 0,
+          destination_stop_id: "70093",
+          seconds_until_arrival: nil,
+          seconds_until_departure: 240,
+          trip_id: "123"
+        }
+      ]
+    end
+
     def for_stop("passthrough_trains", 0) do
       [
         %Predictions.Prediction{
@@ -1124,6 +1151,27 @@ defmodule Signs.Utilities.PredictionsTest do
       assert {
                {^s, %Content.Message.Predictions{headsign: "Alewife", minutes: :approaching}},
                {^s, %Content.Message.Predictions{headsign: "Alewife", minutes: 2}}
+             } = Signs.Utilities.Predictions.get_messages(sign)
+    end
+
+    test "doesn't sort 0 stops away to first for terminals when another departure is sooner" do
+      s = %SourceConfig{
+        stop_id: "terminal_dont_sort_0_stops_first",
+        headway_direction_name: "Southbound",
+        direction_id: 0,
+        terminal?: true,
+        platform: nil,
+        routes: nil,
+        announce_arriving?: false,
+        announce_boarding?: true
+      }
+
+      config = {[s]}
+      sign = %{@sign | source_config: config}
+
+      assert {
+               {^s, %Content.Message.Predictions{headsign: "Braintree", minutes: 1}},
+               {^s, %Content.Message.Predictions{headsign: "Ashmont", minutes: 3}}
              } = Signs.Utilities.Predictions.get_messages(sign)
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🔍 out of order predictions at Forest Hills](https://app.asana.com/0/584764604969369/1138511352189969/f)

One of the issues uncovered in this investigation is that we _always_ sort predictions with 0 stops away to the front. At terminals, though, this shouldn't necessarily be the case, since you could have a train on one track, and then have a train that's going to come in on the other track and leave first. 

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
