### PR TITLE
fix: variable not picked up on Windows

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -2,13 +2,11 @@
 
 # Run this from the repo root directory (e.g. /c/Users/RTRUser/GitHub/realtime_signs_release_dev)
 
-MIX_ENV=prod
 ERL_DIR="erl10.5"
 ELIXIR_DIR="elixir1.9.4"
-PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH"
 
 rm -r _build/
-mix deps.get
-mix release
+env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix deps.get
+env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix release
 
 echo "Release is built. Restart the Windows service to run it."


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

During PR review on my last ticket I pulled out the `env PATH=... MIX_ENV=prod ...` stuff to variables. However, while that works locally on my Mac, when I ran the script on Windows it didn't seem to pick up the `MIX_ENV=prod` for some reason, and built the release with the dev environment, for some reason....

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
