### PR TITLE
feat: only log :warn to console on prod

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -4,7 +4,7 @@ config :sentry,
   dsn: System.get_env("SENTRY_DSN") || "",
   environment_name: :prod,
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!,
+  root_source_code_path: File.cwd!(),
   tags: %{
     env: "production"
   },
@@ -12,6 +12,8 @@ config :sentry,
 
 config :logger,
   backends: [{Logger.Backend.Splunk, :splunk}, :console]
+
+config :logger, :console, level: :warn
 
 config :logger, :splunk,
   connector: Logger.Backend.Splunk.Output.Http,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 Don't save logs to disk on opstech3](https://app.asana.com/0/584764604969369/1149450961608203/f)

After discussion, this sounds better than doing _no_ logging at all on `opstech3`. I've got this running on dev right now and it seems to be working (not logging additional `info` messages to disk, but they are being logged to Splunk).

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
