### PR TITLE
feat: Orange Line signs show station train is waiting at

### DIFF
--- a/lib/content/audio/stopped_at_station.ex
+++ b/lib/content/audio/stopped_at_station.ex
@@ -1,0 +1,56 @@
+defmodule Content.Audio.StoppedAtStation do
+  @moduledoc """
+  The next train to [destination] is waiting at [station]
+  """
+
+  require Logger
+
+  @enforce_keys [:destination, :stopped_at]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: atom(),
+          stopped_at: atom()
+        }
+
+  @spec from_message(Content.Message.StoppedAtStation.t()) :: Content.Audio.StoppedAtStation.t()
+  def from_message(%Content.Message.StoppedAtStation{} = msg) do
+    %__MODULE__{destination: msg.destination, stopped_at: msg.stopped_at}
+  end
+
+  defimpl Content.Audio do
+    @destination_var %{
+      forest_hills: "824",
+      oak_grove: "825"
+    }
+
+    @stopped_at_var %{
+      assembly: "826",
+      back_bay: "827",
+      chinatown: "828",
+      community_college: "829",
+      downtown_crossing: "830",
+      forest_hills: "831",
+      green_street: "832",
+      haymarket: "833",
+      jackson_square: "834",
+      malden_center: "835",
+      massachusetts_avenue: "836",
+      north_station: "837",
+      oak_grove: "838",
+      roxbury_crossing: "839",
+      ruggles: "840",
+      state: "841",
+      stony_brook: "842",
+      sullivan_square: "843",
+      tufts_medical_center: "844",
+      wellington: "845"
+    }
+    def to_params(%Content.Audio.StoppedAtStation{} = audio) do
+      with {:ok, dest_var} <- Map.fetch(@destination_var, audio.destination),
+           {:ok, stopped_var} <- Map.fetch(@stopped_at_var, audio.stopped_at) do
+        PaEss.Utilities.take_message([dest_var, stopped_var], :audio)
+      end
+    end
+  end
+end

