### PR TITLE
feat: Single Tracking Predictions at Wellington

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1282,6 +1282,16 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
+        },
+        {
+          "stop_id": "70032",
+          "routes": ["Orange"],
+          "direction_id": 1,
+          "headway_direction_name": "Oak Grove",
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
         }
       ]
     ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update realtime signs to display NB predictions on the SB platform at Wellington](https://app.asana.com/0/584764604969369/1200018121555438)

The sign on the southbound (Forest Hills) side of Wellington now has to include data for northbound (Oak Grove) trains. 

`source_config` has only 1 entry which means the 2 lines on the sign will display data from the same set of sources. The 2 dictionaries in this entry represent 2 sources for the set of data. It already contained the southbound source. This pull request adds the northbound source.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
