### PR TITLE
fix: trips ending at stop 71199 should get a headsign of Park St

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -56,6 +56,7 @@ defmodule Content.Utilities do
   def destination_for_prediction(_, 1, "70205"), do: {:ok, :north_station}
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}
   def destination_for_prediction(_, 1, "70200"), do: {:ok, :park_street}
+  def destination_for_prediction(_, 1, "71199"), do: {:ok, :park_street}
   def destination_for_prediction(_, 1, "70150"), do: {:ok, :kenmore}
   def destination_for_prediction(_, 1, "70174"), do: {:ok, :reservoir}
 

--- a/test/content/utilities_test.exs
+++ b/test/content/utilities_test.exs
@@ -19,6 +19,8 @@ defmodule Content.UtilitiesTest do
 
       assert destination_for_prediction("Green-D", 0, "Government Center-Brattle") ==
                {:ok, :government_center}
+
+      assert destination_for_prediction("Green-E", 1, "71199") == {:ok, :park_street}
     end
 
     test "Southbound headsign on Red Line trunk" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Handle stop ID 71199 (Park St fence track EB platform) when determining headsigns](https://app.asana.com/0/584764604969369/1174799412295865/f)

Small thing I noticed while working on [this other ticket](https://app.asana.com/0/584764604969369/1164692141296041/f) to investigate some GL alert issues.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
