### PR TITLE
feat: change logging of unknown process messages from warn to info

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -58,7 +58,7 @@ defmodule Engine.Config do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("#{__MODULE__} unknown message: #{inspect(msg)}")
+    Logger.info("#{__MODULE__} unknown message: #{inspect(msg)}")
     {:noreply, state}
   end
 

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -84,7 +84,7 @@ defmodule Engine.Predictions do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("#{__MODULE__} unknown message: #{inspect(msg)}")
+    Logger.info("#{__MODULE__} unknown message: #{inspect(msg)}")
     {:noreply, state}
   end
 

--- a/test/engine/predictions_test.exs
+++ b/test/engine/predictions_test.exs
@@ -148,7 +148,7 @@ defmodule Engine.PredictionsTest do
       }
 
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :info], fn ->
           {:noreply, ^existing_state} = handle_info(:unrecognized, existing_state)
         end)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Related to [🏙 Run realtime-signs as a release](https://app.asana.com/0/584764604969369/1152613107841233/f)

So that we don't get spammed with `warn`s for this `:ssl_closed` message that some of our genservers receive.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
