### PR TITLE
Announce opposite platform boarding at Park St

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -26,20 +26,11 @@ defmodule Content.Audio.Predictions do
         multi_source?
       ) do
     cond do
-      predictions.route_id in ["Green-B", "Green-D"] and
-        predictions.stop_id in ["70197", "70199"] and predictions.minutes == :boarding ->
+      TrackChange.park_track_change?(predictions) and predictions.minutes == :boarding ->
         %TrackChange{
           destination: predictions.destination,
           route_id: predictions.route_id,
-          track: 1
-        }
-
-      predictions.route_id in ["Green-C", "Green-E"] and
-        predictions.stop_id in ["70196", "70198"] and predictions.minutes == :boarding ->
-        %TrackChange{
-          destination: predictions.destination,
-          route_id: predictions.route_id,
-          track: 2
+          berth: predictions.stop_id
         }
 
       predictions.minutes == :boarding ->

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -5,62 +5,77 @@ defmodule Content.Audio.TrackChange do
 
   require Logger
 
-  @enforce_keys [:destination, :track, :route_id]
+  @enforce_keys [:destination, :berth, :route_id]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           route_id: String.t(),
-          track: integer()
+          berth: String.t()
         }
+
+  @spec park_track_change?(Content.Message.Predictions.t()) :: boolean()
+  def park_track_change?(%{route_id: "Green-B", stop_id: "70197"}), do: true
+  def park_track_change?(%{route_id: "Green-C", stop_id: "70196"}), do: true
+  def park_track_change?(%{route_id: "Green-D", stop_id: "70199"}), do: true
+  def park_track_change?(%{route_id: "Green-E", stop_id: "70198"}), do: true
+  def park_track_change?(_prediction), do: false
 
   defimpl Content.Audio do
     @track_change "540"
-    @the_next "501"
-    @train_to "507"
-    @is_now_boarding "544"
-    @on_track_1 "541"
-    @on_track_2 "542"
+    @b_to_boston_college_c_platform "813"
+    @c_to_cleveland_circle_b_platform "814"
+    @d_to_reservoir_e_platform "815"
+    @d_to_riverside_e_platform "818"
+    @e_to_heath_d_platform "816"
+    @kenmore_b_platform "823"
+    @kenmore_c_platform "820"
+    @kenmore_d_platform "821"
+    @kenmore_e_platform "822"
 
     def to_params(audio) do
-      case PaEss.Utilities.destination_var(audio.destination) do
-        {:ok, dest_var} ->
-          vars =
-            case Content.Utilities.route_and_destination_branch_letter(
-                   audio.route_id,
-                   audio.destination
-                 ) do
-              nil ->
-                [
-                  @track_change,
-                  @the_next,
-                  @train_to,
-                  dest_var,
-                  @is_now_boarding,
-                  track(audio.track)
-                ]
+      case {audio.route_id, audio.berth, audio.destination} do
+        {"Green-B", "70197", :boston_college} ->
+          track_change_message(@b_to_boston_college_c_platform)
 
-              branch ->
-                [
-                  @track_change,
-                  @the_next,
-                  PaEss.Utilities.green_line_branch_var(branch),
-                  @train_to,
-                  dest_var,
-                  @is_now_boarding,
-                  track(audio.track)
-                ]
-            end
+        {"Green-B", "70197", :kenmore} ->
+          track_change_message(@kenmore_c_platform)
 
-          PaEss.Utilities.take_message(vars, :audio_visual)
+        {"Green-C", "70196", :cleveland_circle} ->
+          track_change_message(@c_to_cleveland_circle_b_platform)
 
-        {:error, :unknown} ->
-          Logger.error("TrackChange.to_params unknown destination: #{inspect(audio.destination)}")
+        {"Green-C", "70196", :kenmore} ->
+          track_change_message(@kenmore_b_platform)
+
+        {"Green-D", "70199", :reservoir} ->
+          track_change_message(@d_to_reservoir_e_platform)
+
+        {"Green-D", "70199", :riverside} ->
+          track_change_message(@d_to_riverside_e_platform)
+
+        {"Green-D", "70199", :kenmore} ->
+          track_change_message(@kenmore_e_platform)
+
+        {"Green-E", "70198", :heath_street} ->
+          track_change_message(@e_to_heath_d_platform)
+
+        {"Green-E", "70198", :kenmore} ->
+          track_change_message(@kenmore_d_platform)
+
+        {route, berth, destination} ->
+          Logger.error(
+            "TrackChange.to_params unknown route, berth, destination: #{
+              inspect({route, berth, destination})
+            }"
+          )
+
           nil
       end
     end
 
-    defp track(1), do: @on_track_1
-    defp track(2), do: @on_track_2
+    defp track_change_message(msg_id) do
+      vars = [@track_change, msg_id]
+      PaEss.Utilities.take_message(vars, :audio_visual)
+    end
   end
 end

--- a/test/content/audio/predictions_test.exs
+++ b/test/content/audio/predictions_test.exs
@@ -18,7 +18,7 @@ defmodule Content.Audio.PredictionsTest do
   }
 
   describe "from_sign_content/3" do
