### PR TITLE
fix: Consider any HTTP status 200-299 as successful for health check

### DIFF
--- a/lib/engine/network_check/hackney.ex
+++ b/lib/engine/network_check/hackney.ex
@@ -13,7 +13,7 @@ defmodule Engine.NetworkCheck.Hackney do
       ])
 
     case response do
-      {:ok, 200, _} ->
+      {:ok, status, _} when status >= 200 and status < 300 ->
         Logger.info("#{__MODULE__} check_network result=success")
         :ok
 

--- a/test/engine/network_check/hackney_test.exs
+++ b/test/engine/network_check/hackney_test.exs
@@ -6,13 +6,24 @@ defmodule Engine.NetworkCheck.HackneyTest do
     def unquote(:do)(_data), do: {:proceed, [response: {500, 'Not OK'}]}
   end
 
-  defmodule MockGoodNetwork do
+  defmodule MockGoodNetwork200 do
     def unquote(:do)(_data), do: {:proceed, [response: {200, 'OK'}]}
+  end
+
+  defmodule MockGoodNetwork204 do
+    def unquote(:do)(_data), do: {:proceed, [response: {204, 'OK'}]}
   end
 
   describe "check/0" do
     test "returns :ok on valid check" do
-      {:ok, pid, port} = Helpers.start_server(MockGoodNetwork)
+      {:ok, pid, port} = Helpers.start_server(MockGoodNetwork200)
+      on_exit(fn -> :inets.stop(:httpd, pid) end)
+
+      assert Engine.NetworkCheck.Hackney.check("http://localhost:#{port}/") == :ok
+    end
+
+    test "returns :ok on 204 response" do
+      {:ok, pid, port} = Helpers.start_server(MockGoodNetwork204)
       on_exit(fn -> :inets.stop(:httpd, pid) end)
 
       assert Engine.NetworkCheck.Hackney.check("http://localhost:#{port}/") == :ok


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** n/a

Noticed an email that our health checker, which tests for network connectivity was restarting the application. In the logs I saw it was because it was treating a `204` as a failure. I updated the check to consider anything in the `200-299` range successful.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
