### PR TITLE
build: Handle different versions of releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,20 @@ To manage the Windows service we use [`nssm`](https://nssm.cc/). The service is 
 
 To deploy a new version of the code:
 
+1. Ensure a new version of the app has been merged (`@version` in mix.exs)
 1. In Git Bash, navigate to `/c/Users/RTRUser/GitHub/realtime_signs_release_[dev|prod]`
 1. `git pull` the latest version
+1. Tag the release in git: `git tag -a yyyy-mm-dd -m "Deploying on [date] at [time]"`
+1. Push the tag to GitHub: `git push origin yyyy-mm-dd`
 1. Run `./build_release.sh realtime_signs_[dev|prod]` to compile a new release. The second argument gives the name of the Erlang node to run the relase under and isn't terribly important as long as it's distinct for dev versus prod.
 1. Open the Windows `Services` application and restart `realtime-signs-[staging/prod]`
+
+## Rolling back
+
+To quickly roll back to a previous version:
+
+* See the available versions with `ls _build/prod/rel/realtime_signs/releases`
+* Identify the version in that list to roll back to
+* `nssm edit realtime-signs-[dev|prod]`
+* Set the environment variable `RELEASE_VSN=[...]` to that version string
+* Restart the service

--- a/build_release.sh
+++ b/build_release.sh
@@ -12,7 +12,6 @@ fi
 ERL_DIR="erl10.5"
 ELIXIR_DIR="elixir1.9.4"
 
-rm -rf _build/
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix deps.get
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" RELEASE_NODE=$1 mix release
 

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -1,8 +1,13 @@
 defmodule RealtimeSigns do
+  require Logger
   alias RealtimeSignsConfig, as: Config
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
+
+    Logger.info(
+      "Starting realtime_signs version #{inspect(Application.spec(:realtime_signs, :vsn))}"
+    )
 
     runtime_config()
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,12 @@
 defmodule RealtimeSigns.Mixfile do
   use Mix.Project
 
+  @version "1.0.0-2020-01-02"
+
   def project do
     [
       app: :realtime_signs,
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Tag realtime-signs releases with versions for easier rollback](https://app.asana.com/0/584764604969369/1155524779531825)

This implements what we chatted about [in Slack](https://mbtace.slack.com/archives/CF9QKK2AF/p1577981278215800).

We'll now have to issue a quick PR to update the `@version` prior to a deploy, but it then lets us easily deploy different release versions as necessary.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
