### PR TITLE
Set http updater max send rate per sec to 8

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -15,7 +15,7 @@ defmodule PaEss.HttpUpdater do
           {:ok, :sent} | {:ok, :no_audio} | {:error, :bad_status} | {:error, :post_error}
 
   # Normally an anti-pattern! But we mix compile --force with every deploy
-  @max_send_rate_per_sec (32 / Application.get_env(:realtime_signs, :number_of_http_updaters))
+  @max_send_rate_per_sec (8/ Application.get_env(:realtime_signs, :number_of_http_updaters))
                          |> Float.ceil()
                          |> Kernel.trunc()
   @avg_ms_between_sends round(1000 / @max_send_rate_per_sec)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Run rate-limiting experiment in Dev](https://app.asana.com/0/1199570165415679/1201622027899197/f)

This PR is to set the maximum send rate for the http updaters to 8, a 75% reduction from the original 32.

The purpose of this is to experiment to see if a slower rate of messages yields a wider gap in between latency spikes from the ARINC headend server. This change will **only be applied in dev** and will never in prod. My intention is to let the change bake in dev for a work day or so and observe how the latencies are affected from Splunk.
