### PR TITLE
fix: make north station the default destination of eastbound green-e trains

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -69,7 +69,7 @@ defmodule Content.Utilities do
   def destination_for_prediction("Green-B", 1, _), do: {:ok, :park_street}
   def destination_for_prediction("Green-C", 1, _), do: {:ok, :north_station}
   def destination_for_prediction("Green-D", 1, _), do: {:ok, :government_center}
-  def destination_for_prediction("Green-E", 1, _), do: {:ok, :lechmere}
+  def destination_for_prediction("Green-E", 1, _), do: {:ok, :north_station}
 
   def destination_for_prediction(_, _, _), do: {:error, :not_found}
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Don't show "Lechmere" headsign on countdown clocks during GLX construction](https://app.asana.com/0/584764604969369/1181984480390625/f)

- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
