### PR TITLE
Translate terminal stop IDs in departure engine

### DIFF
--- a/lib/engine/departures.ex
+++ b/lib/engine/departures.ex
@@ -103,7 +103,7 @@ defmodule Engine.Departures do
           end).()
       |> Enum.take(3)
 
-    Map.put(departures, stop_id, new_times_for_stop)
+    Map.put(departures, translate_terminal_stop_id(stop_id), new_times_for_stop)
   end
 
   @spec headway_sort({non_neg_integer, non_neg_integer}) :: {non_neg_integer, non_neg_integer}
@@ -114,4 +114,11 @@ defmodule Engine.Departures do
   defp headway_sort({first, second}) when first <= second do
     {first, second}
   end
+
+  @spec translate_terminal_stop_id(String.t()) :: String.t()
+  defp translate_terminal_stop_id("Alewife-" <> _), do: "70061"
+  defp translate_terminal_stop_id("Braintree-" <> _), do: "70105"
+  defp translate_terminal_stop_id("Forest Hills-" <> _), do: "70001"
+  defp translate_terminal_stop_id("Oak Grove-" <> _), do: "70036"
+  defp translate_terminal_stop_id(stop_id), do: stop_id
 end

--- a/test/engine/departures_test.exs
+++ b/test/engine/departures_test.exs
@@ -50,6 +50,39 @@ defmodule Engine.DeparturesTest do
       assert :sys.get_state(departures_pid).departures == %{"a" => [time2], "b" => [time3, time1]}
     end
 
+    test "handles terminal platform stop IDs" do
+      {:ok, departures_pid} = Engine.Departures.start_link(gen_server_name: :departures_test)
+
+      time1 = Timex.now()
+
+      :ok =
+        Engine.Departures.update_train_state(
+          departures_pid,
+          MapSet.new(["Alewife-02"]),
+          time1
+        )
+
+      time2 = Timex.shift(time1, minutes: 1)
+
+      :ok =
+        Engine.Departures.update_train_state(
+          departures_pid,
+          MapSet.new(["Alewife-01", "Alewife-02"]),
+          time2
+        )
+
+      time3 = Timex.shift(time2, minutes: 1)
+
+      :ok =
+        Engine.Departures.update_train_state(
+          departures_pid,
+          MapSet.new(["Alewife-01"]),
+          time3
+        )
+
+      assert :sys.get_state(departures_pid).departures == %{"70061" => [time3]}
+    end
+
     test "when a departure is very quick assume that it is actually the real version of the previous departure" do
       {:ok, departures_pid} = Engine.Departures.start_link(gen_server_name: :departures_test)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏳ Change realtime_signs headway mode to use observed for all routes](https://app.asana.com/0/584764604969369/1136801165271463/f)

We forgot to do this in the main PR.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
