### PR TITLE
fix: don't filter out passthrough predictions without stops_away

### DIFF
--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -321,7 +321,7 @@ defmodule Fake.HTTPoison do
                   "schedule_relationship" => "SKIPPED",
                   "stop_id" => "70261",
                   "stop_sequence" => 2,
-                  "stops_away" => 0,
+                  "stops_away" => nil,
                   "stopped?" => true
                 }
               ],

--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -13,8 +13,8 @@ defmodule Predictions.Predictions do
       |> Enum.reject(&(&1["trip"]["schedule_relationship"] == "CANCELED"))
       |> Enum.flat_map(&transform_stop_time_updates/1)
       |> Enum.filter(fn {update, _, _, _, _, _, _, _} ->
-        (update["arrival"] || update["passthrough_time"] || update["departure"]) &&
-          not is_nil(update["stops_away"])
+        ((update["arrival"] || update["departure"]) &&
+           not is_nil(update["stops_away"])) || update["passthrough_time"]
       end)
       |> Enum.map(&prediction_from_update(&1, current_time))
       |> Enum.reject(

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -19,7 +19,7 @@ defmodule Predictions.PredictionsTest do
               "schedule_relationship" => "SKIPPED",
               "stop_id" => "70265",
               "stop_sequence" => 1,
-              "stops_away" => 0,
+              "stops_away" => nil,
               "stopped?" => false,
               "passthrough_time" => 1_491_570_110
             },
@@ -120,7 +120,7 @@ defmodule Predictions.PredictionsTest do
             schedule_relationship: :skipped,
             route_id: "Mattapan",
             destination_stop_id: "70261",
-            stops_away: 0,
+            stops_away: nil,
             stopped?: false,
             trip_id: "32568935",
             new_cars?: false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🐛 Passthrough train audio not playing](https://app.asana.com/0/584764604969369/1199184345609901/f)

Currently running on dev.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
