### PR TITLE
chore: clean up Kenmore sign config

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -4924,21 +4924,11 @@
     "type": "realtime",
     "source_config": [
       [
-        {
-          "stop_id": "70150",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-B"],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
 	{
           "stop_id": "71150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B"],
+          "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4956,21 +4946,11 @@
     "type": "realtime",
     "source_config": [
       [
-        {
-          "stop_id": "70151",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": ["Green-B"],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
 	{
           "stop_id": "71151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B"],
+          "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4992,7 +4972,7 @@
           "stop_id": "70150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-C", "Green-D"],
+          "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5014,7 +4994,7 @@
           "stop_id": "70151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-C", "Green-D"],
+          "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 [extra] Remove route filtering from Kenmore signs](https://app.asana.com/0/584764604969369/1110868830335872/f)

I'm not actually sure that having each of the four signs reference all three Green Line branches that pass through, but cleaning it up so that each sign only references on stop ID is definitely good.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
