### PR TITLE
fix: don't filter uncertain predictions on light rail

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -75,14 +75,16 @@ defmodule Predictions.Predictions do
     current_time_seconds = DateTime.to_unix(current_time)
 
     seconds_until_arrival =
-      if stop_time_update["arrival"] && sufficient_certainty?(stop_time_update["arrival"]),
-        do: stop_time_update["arrival"]["time"] - current_time_seconds,
-        else: nil
+      if stop_time_update["arrival"] &&
+           sufficient_certainty?(stop_time_update["arrival"], route_id),
+         do: stop_time_update["arrival"]["time"] - current_time_seconds,
+         else: nil
 
     seconds_until_departure =
-      if stop_time_update["departure"] && sufficient_certainty?(stop_time_update["departure"]),
-        do: stop_time_update["departure"]["time"] - current_time_seconds,
-        else: nil
+      if stop_time_update["departure"] &&
+           sufficient_certainty?(stop_time_update["departure"], route_id),
+         do: stop_time_update["departure"]["time"] - current_time_seconds,
+         else: nil
 
     seconds_until_passthrough =
       if stop_time_update["passthrough_time"],
@@ -140,8 +142,13 @@ defmodule Predictions.Predictions do
     :scheduled
   end
 
-  @spec sufficient_certainty?(map()) :: boolean()
-  defp sufficient_certainty?(stop_time_event) do
+  @spec sufficient_certainty?(map(), String.t()) :: boolean()
+  defp sufficient_certainty?(_stop_time_event, route_id)
+       when route_id in ["Mattapan", "Green-B", "Green-C", "Green-D", "Green-E"] do
+    true
+  end
+
+  defp sufficient_certainty?(stop_time_event, _route_id) do
     if Application.get_env(:realtime_signs, :filter_uncertain_predictions?) do
       is_nil(stop_time_event["uncertainty"]) or stop_time_event["uncertainty"] <= 300
     else

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -571,7 +571,7 @@ defmodule Predictions.PredictionsTest do
                     "uncertainty" => 60
                   },
                   "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70263",
+                  "stop_id" => "70063",
                   "stop_sequence" => 1,
                   "stops_away" => 1,
                   "stopped?" => true,
@@ -581,15 +581,15 @@ defmodule Predictions.PredictionsTest do
               "timestamp" => nil,
               "trip" => %{
                 "direction_id" => 0,
-                "route_id" => "Mattapan",
+                "route_id" => "Red",
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
                 "trip_id" => "32568935"
               },
               "vehicle" => %{
-                "id" => "G-10040",
-                "label" => "3260",
+                "id" => "R-54639F6C",
+                "label" => "1631",
                 "license_plate" => nil
               }
             },
@@ -604,7 +604,7 @@ defmodule Predictions.PredictionsTest do
       }
 
       assert {%{
-                {"70263", 0} => [
+                {"70063", 0} => [
                   %Predictions.Prediction{
                     seconds_until_departure: 120
                   }
@@ -636,7 +636,7 @@ defmodule Predictions.PredictionsTest do
                     "uncertainty" => 360
                   },
                   "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70263",
+                  "stop_id" => "70063",
                   "stop_sequence" => 1,
                   "stops_away" => 1,
                   "stopped?" => true,
@@ -646,15 +646,15 @@ defmodule Predictions.PredictionsTest do
               "timestamp" => nil,
               "trip" => %{
                 "direction_id" => 0,
-                "route_id" => "Mattapan",
+                "route_id" => "Red",
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
                 "trip_id" => "32568935"
               },
               "vehicle" => %{
-                "id" => "G-10040",
-                "label" => "3260",
+                "id" => "R-54639F6C",
+                "label" => "1631",
                 "license_plate" => nil
               }
             },
@@ -675,6 +675,72 @@ defmodule Predictions.PredictionsTest do
 
     test "doesn't filter predictions with high uncertainty when feature is off" do
       reassign_env(:filter_uncertain_predictions?, false)
+
+      feed_message = %{
+        "entity" => [
+          %{
+            "alert" => nil,
+            "id" => "1490783458_32568935",
+            "is_deleted" => false,
+            "trip_update" => %{
+              "delay" => nil,
+              "stop_time_update" => [
+                %{
+                  "arrival" => %{
+                    "delay" => nil,
+                    "time" => 1_491_570_110,
+                    "uncertainty" => 360
+                  },
+                  "departure" => %{
+                    "delay" => nil,
+                    "time" => 1_491_570_120,
+                    "uncertainty" => 360
+                  },
+                  "schedule_relationship" => "SCHEDULED",
+                  "stop_id" => "70063",
+                  "stop_sequence" => 1,
+                  "stops_away" => 1,
+                  "stopped?" => true,
+                  "boarding_status" => "Stopped 1 stop away"
+                }
+              ],
+              "timestamp" => nil,
+              "trip" => %{
+                "direction_id" => 0,
+                "route_id" => "Red",
+                "schedule_relationship" => "SCHEDULED",
+                "start_date" => "20170329",
+                "start_time" => nil,
+                "trip_id" => "32568935"
+              },
+              "vehicle" => %{
+                "id" => "R-54639F6C",
+                "label" => "1631",
+                "license_plate" => nil
+              }
+            },
+            "vehicle" => nil
+          }
+        ],
+        "header" => %{
+          "gtfs_realtime_version" => "1.0",
+          "incrementality" => "FULL_DATASET",
+          "timestamp" => 1_490_783_458
+        }
+      }
+
+      assert {%{
+                {"70063", 0} => [
+                  %Predictions.Prediction{
+                    seconds_until_arrival: 110,
+                    seconds_until_departure: 120
+                  }
+                ]
+              }, _} = get_all(feed_message, @current_time)
+    end
+
+    test "doesn't filter out uncertain light rail predictions" do
+      reassign_env(:filter_uncertain_predictions?, true)
 
       feed_message = %{
         "entity" => [


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Followup on [rt-signs throws out uncertain predictions](https://app.asana.com/0/584764604969369/1167184327376436/f)

Note that for now I'm just undoing the filtering entirely for light rail - there's no distinction being made between reverse predictions and predictions where the train is at the terminal waiting to depart.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
