### PR TITLE
Actually fix terminals in the departures engine

### DIFF
--- a/lib/engine/departures.ex
+++ b/lib/engine/departures.ex
@@ -85,8 +85,10 @@ defmodule Engine.Departures do
           String.t() => [DateTime.t()]
         }
   defp add_departure(departures, stop_id, time) do
+    translated_stop_id = translate_terminal_stop_id(stop_id)
+
     new_times_for_stop =
-      departures[stop_id]
+      departures[translated_stop_id]
       |> List.wrap()
       |> (fn stop_departures ->
             case stop_departures do
@@ -103,7 +105,7 @@ defmodule Engine.Departures do
           end).()
       |> Enum.take(3)
 
-    Map.put(departures, translate_terminal_stop_id(stop_id), new_times_for_stop)
+    Map.put(departures, translated_stop_id, new_times_for_stop)
   end
 
   @spec headway_sort({non_neg_integer, non_neg_integer}) :: {non_neg_integer, non_neg_integer}

--- a/test/engine/departures_test.exs
+++ b/test/engine/departures_test.exs
@@ -62,7 +62,7 @@ defmodule Engine.DeparturesTest do
           time1
         )
 
-      time2 = Timex.shift(time1, minutes: 1)
+      time2 = Timex.shift(time1, minutes: 3)
 
       :ok =
         Engine.Departures.update_train_state(
@@ -71,7 +71,7 @@ defmodule Engine.DeparturesTest do
           time2
         )
 
-      time3 = Timex.shift(time2, minutes: 1)
+      time3 = Timex.shift(time2, minutes: 3)
 
       :ok =
         Engine.Departures.update_train_state(
@@ -81,6 +81,17 @@ defmodule Engine.DeparturesTest do
         )
 
       assert :sys.get_state(departures_pid).departures == %{"70061" => [time3]}
+
+      time4 = Timex.shift(time3, minutes: 3)
+
+      :ok =
+        Engine.Departures.update_train_state(
+          departures_pid,
+          MapSet.new([]),
+          time4
+        )
+
+      assert :sys.get_state(departures_pid).departures == %{"70061" => [time4, time3]}
     end
 
     test "when a departure is very quick assume that it is actually the real version of the previous departure" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [⏳ Change realtime_signs headway mode to use observed for all routes](https://app.asana.com/0/584764604969369/1136801165271463/f)

The approach in #309 still has issues, this should actually fix it.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
