### PR TITLE
feat: Configure application at runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,22 +24,16 @@ use Mix.Config
 config :realtime_signs,
   http_client: HTTPoison,
   posts_log_dir: "log/posts/",
-  sign_head_end_host: System.get_env("SIGN_HEAD_END_HOST") || "172.20.145.28",
-  sign_ui_url: System.get_env("SIGN_UI_URL") || "signs-dev.mbtace.com",
-  sign_ui_api_key: System.get_env("SIGN_UI_API_KEY"),
+  sign_head_end_host: "127.0.0.1",
+  sign_ui_url: "signs-dev.mbtace.com",
+  sign_ui_api_key: nil,
   time_zone: "America/New_York",
   bridge_requester: Bridge.Request,
-  bridge_api_username: System.get_env("BRIDGE_API_USERNAME") || "",
-  bridge_api_password: System.get_env("BRIDGE_API_PASSWORD") || "",
-  trip_update_url:
-    System.get_env("TRIP_UPDATE_URL") ||
-      "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json",
+  bridge_api_username: "",
+  bridge_api_password: "",
+  trip_update_url: "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json",
   vehicle_positions_url:
-    System.get_env("VEHICLE_POSITIONS_URL") ||
-      "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/VehiclePositions_enhanced.json",
-  recent_headways_url:
-    System.get_env("RECENT_HEADWAYS_URL") ||
-      "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/LastHeadways.json",
+    "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/VehiclePositions_enhanced.json",
   sign_updater_mod: PaEss.Logger,
   http_poster_mod: HTTPoison,
   scheduled_headway_requester: Headway.Request,
@@ -47,11 +41,11 @@ config :realtime_signs,
   external_config_getter: ExternalConfig.Local,
   aws_client: ExAws,
   s3_client: ExAws.S3,
-  s3_bucket: System.get_env("SIGNS_S3_BUCKET"),
-  s3_path: System.get_env("SIGNS_S3_PATH"),
-  api_v3_key: System.get_env("API_V3_KEY"),
-  api_v3_url: System.get_env("API_V3_URL") || "https://green.dev.api.mbtace.com",
-  number_of_http_updaters: String.to_integer(System.get_env("NUMBER_OF_HTTP_UPDATERS") || "4")
+  s3_bucket: nil,
+  s3_path: nil,
+  api_v3_key: nil,
+  api_v3_url: "https://green.dev.api.mbtace.com",
+  number_of_http_updaters: 4
 
 config :ex_aws,
   access_key_id: [{:system, "SIGNS_S3_CONFIG_KEY"}, :instance_role],

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -1,9 +1,10 @@
 defmodule RealtimeSigns do
