### PR TITLE
build: Update build script to store previous release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
 
+# The directory we move the previously built release to as backup
+/_build-prev/
+
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,17 @@ To manage the Windows service we use [`nssm`](https://nssm.cc/). The service is 
 
 To deploy a new version of the code:
 
-1. Ensure a new version of the app has been merged (`@version` in mix.exs)
 1. In Git Bash, navigate to `/c/Users/RTRUser/GitHub/realtime_signs_release_[dev|prod]`
 1. `git pull` the latest version
-1. Tag the release in git: `git tag -a yyyy-mm-dd -m "Deploying on [date] at [time]"`
-1. Push the tag to GitHub: `git push origin yyyy-mm-dd`
 1. Run `./build_release.sh realtime_signs_[dev|prod]` to compile a new release. The second argument gives the name of the Erlang node to run the relase under and isn't terribly important as long as it's distinct for dev versus prod.
 1. Open the Windows `Services` application and restart `realtime-signs-[staging/prod]`
+1. Tag the release in git: `git tag -a yyyy-mm-dd -m "Deployed on [date] at [time]"`
+1. Push the tag to GitHub: `git push origin yyyy-mm-dd`
 
 ## Rolling back
 
 To quickly roll back to a previous version:
 
-* See the available versions with `ls _build/prod/rel/realtime_signs/releases`
-* Identify the version in that list to roll back to
-* `nssm edit realtime-signs-[dev|prod]`
-* Set the environment variable `RELEASE_VSN=[...]` to that version string
+* Move the broken release: `mv _build _build-broken`
+* Restore the previous release: `mv _build-prev _build`
 * Restart the service

--- a/build_release.sh
+++ b/build_release.sh
@@ -12,6 +12,9 @@ fi
 ERL_DIR="erl10.5"
 ELIXIR_DIR="elixir1.9.4"
 
+rm -rf _build-prev
+test -e "_build" && mv _build _build-prev
+
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix deps.get
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" RELEASE_NODE=$1 mix release
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule RealtimeSigns.Mixfile do
   use Mix.Project
 
-  @version "1.1.0-2020-01-06"
+  @version "1.0.0"
 
   def project do
     [


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Update realtime_signs release process to use `mv` approach.](https://app.asana.com/0/584764604969369/1156181911303115)

Since we couldn't build multiple versions of a release on Windows, this updates the process to simply copy the last version to a backup directory.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
