### PR TITLE
feat: show two GL predictions on N Station mezz sign

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5959,26 +5959,14 @@
     "source_config": [
       [
         {
-          "stop_id": "70205",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
           "stop_id": "70206",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
           "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "platform": null,
           "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
+          "announce_arriving": false,
+          "announce_boarding": true
         }
       ]
     ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [❇️ Signs at North Station GL lobby show two trains](https://app.asana.com/0/584764604969369/1199550046000723/f)

Currently running on realtime_signs dev:
![Screen Shot 2021-02-01 at 1 47 33 PM](https://user-images.githubusercontent.com/2010157/106503880-3447f300-6494-11eb-8c22-22558c918ab9.png)

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
