### PR TITLE
Remove functionality to adjust headways during alerts

### DIFF
--- a/test/signs/utilities/headways_test.exs
+++ b/test/signs/utilities/headways_test.exs
@@ -2,11 +2,6 @@ defmodule Signs.Utilities.HeadwaysTest do
   use ExUnit.Case
 
   defmodule FakeAlerts do
-    def max_stop_status(["suspended"], _routes), do: :suspension_closed_station
-    def max_stop_status(["suspended_transfer"], _routes), do: :suspension_transfer_station
-    def max_stop_status(["shuttles"], _routes), do: :shuttles_closed_station
-    def max_stop_status(["closure"], _routes), do: :station_closure
-    def max_stop_status(_stops, ["Green-B"]), do: :alert_along_route
     def max_stop_status(_stops, _routes), do: :none
   end
 
@@ -139,66 +134,6 @@ defmodule Signs.Utilities.HeadwaysTest do
                 {source_with_headway,
                  %Content.Message.Headways.Bottom{
                    range: {2, 8},
-                   prev_departure_mins: 5
-                 }}}
-    end
-
-    test "increases the headways if there are alerts on the route" do
-      source_config = %{source_config_for_stop_id("a") | routes: ["Green-B"]}
-
-      sign = %{
-        @sign
-        | source_config: {[source_config]}
-      }
-
-      current_time = Timex.shift(FakeDepartures.test_departure_time(), minutes: 5)
-
-      assert Signs.Utilities.Headways.get_messages(sign, current_time) ==
-               {{source_config,
-                 %Content.Message.Headways.Top{headsign: "Southbound", vehicle_type: :train}},
-                {source_config,
-                 %Content.Message.Headways.Bottom{
-                   range: {3, 11},
-                   prev_departure_mins: 5
-                 }}}
-    end
-
-    test "increases the headways if there are alerts on the route and it only gets a bottom end of the range" do
-      source_config = %{source_config_for_stop_id("h") | routes: ["Green-B"]}
-
-      sign = %{
-        @sign
-        | source_config: {[source_config]}
-      }
-
-      current_time = Timex.shift(FakeDepartures.test_departure_time(), minutes: 5)
-
-      assert Signs.Utilities.Headways.get_messages(sign, current_time) ==
-               {{source_config,
-                 %Content.Message.Headways.Top{headsign: "Southbound", vehicle_type: :train}},
-                {source_config,
-                 %Content.Message.Headways.Bottom{
-                   range: {3, nil},
-                   prev_departure_mins: 5
-                 }}}
-    end
-
-    test "increases the headways if there are alerts on the route and it only gets a top end of the range" do
-      source_config = %{source_config_for_stop_id("g") | routes: ["Green-B"]}
-
-      sign = %{
-        @sign
-        | source_config: {[source_config]}
-      }
-
-      current_time = Timex.shift(FakeDepartures.test_departure_time(), minutes: 5)
-
-      assert Signs.Utilities.Headways.get_messages(sign, current_time) ==
-               {{source_config,
-                 %Content.Message.Headways.Top{headsign: "Southbound", vehicle_type: :train}},
-                {source_config,
-                 %Content.Message.Headways.Bottom{
-                   range: {nil, 7},
                    prev_departure_mins: 5
                  }}}
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Remove 1.4x padding on headways during disruptions](https://app.asana.com/0/584764604969369/1149450961608201/f)

The padding is no longer relevant as we now use observed headways everywhere except on the SL3.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
