### PR TITLE
fix: Handle unknown messages like ssl_closed

### DIFF
--- a/lib/engine/health.ex
+++ b/lib/engine/health.ex
@@ -46,6 +46,11 @@ defmodule Engine.Health do
     {:noreply, state}
   end
 
+  def handle_info(msg, state) do
+    Logger.info("Engine.Health unknown_message msg=#{inspect(msg)}")
+    {:noreply, state}
+  end
+
   defp log_hackney_pools do
     Enum.each(
       @hackney_pools,

--- a/test/engine/health_test.exs
+++ b/test/engine/health_test.exs
@@ -66,6 +66,18 @@ defmodule Engine.HealthTest do
     refute_received :restarting
   end
 
+  test "handles unknown messages like :ssl_closed" do
+    {:ok, pid} = Engine.Health.start_link()
+
+    log =
+      capture_log(fn ->
+        send(pid, :ssl_closed)
+      end)
+
+    assert log =~ "unknown_message"
+    assert Process.alive?(pid)
+  end
+
   describe "restart_noop/0" do
     test "does nothing and returns :ok" do
       assert Engine.Health.restart_noop() == :ok


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Noticed this error/crash in the logs:

```
2021-03-22T11:01:54.087 [error] node=realtime_signs_prod@OPSTECH3 GenServer #PID<0.1192.0> terminating 
** (FunctionClauseError) no function clause matching in Engine.Health.handle_info/2
     (realtime_signs 1.0.0) lib/engine/health.ex:37: Engine.Health.handle_info({:ssl_closed, {:sslsocket, {:gen_tcp, #Port<0.861>, :tls_connection, :undefined}, [#PID<0.4170.0>, #PID<0.4169.0>]}}, %Engine.Health{failed_requests: 0, network_check_mod: Engine.NetworkCheck.Hackney, restart_fn: &System.restart/0, timer_ref: {:interval, #Reference<0.3051823969.2387869702.247830>}})
     (stdlib 3.12) gen_server.erl:637: :gen_server.try_dispatch/4
     (stdlib 3.12) gen_server.erl:711: :gen_server.handle_msg/6
```

Forgot to update this. When changing `Engine.Health` from a `call` to a `handle_info`, forgot our best practice to always have a catch_all `handle_info` clause for unknown messages. (One is provided by `use GenServer` if you don't specify a `handle_info` callback, but once you provide one, you're then responsible for handling all messages.) In particular, whenever the GenServer makes requests, it's liable to get a `:ssl_closed` message.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
