### PR TITLE
feat: Sullivan Square and Community College single tracking

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1425,12 +1425,12 @@
         {
           "stop_id": "70031",
           "routes": ["Orange"],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
+          "direction_id": 0,
+          "headway_direction_name": "Forest Hills",
           "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
         }
       ]
     ]
@@ -1489,6 +1489,16 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
+        },
+        {
+          "stop_id": "70029",
+          "routes": ["Orange"],
+          "direction_id": 0,
+          "headway_direction_name": "Forest Hills",
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
         }
       ]
     ]
@@ -1508,6 +1518,16 @@
           "routes": ["Orange"],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70029",
+          "routes": ["Orange"],
+          "direction_id": 0,
+          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] Realtime Signs updates for Sullivan Sq single tracking](https://app.asana.com/0/584764604969369/1200085512957616)

This updates:

* Community College NB platform signs to also consider direction `0` trips at that stop ID.
* Sullivan Sq NB platform to be more akin to a SB terminal (using departures vs arrivals, announcing BRD vs ARR).


#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
