### PR TITLE
feat: Add a health check engine to monitor conneciton pools

### DIFF
--- a/lib/engine/health.ex
+++ b/lib/engine/health.ex
@@ -1,0 +1,40 @@
+defmodule Engine.Health do
+  use GenServer
+  require Logger
+
+  @hackney_pools [:default, :arinc_pool]
+  @default_period_ms 60_000
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    period_ms = Keyword.get(opts, :period_ms, @default_period_ms)
+    GenServer.start_link(__MODULE__, period_ms, name: name)
+  end
+
+  @spec health_check(GenServer.server()) :: {:ok, []}
+  def health_check(pid) do
+    GenServer.call(pid, :health_check)
+  end
+
+  def init(period_ms) do
+    {:ok, timer_ref} = :timer.apply_interval(period_ms, __MODULE__, :health_check, [self()])
+    {:ok, timer_ref}
+  end
+
+  def handle_call(:health_check, _from, timer_ref) do
+    Enum.each(
+      @hackney_pools,
+      fn pool ->
+        stats = :hackney_pool.get_stats(pool)
+
+        Logger.info(
+          "event=pool_info name=#{pool} pool_max=#{stats[:max]} in_use_count=#{
+            stats[:in_use_count]
+          } free_count=#{stats[:free_count]} queue_count=#{stats[:queue_count]}"
+        )
+      end
+    )
+
+    {:reply, [], timer_ref}
+  end
+end

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -13,7 +13,9 @@ defmodule RealtimeSigns do
 
     children =
       [
+        :hackney_pool.child_spec(:default, []),
         :hackney_pool.child_spec(:arinc_pool, []),
+        worker(Engine.Health, []),
         worker(Engine.Config, []),
         worker(Engine.Predictions, []),
         worker(Engine.ScheduledHeadways, []),

--- a/test/engine/health_test.exs
+++ b/test/engine/health_test.exs
@@ -1,0 +1,15 @@
+defmodule Engine.HealthTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  test "logs pool stats" do
+    {:ok, _pid} = Engine.Health.start_link(name: :health_test, period_ms: 500)
+
+    log =
+      capture_log(fn ->
+        Process.sleep(600)
+      end)
+
+    assert log =~ "event=pool_info"
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [[extra] Investigate realtime_signs weekend crash](https://app.asana.com/0/584764604969369/1185276382736881)

This adds a new health check GenServer that polls the hackney pool stats once per minute and logs the info. For instance, [here](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20event%3Dpool_info%20name%3Ddefault%20%7C%20timechart%20min(in_use_count)&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1595423594.4753807) you can see that the `default` pool's `min(in_use_count)` has increased over the past 24 hours from `0`, right after a restart to `2` now. My hunch is that something is preventing a socket from being freed occasionally, and the socket pool slowly fills up, eventually leading to frequent timeouts down the line. But it was hard to tell before what that event was, since we didn't have any insight into the socket pool.

Having the numbers in the logs will make it easier to set up splunk alerts. Once this is merged, I'll set up an alert whenever the `in_use_count` goes above `30`.

Hopefully, being able to correlate increases in the `in_use_count` to other events in the logs will help us narrow down what specifically is causing the pool to fill up. Already I see that in the last 24 hours the `default` pool has filled up a bit, while `arinc_pool` has not. So perhaps, it has something to do with, e.g., `ex_aws_s3`, which uses the `default` pool for its requests, while `arinc_pool` is only used by `HttPoison`.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
