### PR TITLE
Fix DateTime issue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,9 @@ config :ehmon, :report_mf, {:ehmon, :info_report}
 
 config :sentry, json_library: Jason
 
-config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+# Have to use Timex's DB for now because Timex.parse can return times in
+# "Etc/UTC-4" time zone, which is invalid by IANA and TzData.TimeZoneDatabase
+config :elixir, :time_zone_database, Timex.Timezone.Database
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[extra] realtime-signs master is broken with time zone issue](https://app.asana.com/0/584764604969369/1200228954105481)

This adds a test case to capture the crash we were seeing on realtime-signs-dev, and includes a fix for it, which is switching our app's timezone database from `Tzdata.Database` to `Timex.Timezone.Database`.

The problem was ultimately that `Timex.parse!/2` was returning a DateTime, in a time zone (`Etc/UTC-4`) that wasn't present in the `Tzdata.Database`, I think because `Etc/UTC-4` is not a valid IANA time zone ID. (Timex issue opened [here](https://github.com/bitwalker/timex/issues/664)).

Ideally, we could just switch away from Timex, which I've been gradually doing in our apps, once we get to Elixir 1.11 which has all the DateTime functions I've needed in Timex, but upgrading Elixir on opstech3 is a little annoying, and we use Timex a fair bit in realtime signs.

I also considered just patching our `Timex.parse!(..)` calls, as `%{dt | time_zone: "Etc/GMT-4"}` works. But that seems like it leaves a footgun in place for future work.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
