### PR TITLE
feat: alerts take precedence over multi-sign headways

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -26,7 +26,10 @@ defmodule Signs.Utilities.Messages do
       ) do
     cond do
       headway_config ->
-        Signs.Utilities.Headways.get_configured_messages(sign, headway_config)
+        case get_alert_messages(alert_status, mode) do
+          nil -> Signs.Utilities.Headways.get_configured_messages(sign, headway_config)
+          messages -> messages
+        end
 
       match?({:static_text, {_, _}}, sign_config) ->
         {:static_text, {line1, line2}} = sign_config

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -114,7 +114,7 @@ defmodule Signs.Utilities.MessagesTest do
     test "when custom text is present, display it, overriding alerts or disabled status" do
       sign = @sign
       sign_config = {:static_text, {"Test message", "Please ignore"}}
-      alert_status = :suspension
+      alert_status = :suspension_closed_station
 
       assert Messages.get_messages(sign, sign_config, nil, Timex.now(), alert_status, :train, nil) ==
                {{nil, Content.Message.Custom.new("Test message", :top)},
@@ -341,7 +341,7 @@ defmodule Signs.Utilities.MessagesTest do
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
 
-      alert_status = :suspension
+      alert_status = :suspension_closed_station
       sign_config = :auto
 
       assert Messages.get_messages(sign, sign_config, nil, Timex.now(), alert_status, :train, nil) ==
@@ -618,6 +618,31 @@ defmodule Signs.Utilities.MessagesTest do
 
       assert {{_, %Content.Message.Headways.Top{destination: :alewife}},
               {_, %Content.Message.Headways.Bottom{prev_departure_mins: nil, range: {13, 17}}}} =
+               Messages.get_messages(
+                 sign,
+                 sign_config,
+                 headway_config,
+                 Timex.now(),
+                 alert_status,
+                 :train,
+                 nil
+               )
+    end
+
+    test "when a specified headway is configured but an alert is present, shows the alert" do
+      src = %{@src | headway_destination: :alewife}
+      sign = %{@sign | source_config: {[src]}}
+      sign_config = :auto
+
+      headway_config = %Engine.Config.Headway{
+        group_id: "headway_group",
+        range_low: 13,
+        range_high: 17
+      }
+
+      alert_status = :suspension_closed_station
+
+      assert {{_, %Content.Message.Alert.NoService{mode: :train}}, {_, %Content.Message.Empty{}}} =
                Messages.get_messages(
                  sign,
                  sign_config,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Alerts take precedence on signs over multi-sign headways](https://app.asana.com/0/584764604969369/1167115799736569/f)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
