### PR TITLE
Log environment variables on start up

### DIFF
--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -32,14 +32,14 @@ defmodule RealtimeSigns do
     env = System.get_env()
     :ok = Config.update_env(env, :sign_head_end_host, "SIGN_HEAD_END_HOST")
     :ok = Config.update_env(env, :sign_ui_url, "SIGN_UI_URL")
-    :ok = Config.update_env(env, :sign_ui_api_key, "SIGN_UI_API_KEY")
+    :ok = Config.update_env(env, :sign_ui_api_key, "SIGN_UI_API_KEY", private?: true)
     :ok = Config.update_env(env, :bridge_api_username, "BRIDGE_API_USERNAME")
-    :ok = Config.update_env(env, :bridge_api_password, "BRIDGE_API_PASSWORD")
+    :ok = Config.update_env(env, :bridge_api_password, "BRIDGE_API_PASSWORD", private?: true)
     :ok = Config.update_env(env, :trip_update_url, "TRIP_UPDATE_URL")
     :ok = Config.update_env(env, :vehicle_positions_url, "VEHICLE_POSITIONS_URL")
     :ok = Config.update_env(env, :s3_bucket, "SIGNS_S3_BUCKET")
     :ok = Config.update_env(env, :s3_path, "SIGNS_S3_PATH")
-    :ok = Config.update_env(env, :api_v3_key, "API_V3_KEY")
+    :ok = Config.update_env(env, :api_v3_key, "API_V3_KEY", private?: true)
     :ok = Config.update_env(env, :api_v3_url, "API_V3_URL")
 
     :ok =

--- a/lib/realtime_sigs_config.ex
+++ b/lib/realtime_sigs_config.ex
@@ -1,8 +1,11 @@
 defmodule RealtimeSignsConfig do
+  require Logger
+
   @doc "Helper for setting configuration at runtime"
   @spec update_env(map(), atom(), String.t(), Keyword.t()) :: :ok | no_return()
   def update_env(env, app_key, env_var, opts \\ []) do
     type = Keyword.get(opts, :type, :string)
+    private? = Keyword.get(opts, :private?, false)
 
     case Map.get(env, env_var) do
       nil ->
@@ -14,6 +17,10 @@ defmodule RealtimeSignsConfig do
             :string -> value
             :integer -> String.to_integer(value)
           end
+
+        unless private? do
+          Logger.info("environment_variable #{env_var}=#{inspect(value)}")
+        end
 
         Application.put_env(:realtime_signs, app_key, value)
         :ok

--- a/test/realtime_signs_config_test.exs
+++ b/test/realtime_signs_config_test.exs
@@ -1,5 +1,6 @@
 defmodule RealtimeSignsConfigTest do
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
 
   import RealtimeSignsConfig
 
@@ -21,6 +22,20 @@ defmodule RealtimeSignsConfigTest do
     test "converts an integer before storing in application environment" do
       assert :ok = update_env(%{"ENV_VAR" => "5"}, :app_key, "ENV_VAR", type: :integer)
       assert Application.get_env(:realtime_signs, :app_key) == 5
+    end
+
+    test "logs the environment variable unless it's private" do
+      env = %{"ENV1" => "env1", "ENV2" => "env2"}
+
+      log =
+        capture_log(fn ->
+          :ok = update_env(env, :app_key, "ENV1")
+          :ok = update_env(env, :app_key, "ENV2", private?: true)
+          :ok = Process.sleep(50)
+        end)
+
+      assert log =~ ~s(ENV1="env1")
+      refute log =~ "ENV2"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Log ENV vars on realtime-signs start up](https://app.asana.com/0/584764604969369/1155303864117113)

After the power outage last week we wanted to know which ARINC head end server we were posting to. That, as well as some other environment variables, would be useful to know. This updates the app to log them on start up.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
