### PR TITLE
feat: Prepare for new sign config format

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -42,6 +42,11 @@ defmodule Engine.Config do
     latest_version =
       case updater.get(state.current_version) do
         {version, config} ->
+          # To handle two formats of signs config:
+          # old: %{ "sign_id" => %{ sign config}, "sign_id2" => ...}
+          # new: %{ "signs" => %{ "sign_id" => %{ sign_config }, ...}}
+          config = Map.get(config, "signs", config)
+
           config =
             Enum.map(config, fn {sign_id, config_json} ->
               {sign_id, transform_sign_config(state, config_json)}

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -6,6 +6,17 @@ defmodule Fake.ExternalConfig.Local do
     :unchanged
   end
 
+  def get("new_format") do
+    {
+      nil,
+      %{
+        "signs" => %{
+          "some_custom_sign" => %{"line1" => "custom", "line2" => "", "expires" => nil}
+        }
+      }
+    }
+  end
+
   def get(_current_version) do
     {nil,
      %{

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -63,6 +63,21 @@ defmodule Engine.ConfigTest do
       assert state[:current_version] == "unchanged"
     end
 
+    test "handles new format of config" do
+      :ets.new(:test_new_format, [:set, :protected, :named_table, read_concurrency: true])
+
+      {:noreply, state} =
+        Engine.Config.handle_info(:update, %{
+          ets_table_name: :test_new_format,
+          current_version: "new_format",
+          time_fetcher: &DateTime.utc_now/0
+        })
+
+      assert :ets.lookup(:test_new_format, "some_custom_sign") == [
+               {"some_custom_sign", {:static_text, {"custom", ""}}}
+             ]
+    end
+
     test "correctly loads config for a sigh with a mode of \"off\"" do
       _state = initialize_test_state(:config_test_off, fn -> DateTime.utc_now() end)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [make rt-signs and sign-ui compatible with S3 configuration](https://app.asana.com/0/584764604969369/1166302267970957)

Updates realtime-signs to handle a new signs config from S3 (the thing that sets custom text, headway mode, etc).

Formerly, the structure was:

```json
{
  "sign_id1": { ... },
  "sign_id2": { ... }
}
```

The new structure is:

```json
{
  "signs": {
    "sign_id1": { ... },
    "sign_id2": { ... }
  }
}
```

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