-    test "returns a TrackChange audio when Green-B boarding other side at Park St" do
+    test "returns a TrackChange audio when Green-B boarding at C berth at Park St" do
       src = %{@src | stop_id: "70197", direction_id: 0, headway_destination: :boston_college}
 
       predictions = %Message.Predictions{
@@ -31,24 +31,24 @@ defmodule Content.Audio.PredictionsTest do
       assert %Audio.TrackChange{
                destination: :boston_college,
                route_id: "Green-B",
-               track: 1
+               berth: "70197"
              } = from_sign_content({src, predictions}, :top, false)
     end
 
-    test "returns a TrackChange audio when Green-E boarding other side at Park St" do
-      src = %{@src | stop_id: "70196", direction_id: 0, headway_destination: :heath_street}
+    test "returns a TrackChange audio when Green-E boarding at D berth at Park St" do
+      src = %{@src | stop_id: "70198", direction_id: 0, headway_destination: :heath_street}
 
       predictions = %Message.Predictions{
         destination: :heath_street,
         minutes: :boarding,
         route_id: "Green-E",
-        stop_id: "70196"
+        stop_id: "70198"
       }
 
       assert %Audio.TrackChange{
                destination: :heath_street,
                route_id: "Green-E",
-               track: 2
+               berth: "70198"
              } = from_sign_content({src, predictions}, :top, false)
     end
 

--- a/test/content/audio/track_change_test.exs
+++ b/test/content/audio/track_change_test.exs
@@ -3,82 +3,156 @@ defmodule Content.Audio.TrackChangeTest do
   import ExUnit.CaptureLog
 
   describe "to_params/1" do
-    test "correctly changes tracks for b/d" do
+    test "correctly changes berths from b to c" do
       audio = %Content.Audio.TrackChange{
         destination: :boston_college,
         route_id: "Green-B",
-        track: 1
+        berth: "70197"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"115",
+                {"105",
                  [
                    "540",
                    "21000",
-                   "501",
-                   "21000",
-                   "536",
-                   "21000",
-                   "507",
-                   "21000",
-                   "4202",
-                   "21000",
-                   "544",
-                   "21000",
-                   "541"
+                   "813"
                  ], :audio_visual}}
     end
 
-    test "correctly changes tracks for c/e" do
+    test "correctly changes berths from c to b" do
+      audio = %Content.Audio.TrackChange{
+        destination: :cleveland_circle,
+        route_id: "Green-C",
+        berth: "70196"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
+                   "21000",
+                   "814"
+                 ], :audio_visual}}
+    end
+
+    test "correctly changes berths from d to e (reservoir)" do
+      audio = %Content.Audio.TrackChange{
+        destination: :reservoir,
+        route_id: "Green-D",
+        berth: "70199"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
+                   "21000",
+                   "815"
+                 ], :audio_visual}}
+    end
+
+    test "correctly changes berths from d to e (riverside)" do
+      audio = %Content.Audio.TrackChange{
+        destination: :riverside,
+        route_id: "Green-D",
+        berth: "70199"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
+                   "21000",
+                   "818"
+                 ], :audio_visual}}
+    end
+
+    test "correctly changes berths from e to d" do
       audio = %Content.Audio.TrackChange{
         destination: :heath_street,
         route_id: "Green-E",
-        track: 1
+        berth: "70198"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"115",
+                {"105",
                  [
                    "540",
                    "21000",
-                   "501",
-                   "21000",
-                   "539",
-                   "21000",
-                   "507",
-                   "21000",
-                   "4204",
-                   "21000",
-                   "544",
-                   "21000",
-                   "541"
+                   "816"
                  ], :audio_visual}}
     end
 
-    test "omits branch letter from Kenmore-bound trains" do
+    test "correctly announces Kenmore B track changes to the C platform" do
       audio = %Content.Audio.TrackChange{
         destination: :kenmore,
-        route_id: "Green-D",
-        track: 2
+        route_id: "Green-B",
+        berth: "70197"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"113",
+                {"105",
                  [
                    "540",
                    "21000",
-                   "501",
+                   "820"
+                 ], :audio_visual}}
+    end
+
+    test "correctly announces Kenmore C track changes to the B platform" do
+      audio = %Content.Audio.TrackChange{
+        destination: :kenmore,
+        route_id: "Green-C",
+        berth: "70196"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
                    "21000",
-                   "507",
+                   "823"
+                 ], :audio_visual}}
+    end
+
+    test "correctly announces Kenmore D track changes to the E platform" do
+      audio = %Content.Audio.TrackChange{
+        destination: :kenmore,
+        route_id: "Green-D",
+        berth: "70199"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
                    "21000",
-                   "4070",
+                   "822"
+                 ], :audio_visual}}
+    end
+
+    test "correctly announces Kenmore E track changes to the D platform" do
+      audio = %Content.Audio.TrackChange{
+        destination: :kenmore,
+        route_id: "Green-E",
+        berth: "70198"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"105",
+                 [
+                   "540",
                    "21000",
-                   "544",
-                   "21000",
-                   "542"
+                   "821"
                  ], :audio_visual}}
     end
 
@@ -86,7 +160,7 @@ defmodule Content.Audio.TrackChangeTest do
       audio = %Content.Audio.TrackChange{
         destination: :unknown,
         route_id: "Green-E",
-        track: 1
+        berth: "00000"
       }
 
       log =
@@ -94,7 +168,7 @@ defmodule Content.Audio.TrackChangeTest do
           assert Content.Audio.to_params(audio) == nil
         end)
 
-      assert log =~ "unknown destination"
+      assert log =~ "unknown route, berth, destination"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [💳 announce opposite platform boarding at Park St](https://app.asana.com/0/584764604969369/1186296208448393/f)

This change adds new logic that handles switching of B, C, D, and E Green Line trains onto opposite "platforms" at Park Street station, of which there are now four, whereas before announcements would only be made for trains switching onto opposite tracks.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
