### PR TITLE
chore: Use distinct hackney_pool for ARINC requests

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -280,9 +280,14 @@ defmodule PaEss.HttpUpdater do
 
   @spec send_post(module(), binary()) :: post_result()
   defp send_post(http_poster, query) do
-    case http_poster.post(sign_url(), query, [
-           {"Content-type", "application/x-www-form-urlencoded"}
-         ]) do
+    case http_poster.post(
+           sign_url(),
+           query,
+           [
+             {"Content-type", "application/x-www-form-urlencoded"}
+           ],
+           hackney: [pool: :arinc_pool]
+         ) do
       {:ok, %HTTPoison.Response{status_code: status}} when status >= 200 and status < 300 ->
         {:ok, :sent}
 
@@ -301,10 +306,15 @@ defmodule PaEss.HttpUpdater do
   def update_ui(http_poster, query) do
     key = Application.get_env(:realtime_signs, :sign_ui_api_key)
 
-    case http_poster.post(sign_ui_url(), query, [
-           {"Content-type", "application/x-www-form-urlencoded"},
-           {"x-api-key", key}
-         ]) do
+    case http_poster.post(
+           sign_ui_url(),
+           query,
+           [
+             {"Content-type", "application/x-www-form-urlencoded"},
+             {"x-api-key", key}
+           ],
+           hackney: [pool: :arinc_pool]
+         ) do
       {:ok, %HTTPoison.Response{status_code: status}} when status == 201 ->
         {:ok, :sent}
 

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -13,6 +13,7 @@ defmodule RealtimeSigns do
 
     children =
       [
+        :hackney_pool.child_spec(:arinc_pool, []),
         worker(Engine.Config, []),
         worker(Engine.Predictions, []),
         worker(Engine.ScheduledHeadways, []),

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule RealtimeSigns.Mixfile do
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [
-        plt_add_apps: [:mix],
+        plt_add_apps: [:mix, :hackney],
         plt_add_deps: true,
         ignore_warnings: ".dialyzer.ignore-warnings"
       ],

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -9,7 +9,7 @@ defmodule PaEss.HttpUpdaterTest do
   import ExUnit.CaptureLog
 
   defmodule FakePoster do
-    def post(_, q, _) do
+    def post(_, q, _, _) do
       send(self(), {:post, q})
       {:ok, %HTTPoison.Response{status_code: 200}}
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Separate hackney pool for ARINC](https://app.asana.com/0/584764604969369/1179942155771581)

We had delays in posting to ARINC the other day, we think because of an issue with hackney pools. Both the API and realtime_signs exhibited issues beginning around the same time, and both were fixed with restarts.

The error was `checkout_timeout` meaning `hackney` wasn't able to check out a socket connection from a pool. I still don't know why this was the case; it might be something to do with AWS slowness and a bug with hackney or `ex_aws`.

Regardless of the underlying cause, the API had a recent [PR](https://github.com/mbta/api/pull/248) to mitigate the issue somewhat by having distinct hackney pools, so that an issue with one wouldn't cause issues with other connections.

`realtime_signs` makes a number of different connections, but the POSTs to ARINC are the most important and time sensitive. Things like fetching the config file or alerts from the API can time out and be retried without customer facing issues, but a block on ARINC requests will fill up the queue fast, causing dropped messages and delayed updates to signs. So I decided to give ARINC requests their own pool, and let everything else continue to use the default pool.

This branch is running on realtime-signs-dev right now.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