-  @env Mix.env()
-  def env, do: @env
+  alias RealtimeSignsConfig, as: Config
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
+
+    runtime_config()
 
     children =
       [
@@ -24,6 +25,23 @@ defmodule RealtimeSigns do
     opts = [strategy: :one_for_one, name: __MODULE__]
     :ok = :error_logger.add_report_handler(Sentry.Logger)
     Supervisor.start_link(children, opts)
+  end
+
+  @spec runtime_config() :: :ok
+  def runtime_config do
+    env = System.get_env()
+    :ok = Config.update_env(env, :sign_head_end_host, "SIGN_HEAD_END_HOST", :string)
+    :ok = Config.update_env(env, :sign_ui_url, "SIGN_UI_URL", :string)
+    :ok = Config.update_env(env, :sign_ui_api_key, "SIGN_UI_API_KEY", :string)
+    :ok = Config.update_env(env, :bridge_api_username, "BRIDGE_API_USERNAME", :string)
+    :ok = Config.update_env(env, :bridge_api_password, "BRIDGE_API_PASSWORD", :string)
+    :ok = Config.update_env(env, :trip_update_url, "TRIP_UPDATE_URL", :string)
+    :ok = Config.update_env(env, :vehicle_positions_url, "VEHICLE_POSITIONS_URL", :string)
+    :ok = Config.update_env(env, :s3_bucket, "SIGNS_S3_BUCKET", :string)
+    :ok = Config.update_env(env, :s3_path, "SIGNS_S3_PATH", :string)
+    :ok = Config.update_env(env, :api_v3_key, "API_V3_KEY", :string)
+    :ok = Config.update_env(env, :api_v3_url, "API_V3_URL", :string)
+    :ok = Config.update_env(env, :number_of_http_updaters, "NUMBER_OF_HTTP_UPDATERS", :integer)
   end
 
   def http_updater_children do

--- a/lib/realtime_sigs_config.ex
+++ b/lib/realtime_sigs_config.ex
@@ -1,0 +1,20 @@
+defmodule RealtimeSignsConfig do
+  @doc "Helper for setting configuration at runtime"
+  @spec update_env(map(), atom(), String.t(), :string | :integer) :: :ok | no_return()
+  def update_env(env, app_key, env_var, type) do
+    case Map.get(env, env_var) do
+      nil ->
+        :ok
+
+      value ->
+        value =
+          case type do
+            :string -> value
+            :integer -> String.to_integer(value)
+          end
+
+        Application.put_env(:realtime_signs, app_key, value)
+        :ok
+    end
+  end
+end

--- a/test/engine/bridge_test.exs
+++ b/test/engine/bridge_test.exs
@@ -1,6 +1,5 @@
 defmodule Engine.BridgeTest do
   use ExUnit.Case
-  import ExUnit.CaptureLog
 
   describe "status/2" do
     test "gives the status for the bridge id provided" do

--- a/test/engine/predictions_test.exs
+++ b/test/engine/predictions_test.exs
@@ -134,7 +134,7 @@ defmodule Engine.PredictionsTest do
         "vehicle_positions_out_of_service_2"
       )
 
-      {:noreply, state} = handle_info(:update, state)
+      {:noreply, _} = handle_info(:update, state)
 
       state = :sys.get_state(Engine.Departures)
       assert state.departures == %{}

--- a/test/realtime_signs_config_test.exs
+++ b/test/realtime_signs_config_test.exs
@@ -1,0 +1,26 @@
+defmodule RealtimeSignsConfigTest do
+  use ExUnit.Case, async: false
+
+  import RealtimeSignsConfig
+
+  setup do
+    on_exit(fn -> Application.delete_env(:realtime_signs, :app_key) end)
+  end
+
+  describe "update_env/5" do
+    test "sets the application environment" do
+      assert :ok = update_env(%{"ENV_VAR" => "foo"}, :app_key, "ENV_VAR", :string)
+      assert Application.get_env(:realtime_signs, :app_key) == "foo"
+    end
+
+    test "still returns :ok if missing, and doesn't update app environment" do
+      assert :ok = update_env(%{}, :app_key, "ENV_VAR", :string)
+      assert Application.get_env(:realtime_signs, :app_key) == nil
+    end
+
+    test "converts an integer before storing in application environment" do
+      assert :ok = update_env(%{"ENV_VAR" => "5"}, :app_key, "ENV_VAR", :integer)
+      assert Application.get_env(:realtime_signs, :app_key) == 5
+    end
+  end
+end

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -569,7 +569,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :headway
       alert_status = :station_closure
 
-      assert {{_, %Content.Message.Alert.NoService{mode: mode}}, {_, %Content.Message.Empty{}}} =
+      assert {{_, %Content.Message.Alert.NoService{mode: _mode}}, {_, %Content.Message.Empty{}}} =
                Messages.get_messages(sign, sign_config, Timex.now(), alert_status, :train, nil)
     end
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** part of [🏙 Run realtime-signs as a release](https://app.asana.com/0/584764604969369/1152613107841233).

Since we want to compile in advance and then run the release later, we need to move all the configuration that we currently have at compile time to run time.

This PR removes the `System.get_env/1` calls from `config.exs` and adds some logic to the `RealtimeSigns.start/2` callback that gets called when the application is starting up. This is when/how we do the same configuration in our other apps, like RTR.

I also snuck in a couple small fixes that the test suite raised as warnings.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
