### PR TITLE
chore: Upgrade Elixir and Erlang

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.1.7
-elixir 1.9.4-otp-22
+erlang 22.3.4
+elixir v1.10.3-otp-22

--- a/build_release.sh
+++ b/build_release.sh
@@ -9,12 +9,14 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-ERL_DIR="erl10.5"
-ELIXIR_DIR="elixir1.9.4"
+ERL_DIR="erl10.7" # erlang/otp 22.3
+ELIXIR_DIR="elixir1.10.3"
 
 rm -rf _build-prev
 test -e "_build" && mv _build _build-prev
 
+env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix local.hex --force
+env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix local.rebar --force
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" mix deps.get
 env MIX_ENV=prod PATH="/c/Users/RTRUser/bin/$ERL_DIR/bin/:/c/Users/RTRUser/bin/$ELIXIR_DIR/bin/:$PATH" RELEASE_NODE=$1 mix release
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [tend to dependabot ](https://app.asana.com/0/584764604969369/1178039022748262)

Upgrades Erlang and Elixir to the versions that are already on Opstech3 from the recent upgrade of Socket Proxy.

I also added the `local.hex` and `local.rebar` lines which I put in this version of the script on Socket Proxy. We started getting warning logs when building realtime_signs that our hex was out of date, so this ensures it stays up to date.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
