### PR TITLE
feat: filter out stop_time_updates with departure in past

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -7,8 +7,6 @@ defmodule Predictions.Predictions do
              optional({String.t(), integer()}) => [Predictions.Prediction.t()]
            }, MapSet.t(String.t())}
   def get_all(feed_message, current_time) do
-    current_time_unix = DateTime.to_unix(current_time)
-
     predictions =
       feed_message["entity"]
       |> Enum.map(& &1["trip_update"])
@@ -16,7 +14,7 @@ defmodule Predictions.Predictions do
       |> Enum.flat_map(&transform_stop_time_updates/1)
       |> Enum.filter(fn {update, _, _, _, _, _, _, _} ->
         update["arrival"] || update["passthrough_time"] ||
-          (update["departure"] && update["departure"]["time"] > current_time_unix)
+          (update["departure"] && not is_nil(update["stops_away"]))
       end)
       |> Enum.map(&prediction_from_update(&1, current_time))
       |> Enum.reject(

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -439,7 +439,7 @@ defmodule Predictions.PredictionsTest do
                   "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70263",
                   "stopped?" => false,
-                  "stops_away" => 0,
+                  "stops_away" => nil,
                   "stop_sequence" => 1
                 },
                 %{
@@ -481,27 +481,29 @@ defmodule Predictions.PredictionsTest do
         }
       }
 
-      assert {%{
-                {"70264", 0} => [
-                  %Predictions.Prediction{
-                    boarding_status: nil,
-                    destination_stop_id: "70263",
-                    direction_id: 0,
-                    new_cars?: false,
-                    revenue_trip?: true,
-                    route_id: "Mattapan",
-                    schedule_relationship: :scheduled,
-                    seconds_until_arrival: nil,
-                    seconds_until_departure: 100,
-                    seconds_until_passthrough: nil,
-                    stop_id: "70264",
-                    stopped?: false,
-                    stops_away: 1,
-                    trip_id: "32568935",
-                    vehicle_id: "G-10040"
-                  }
-                ]
-              }, _} = get_all(feed_message, @current_time)
+      {predictions_map, _} = get_all(feed_message, @current_time)
+
+      assert predictions_map == %{
+               {"70264", 0} => [
+                 %Predictions.Prediction{
+                   boarding_status: nil,
+                   destination_stop_id: "70263",
+                   direction_id: 0,
+                   new_cars?: false,
+                   revenue_trip?: true,
+                   route_id: "Mattapan",
+                   schedule_relationship: :scheduled,
+                   seconds_until_arrival: nil,
+                   seconds_until_departure: 100,
+                   seconds_until_passthrough: nil,
+                   stop_id: "70264",
+                   stopped?: false,
+                   stops_away: 1,
+                   trip_id: "32568935",
+                   vehicle_id: "G-10040"
+                 }
+               ]
+             }
     end
 
     test "identifies new Orange Line cars" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [📱 don't stop publishing given stop time update until after the scheduled departure time for the trip/stop ](https://app.asana.com/0/584764604969369/1171267038804699/f)

Filters out `stop_time_updates` where `departure_time` is in past

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
