### PR TITLE
feat: Send abbreviation replacements for custom audio

### DIFF
--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -55,6 +55,10 @@ defmodule Fake.HTTPoison do
 
       body =~ "MsgType=AdHoc&uid=1006&msg=Custom+Message&typ=1&sta=MCAP001000&pri=5&tim=60" ->
         {:ok, %HTTPoison.Response{status_code: 200}}
+
+      body =~
+          "MsgType=AdHoc&uid=1006&msg=Custom+Orange+Line+Message&typ=1&sta=MCAP001000&pri=5&tim=60" ->
+        {:ok, %HTTPoison.Response{status_code: 200}}
     end
   end
 

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -162,7 +162,7 @@ defmodule PaEss.HttpUpdater do
           [
             MsgType: "AdHoc",
             uid: state.uid,
-            msg: text,
+            msg: PaEss.Utilities.replace_abbreviations(text),
             typ: audio_type(type),
             sta: "#{station}#{zone_bitmap(zones)}",
             pri: priority,

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -7,6 +7,17 @@ defmodule PaEss.Utilities do
 
   @space "21000"
 
+  @abbreviation_replacements [
+    {~r"\bOL\b", "Orange Line"},
+    {~r"\bBL\b", "Blue Line"},
+    {~r"\bRL\b", "Red Line"},
+    {~r"\bGL\b", "Green Line"},
+    {~r"\bNB\b", "Northbound"},
+    {~r"\bSB\b", "Southbound"},
+    {~r"\bEB\b", "Eastbound"},
+    {~r"\bWB\b", "Westbound"}
+  ]
+
   @spec valid_range?(integer(), Content.Audio.language()) :: boolean()
   def valid_range?(n, :english) do
     n > 0 and n < 60
@@ -250,4 +261,15 @@ defmodule PaEss.Utilities do
   def green_line_branch_var(:c), do: "537"
   def green_line_branch_var(:d), do: "538"
   def green_line_branch_var(:e), do: "539"
+
+  @spec replace_abbreviations(String.t()) :: String.t()
+  def replace_abbreviations(text) when is_binary(text) do
+    Enum.reduce(
+      @abbreviation_replacements,
+      text,
+      fn {abbr, replacement}, text ->
+        String.replace(text, abbr, replacement)
+      end
+    )
+  end
 end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -226,6 +226,26 @@ defmodule PaEss.HttpUpdaterTest do
       assert log =~ "send_custom_audio"
     end
 
+    test "sends custom audio messages with replacements" do
+      state = make_state(%{uid: 1006})
+
+      audio = %Content.Audio.Custom{
+        message: "Custom OL Message"
+      }
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :sent} =
+                   PaEss.HttpUpdater.process(
+                     {:send_audio, [{"MCAP", ["n"]}, audio, 5, 60]},
+                     state
+                   )
+        end)
+
+      assert log =~ "send_custom_audio"
+      assert log =~ "Custom+Orange+Line+Message"
+    end
+
     test "can send two audio messages" do
       state = make_state(%{http_poster: FakePoster})
 

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -133,4 +133,18 @@ defmodule Content.Audio.UtilitiesTest do
       end)
     end
   end
+
+  describe "replace_abbreviations/1" do
+    test "replaces multiple times, including binary start and end" do
+      assert replace_abbreviations("RL and RL and OL") == "Red Line and Red Line and Orange Line"
+    end
+
+    test "does not replace when touching other letters" do
+      assert replace_abbreviations("BLAM!") == "BLAM!"
+    end
+
+    test "replaces when next to punctuation" do
+      assert replace_abbreviations("OL, OK") == "Orange Line, OK"
+    end
+  end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 Station PAs better-announces line abbreviations](https://app.asana.com/0/584764604969369/1161493680682475)

The ticket said to look into what has been placed on signs via the logs. Based on [that](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dsigns-ui-prod%20%22sign_changed%3A%22%20%22static_text%22%20%7C%20rex%20%22%5C%22line1%5C%22%20%3D%3E%20%5C%22(%3F%3Cline1%3E.*%3F)%5C%22%2C%22%20%7C%20rex%20%22%5C%22line2%5C%22%20%3D%3E%20%5C%22(%3F%3Cline2%3E.*%3F)%5C%22%2C%22%20%7C%20eval%20lines%20%3D%20line1%20.%20%22%20%7C%20%22%20.%20line2%20%7C%20dedup%20lines%20%7C%20table%20lines&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-90d%40d&latest=now&display.page.search.tab=statistics&display.general.type=statistics&sid=1583513196.3588831), I went with OL, BL, RL, GL, and NB, SB, WB, EB.

I've tested this on realtime-signs-dev, putting an abbreviation on signs-ui-dev, and verifying the AdHoc message we sent to ARINC had the expanded text.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
