### PR TITLE
fix: Increase log buffer

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,7 +20,8 @@ config :logger, :splunk,
   host: 'https://http-inputs-mbta.splunkcloud.com/services/collector/event',
   token: {:system, "PROD_SIGNS_SPLUNK_TOKEN"},
   format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
-  metadata: [:request_id]
+  metadata: [:request_id],
+  max_buffer: 100
 
 config :realtime_signs,
   external_config_getter: ExternalConfig.S3,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] fixes to realtime_signs after crash](https://app.asana.com/0/584764604969369/1188932323094569)

This increases the `logger_splunk_backend` buffer of messages to log from the default of `10` to `100`. `realtime_signs` logs at roughly 10msg/sec, so the previous buffer was pretty small for that volume. This does mean some messages can be delayed in appearing in Splunk by up to 10 seconds.

We had another brief network outage last night, and on the bright side, dev, which was running this branch at the time, didn't die like prod did.


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