--- a/lib/content/message/stopped_at_station.ex
+++ b/lib/content/message/stopped_at_station.ex
@@ -1,0 +1,161 @@
+defmodule Content.Message.StoppedAtStation do
+  require Logger
+
+  @stations_by_stop_id %{
+    "70036" => :oak_grove,
+    "70034" => :malden_center,
+    "70035" => :malden_center,
+    "70032" => :wellington,
+    "70033" => :wellington,
+    "70278" => :assembly,
+    "70279" => :assembly,
+    "70030" => :sullivan_square,
+    "70031" => :sullivan_square,
+    "70028" => :community_college,
+    "70029" => :community_college,
+    "70026" => :north_station,
+    "70027" => :north_station,
+    "70024" => :haymarket,
+    "70025" => :haymarket,
+    "70022" => :state,
+    "70023" => :state,
+    "70020" => :downtown_crossing,
+    "70021" => :downtown_crossing,
+    "70018" => :chinatown,
+    "70019" => :chinatown,
+    "70016" => :tufts_medical_center,
+    "70017" => :tufts_medical_center,
+    "70014" => :back_bay,
+    "70015" => :back_bay,
+    "70012" => :massachusetts_avenue,
+    "70013" => :massachusetts_avenue,
+    "70010" => :ruggles,
+    "70011" => :ruggles,
+    "70008" => :roxbury_crossing,
+    "70009" => :roxbury_crossing,
+    "70006" => :jackson_square,
+    "70007" => :jackson_square,
+    "70004" => :stony_brook,
+    "70005" => :stony_brook,
+    "70002" => :green_street,
+    "70003" => :green_street,
+    "70001" => :forest_hills
+  }
+
+  @stations_in_order [
+    :oak_grove,
+    :malden_center,
+    :wellington,
+    :assembly,
+    :sullivan_square,
+    :community_college,
+    :north_station,
+    :haymarket,
+    :state,
+    :downtown_crossing,
+    :chinatown,
+    :tufts_medical_center,
+    :back_bay,
+    :massachusetts_avenue,
+    :ruggles,
+    :roxbury_crossing,
+    :jackson_square,
+    :stony_brook,
+    :green_street,
+    :forest_hills,
+    :green_street,
+    :stony_brook,
+    :jackson_square,
+    :roxbury_crossing,
+    :ruggles,
+    :massachusetts_avenue,
+    :back_bay,
+    :tufts_medical_center,
+    :chinatown,
+    :downtown_crossing,
+    :state,
+    :haymarket,
+    :north_station,
+    :community_college,
+    :sullivan_square,
+    :assembly,
+    :wellington,
+    :malden_center,
+    :oak_grove
+  ]
+  defstruct [:destination, :stopped_at]
+
+  @type t :: %__MODULE__{
+          destination: atom(),
+          stopped_at: atom()
+        }
+
+  @spec from_prediction(Predictions.Prediction.t()) :: t() | nil
+  def from_prediction(prediction) do
+    case Content.Utilities.destination_for_prediction(
+           prediction.route_id,
+           prediction.direction_id,
+           prediction.destination_stop_id
+         ) do
+      {:ok, destination} ->
+        %__MODULE__{
+          destination: destination,
+          stopped_at: get_train_location(prediction, destination)
+        }
+
+      {:error, _} ->
+        Logger.warn("StoppedAtStation no_destination_for_prediction #{inspect(prediction)}")
+        nil
+    end
+  end
+
+  defimpl Content.Message do
+    def to_string(stopped_at_station) do
+      [
+        {"#{PaEss.Utilities.destination_to_sign_string(stopped_at_station.destination)} waiting ",
+         6},
+        {"at #{stop_atom_to_string(stopped_at_station.stopped_at)}     ", 3}
+      ]
+    end
+
+    @spec stop_atom_to_string(atom()) :: String.t()
+    def stop_atom_to_string(:oak_grove), do: "Oak Grove"
+    def stop_atom_to_string(:malden_center), do: "Malden Ctr"
+    def stop_atom_to_string(:wellington), do: "Wellington"
+    def stop_atom_to_string(:assembly), do: "Assembly"
+    def stop_atom_to_string(:sullivan_square), do: "Sullivan Sq"
+    def stop_atom_to_string(:community_college), do: "Community Col"
+    def stop_atom_to_string(:north_station), do: "North Station"
+    def stop_atom_to_string(:haymarket), do: "Haymarket"
+    def stop_atom_to_string(:state), do: "State"
+    def stop_atom_to_string(:downtown_crossing), do: "Downtown Xing"
+    def stop_atom_to_string(:chinatown), do: "Chinatown"
+    def stop_atom_to_string(:tufts_medical_center), do: "Tufts Med Ctr"
+    def stop_atom_to_string(:back_bay), do: "Back Bay"
+    def stop_atom_to_string(:massachusetts_avenue), do: "Mass Ave"
+    def stop_atom_to_string(:ruggles), do: "Ruggles"
+    def stop_atom_to_string(:roxbury_crossing), do: "Roxbury Xing"
+    def stop_atom_to_string(:jackson_square), do: "Jackson Sq"
+    def stop_atom_to_string(:stony_brook), do: "Stony Brook"
+    def stop_atom_to_string(:green_street), do: "Green St"
+    def stop_atom_to_string(:forest_hills), do: "Frst Hills"
+  end
+
+  @spec get_train_location(
+          Predictions.Prediction.t(),
+          :forest_hills | :oak_grove
+        ) :: atom()
+  def get_train_location(prediction, destination) do
+    this_station = @stations_by_stop_id[prediction.stop_id]
+    this_station_index = Enum.find_index(@stations_in_order, fn x -> x == this_station end)
+    num_stops_away = prediction.stops_away
+
+    case destination do
+      :oak_grove ->
+        Enum.at(@stations_in_order, this_station_index + num_stops_away)
+
+      :forest_hills ->
+        Enum.at(@stations_in_order, abs(this_station_index - num_stops_away))
+    end
+  end
+end

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -54,6 +54,11 @@ defmodule RealtimeSigns do
 
     :ok =
       Config.update_env(env, :number_of_http_updaters, "NUMBER_OF_HTTP_UPDATERS", type: :integer)
