### PR TITLE
Also announce trains passing through on multi-source signs

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -165,19 +165,19 @@ defmodule Signs.Realtime do
 
   @spec announce_passthrough_trains(Signs.Realtime.t()) :: Signs.Realtime.t()
   defp announce_passthrough_trains(sign) do
-    audio = Utilities.Predictions.get_passthrough_train_audio(sign)
+    sign
+    |> Utilities.Predictions.get_passthrough_train_audio()
+    |> Enum.reduce(sign, fn audio, sign ->
+      if audio.trip_id not in sign.announced_passthroughs do
+        sign.sign_updater.send_audio(sign.audio_id, audio, 5, 60)
 
-    if audio && audio.trip_id not in sign.announced_passthroughs do
-      sign.sign_updater.send_audio(sign.audio_id, audio, 5, 60)
-
-      %__MODULE__{
+        update_in(sign.announced_passthroughs, fn list ->
+          Enum.take([audio.trip_id | list], @announced_history_length)
+        end)
+      else
         sign
-        | announced_passthroughs:
-            Enum.take([audio.trip_id | sign.announced_passthroughs], @announced_history_length)
-      }
-    else
-      sign
-    end
+      end
+    end)
   end
 
   @spec do_expiration(Signs.Realtime.t()) :: Signs.Realtime.t()

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -974,7 +974,7 @@ defmodule Signs.Utilities.PredictionsTest do
   end
 
   describe "get_passthrough_train_audio/1" do
-    test "returns empty list for multi-source sign" do
+    test "returns appropriate audio structs for multi-source sign" do
       s1 = %SourceConfig{
         stop_id: "passthrough_trains",
         headway_direction_name: "Southbound",
@@ -1000,7 +1000,13 @@ defmodule Signs.Utilities.PredictionsTest do
       config = {[s1], [s2]}
       sign = %{@sign | source_config: config}
 
-      assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) == nil
+      assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) == [
+               %Content.Audio.Passthrough{
+                 destination: :braintree,
+                 route_id: "Red",
+                 trip_id: "123"
+               }
+             ]
     end
 
     test "returns appropriate audio structs for single-source sign" do
@@ -1019,11 +1025,13 @@ defmodule Signs.Utilities.PredictionsTest do
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) ==
-               %Content.Audio.Passthrough{
-                 destination: :braintree,
-                 trip_id: "123",
-                 route_id: "Red"
-               }
+               [
+                 %Content.Audio.Passthrough{
+                   destination: :braintree,
+                   trip_id: "123",
+                   route_id: "Red"
+                 }
+               ]
     end
 
     test "handles \"Southbound\" headsign" do
@@ -1042,11 +1050,13 @@ defmodule Signs.Utilities.PredictionsTest do
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) ==
-               %Content.Audio.Passthrough{
-                 destination: :ashmont,
-                 trip_id: "123",
-                 route_id: "Red"
-               }
+               [
+                 %Content.Audio.Passthrough{
+                   destination: :ashmont,
+                   trip_id: "123",
+                   route_id: "Red"
+                 }
+               ]
     end
 
     test "handles case where headsign can't be determined" do
@@ -1066,7 +1076,7 @@ defmodule Signs.Utilities.PredictionsTest do
 
       log =
         capture_log([level: :info], fn ->
-          assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) == nil
+          assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) == []
         end)
 
       assert log =~ "no_passthrough_audio_for_prediction"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Non-rev train did not trigger announcement](https://app.asana.com/0/584764604969369/450671048515734/f)

When I initially wrote this feature to exclude multi-source signs, I forgot about Malden Center. The information may be useful for passengers entering the station on a normal mezzanine anyway.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
