### PR TITLE
feat: Different node names in release

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
 # Run this from the repo root directory (e.g. /c/Users/RTRUser/GitHub/realtime_signs_release_dev)
+# Takes the release node name as an argument (e.g. `$ ./build_release.sh realtime_signs_dev`)
+
+if [ $# -eq 0 ]; then
+  echo "No argument provided"
+  exit 1
+fi
 
 ERL_DIR="erl10.5"
 ELIXIR_DIR="elixir1.9.4"
 
-rm -r _build/
+rm -rf _build/
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix deps.get
-env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix release
+env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" RELEASE_NODE=$1 mix release
 
 echo "Release is built. Restart the Windows service to run it."

--- a/rel/env.bat.eex
+++ b/rel/env.bat.eex
@@ -1,0 +1,6 @@
+@echo off
+rem Set the release to work across nodes. If using the long name format like
+rem the one below (my_app@127.0.0.1), you need to also uncomment the
+rem RELEASE_DISTRIBUTION variable below.
+rem set RELEASE_DISTRIBUTION=name
+set RELEASE_NODE=<%= System.get_env("RELEASE_NODE") || raise "No RELEASE_NODE env var" %>@OPSTECH3

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Sets and enables heart (recommended only in daemon mode)
+# case $RELEASE_COMMAND in
+#   daemon*)
+#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+#     export HEART_COMMAND
+#     export ELIXIR_ERL_OPTIONS="-heart"
+#     ;;
+#   *)
+#     ;;
+# esac
+
+# Set the release to work across nodes. If using the long name format like
+# the one below (my_app@127.0.0.1), you need to also uncomment the
+# RELEASE_DISTRIBUTION variable below.
+# export RELEASE_DISTRIBUTION=name
+export RELEASE_NODE=<%= System.get_env("RELEASE_NODE") || raise "No RELEASE_NODE env var" %>@OPSTECH3

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, etc)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Related to [🏙 Run realtime-signs as a release](https://app.asana.com/0/584764604969369/1152613107841233).

We had an issue running both dev and prod on the same host since by default they ended up with the same Erlang node name. It looks like that's customized [via a couple files](https://hexdocs.pm/mix/Mix.Tasks.Release.html#module-vm-args-and-env-sh-env-bat) you can generate with `mix release.init`.

The ENV var needs to be provided at release build time, so I updated the script to take it as an argument. (So we'll have to do, e.g., `./build_release.sh realtime_signs_dev`) now.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