+
+    :ok =
+      Config.update_env(env, :stations_away_experiment?, "STATIONS_AWAY_EXPERIMENT",
+        type: :boolean
+      )
   end
 
   def http_updater_children do

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -83,6 +83,10 @@ defmodule Signs.Utilities.Audio do
     false
   end
 
+  def should_interrupting_read?({_, %Content.Message.StoppedAtStation{}}, _sign, :bottom) do
+    false
+  end
+
   def should_interrupting_read?({_, %Content.Message.Headways.Bottom{}}, _sign, _line) do
     false
   end
@@ -255,6 +259,30 @@ defmodule Signs.Utilities.Audio do
     Audio.Predictions.from_sign_content(top_content, :top, multi_source?)
   end
 
+  defp get_audio(
+         {_, %Message.StoppedAtStation{destination: same} = top},
+         {_, %Message.StoppedAtStation{destination: same}},
+         _multi_source?
+       ) do
+    Audio.StoppedAtStation.from_message(top)
+  end
+
+  defp get_audio(
+         {_, %Message.StoppedAtStation{destination: same} = top},
+         {_, %Message.Predictions{destination: same}},
+         _multi_source?
+       ) do
+    Audio.StoppedAtStation.from_message(top)
+  end
+
+  defp get_audio(
+         {_, %Message.Predictions{destination: same}} = top_content,
+         {_, %Message.StoppedAtStation{destination: same}},
+         multi_source?
+       ) do
+    Audio.Predictions.from_sign_content(top_content, :top, multi_source?)
+  end
+
   defp get_audio(top, bottom, multi_source?) do
     top_audio = get_audio_for_line(top, :top, multi_source?)
     bottom_audio = get_audio_for_line(bottom, :bottom, multi_source?)
@@ -265,6 +293,10 @@ defmodule Signs.Utilities.Audio do
           Content.Audio.t() | nil
   defp get_audio_for_line({_, %Message.StoppedTrain{} = message}, _line, _multi_source?) do
     Audio.StoppedTrain.from_message(message)
