### PR TITLE
fix: During disruption, use '10 to 12 min' for headways

### DIFF
--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -44,10 +44,16 @@ defmodule Signs.Utilities.Headways do
         ) == :lt
 
     stop_id = sign.headway_stop_id || config.stop_id
-    headway_range = sign.headway_engine.get_headways(stop_id)
 
     all_gl_changed_signs =
       Enum.concat(@haymarket_destination_sign_ids, @lechmere_destination_sign_ids)
+
+    headway_range =
+      if during_gl_gov_ctr_disruption? and sign.id in all_gl_changed_signs do
+        {10, 12}
+      else
+        sign.headway_engine.get_headways(stop_id)
+      end
 
     last_departure =
       if during_gl_gov_ctr_disruption? and sign.id in all_gl_changed_signs do

--- a/test/signs/utilities/headways_test.exs
+++ b/test/signs/utilities/headways_test.exs
@@ -241,7 +241,7 @@ defmodule Signs.Utilities.HeadwaysTest do
                {{source_config_for_stop_id("a"),
                  %Content.Message.Headways.Top{destination: :haymarket, vehicle_type: :train}},
                 {source_config_for_stop_id("a"),
-                 %Content.Message.Headways.Bottom{range: {2, 8}, prev_departure_mins: nil}}}
+                 %Content.Message.Headways.Bottom{range: {10, 12}, prev_departure_mins: nil}}}
     end
 
     test "generates correct messages for Science Park eastbound during disruption" do
@@ -257,7 +257,7 @@ defmodule Signs.Utilities.HeadwaysTest do
                {{source_config_for_stop_id("a"),
                  %Content.Message.Headways.Top{destination: :lechmere, vehicle_type: :train}},
                 {source_config_for_stop_id("a"),
-                 %Content.Message.Headways.Bottom{range: {2, 8}, prev_departure_mins: nil}}}
+                 %Content.Message.Headways.Bottom{range: {10, 12}, prev_departure_mins: nil}}}
     end
 
     test "doesn't change Science Park westbound outside of disruption timeframe" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Hardcode GL weekend diversion headways to 10-12 min](https://app.asana.com/0/584764604969369/1163954974289696)

[Please include a brief description of what was changed]

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
