### PR TITLE
fix: try using :queue.split rather than :queue.drop

### DIFF
--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -19,7 +19,7 @@ defmodule MessageQueue do
         }
 
   @max_size 300
-  @too_full_drop 15
+  @too_full_drop 30
 
   use GenServer
   require Logger

--- a/test/message_queue_test.exs
+++ b/test/message_queue_test.exs
@@ -21,8 +21,8 @@ defmodule MessageQueueTest do
       {:reply, {:ok, :sent}, state} =
         MessageQueue.handle_call({:queue_update, msg}, self(), state)
 
-      assert {{:value, 16}, _queue} = :queue.out(state.queue)
-      assert state.length == 286
+      assert {{:value, 31}, _queue} = :queue.out(state.queue)
+      assert state.length == 271
     end
 
     test "logs if message size is multiple of 30" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** No ticket oh God everything is on fire

See if this reduces the incidence of crash loops when we drop from the queue.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