+  end
+
+  defp get_audio_for_line({_, %Message.StoppedAtStation{} = message}, _line, _multi_source?) do
+    Audio.StoppedAtStation.from_message(message)
   end
 
   defp get_audio_for_line({_, %Message.Predictions{}} = content, line, multi_source?) do

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -44,6 +44,10 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.take(2)
     |> Enum.map(fn {source, prediction} ->
       cond do
+        stopped_train?(prediction) and prediction.route_id == "Orange" and
+            stations_away_experiment?() ->
+          {source, Content.Message.StoppedAtStation.from_prediction(prediction)}
+
         stopped_train?(prediction) ->
           {source, Content.Message.StoppedTrain.from_prediction(prediction)}
 
@@ -157,7 +161,7 @@ defmodule Signs.Utilities.Predictions do
 
   defp stopped_train?(prediction) do
     status = prediction.boarding_status
-    status && String.starts_with?(status, "Stopped") && status != "Stopped at station"
+    !is_nil(status) and String.starts_with?(status, "Stopped") and status != "Stopped at station"
   end
 
   defp allowed_multi_berth_platform?(
@@ -170,5 +174,9 @@ defmodule Signs.Utilities.Predictions do
 
   defp allowed_multi_berth_platform?(_, _) do
     false
+  end
+
+  defp stations_away_experiment? do
+    Application.get_env(:realtime_signs, :stations_away_experiment?, false)
   end
 end

--- a/test/content/audio/stopped_at_station_test.exs
+++ b/test/content/audio/stopped_at_station_test.exs
@@ -1,0 +1,26 @@
+defmodule Content.Audio.StoppedAtStationTest do
+  use ExUnit.Case, async: true
+
+  describe "from_message/1" do
+    test "converts a Message to an Audio" do
+      assert %Content.Audio.StoppedAtStation{
+               destination: :oak_grove,
+               stopped_at: :wellington
+             } =
+               Content.Audio.StoppedAtStation.from_message(%Content.Message.StoppedAtStation{
+                 destination: :oak_grove,
+                 stopped_at: :wellington
+               })
+    end
+  end
+
+  describe "to_params/1" do
+    test "converts an Audio to ARINC params" do
+      assert {:canned, {"105", ["825", "21000", "830"], :audio}} =
+               Content.Audio.to_params(%Content.Audio.StoppedAtStation{
+                 destination: :oak_grove,
+                 stopped_at: :downtown_crossing
+               })
+    end
+  end
+end

--- a/test/content/messages/stopped_at_station_test.exs
+++ b/test/content/messages/stopped_at_station_test.exs
@@ -1,0 +1,109 @@
+defmodule Content.Message.StoppedAtStationTest do
+  use ExUnit.Case, async: true
+
+  alias Content.Message.StoppedAtStation
+  alias Predictions.Prediction
+
+  describe "from_prediction/1" do
+    test "Converts the stops away to the station atom, SB" do
+      assert %StoppedAtStation{
+               destination: :forest_hills,
+               stopped_at: :assembly
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70024",
+                 stops_away: 4,
+                 direction_id: 0,
+                 route_id: "Orange"
+               })
+    end
+
+    test "Converts the stops away to the station atom, NB" do
+      assert %StoppedAtStation{
+               destination: :oak_grove,
+               stopped_at: :tufts_medical_center
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70029",
+                 stops_away: 6,
+                 route_id: "Orange",
+                 direction_id: 1
+               })
+    end
+
+    test "Converts the stops away to the station atom, wrapping around" do
+      assert %StoppedAtStation{
+               destination: :forest_hills,
+               stopped_at: :wellington
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70278",
+                 stops_away: 5,
+                 route_id: "Orange",
+                 direction_id: 0
+               })
+    end
+
+    test "Converts the stops away to the station atom, wrapping around the other way" do
+      assert %StoppedAtStation{
+               destination: :oak_grove,
+               stopped_at: :roxbury_crossing
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70007",
+                 stops_away: 7,
+                 route_id: "Orange",
+                 direction_id: 1
+               })
+    end
+
+    test "Counts the correct direction from single tracked Wellington, NB" do
+      assert %StoppedAtStation{
+               destination: :oak_grove,
+               stopped_at: :sullivan_square
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70032",
+                 stops_away: 2,
+                 route_id: "Orange",
+                 direction_id: 1
+               })
+    end
+
+    test "Counts the correct direction from single tracked Wellington, SB" do
+      assert %StoppedAtStation{
+               destination: :forest_hills,
+               stopped_at: :oak_grove
+             } =
+               StoppedAtStation.from_prediction(%Prediction{
+                 stop_id: "70032",
+                 stops_away: 2,
+                 route_id: "Orange",
+                 direction_id: 0
+               })
+    end
+
+    test "Handles unknown destination" do
+      assert is_nil(
+               StoppedAtStation.from_prediction(%Prediction{
+                 route_id: "Orange",
+                 direction_id: 2,
+                 destination_stop_id: ""
+               })
+             )
+    end
+  end
+
+  describe "to_string protocol" do
+    test "Converts a struct into the text that appears on the sign" do
+      assert [
+               {"Oak Grove waiting ", 6},
+               {"at Wellington     ", 3}
+             ] =
+               Content.Message.to_string(%StoppedAtStation{
+                 destination: :oak_grove,
+                 stopped_at: :wellington
+               })
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update realtime_signs](https://app.asana.com/0/584764604969369/1199999517465615)

Signs now tell riders the stop the next train is waiting at instead of the number of stops away.

`lib/content/message/stopped_at_station.ex` uses `stop_id`s to get stop atoms and uses stop atoms to get stop strings.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
