### PR TITLE
feat: don't post to Signs UI if ARINC post fails

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -65,19 +65,33 @@ defmodule PaEss.HttpUpdater do
     cmd = to_command(msg, duration, start_secs, zone, line_no)
     encoded = URI.encode_query(MsgType: "SignContent", uid: state.uid, sta: station, c: cmd)
 
-    {ui_time, _} = :timer.tc(fn -> update_ui(state.http_poster, encoded) end)
     {arinc_time, result} = :timer.tc(fn -> send_post(state.http_poster, encoded) end)
 
-    Logger.info([
-      "update_single_line: ",
-      encoded,
-      " pid=",
-      inspect(self()),
-      " arinc_ms=",
-      inspect(div(arinc_time, 1000)),
-      " signs_ui_ms=",
-      inspect(div(ui_time, 1000))
-    ])
+    case result do
+      {:ok, _} ->
+        {ui_time, _} = :timer.tc(fn -> update_ui(state.http_poster, encoded) end)
+
+        Logger.info([
+          "update_single_line: ",
+          encoded,
+          " pid=",
+          inspect(self()),
+          " arinc_ms=",
+          inspect(div(arinc_time, 1000)),
+          " signs_ui_ms=",
+          inspect(div(ui_time, 1000))
+        ])
+
+      {:error, _} ->
+        Logger.info([
+          "update_single_line: ",
+          encoded,
+          " pid=",
+          inspect(self()),
+          " arinc_ms=",
+          inspect(div(arinc_time, 1000))
+        ])
+    end
 
     result
   end
@@ -98,19 +112,33 @@ defmodule PaEss.HttpUpdater do
         c: bottom_cmd
       )
 
-    {ui_time, _} = :timer.tc(fn -> update_ui(state.http_poster, encoded) end)
     {arinc_time, result} = :timer.tc(fn -> send_post(state.http_poster, encoded) end)
 
-    Logger.info([
-      "update_sign: ",
-      encoded,
-      " pid=",
-      inspect(self()),
-      " arinc_ms=",
-      inspect(div(arinc_time, 1000)),
-      " signs_ui_ms=",
-      inspect(div(ui_time, 1000))
-    ])
+    case result do
+      {:ok, _} ->
+        {ui_time, _} = :timer.tc(fn -> update_ui(state.http_poster, encoded) end)
+
+        Logger.info([
+          "update_sign: ",
+          encoded,
+          " pid=",
+          inspect(self()),
+          " arinc_ms=",
+          inspect(div(arinc_time, 1000)),
+          " signs_ui_ms=",
+          inspect(div(ui_time, 1000))
+        ])
+
+      {:error, _} ->
+        Logger.info([
+          "update_sign: ",
+          encoded,
+          " pid=",
+          inspect(self()),
+          " arinc_ms=",
+          inspect(div(arinc_time, 1000))
+        ])
+    end
 
     result
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [👁 realtime_signs POSTs to signs-ui only if ARINC post succeeds](https://app.asana.com/0/584764604969369/759678046304386/f)

[Please include a brief description of what was changed]

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
