### PR TITLE
Add new glx stations

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -220,6 +220,7 @@ defmodule PaEss.Utilities do
   def headsign_to_destination("Southbound"), do: {:ok, :southbound}
   def headsign_to_destination("Eastbound"), do: {:ok, :eastbound}
   def headsign_to_destination("Westbound"), do: {:ok, :westbound}
+  def headsign_to_destination("Union Square"), do: {:ok, :union_square}
   def headsign_to_destination(_unknown), do: {:error, :unknown}
 
   @spec destination_to_sign_string(PaEss.destination()) :: String.t()
@@ -247,6 +248,7 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string(:southbound), do: "Southbound"
   def destination_to_sign_string(:eastbound), do: "Eastbound"
   def destination_to_sign_string(:westbound), do: "Westbound"
+  def destination_to_sign_string(:union_square), do: "Union Sq"
 
   @spec destination_to_ad_hoc_string(PaEss.destination()) ::
           {:ok, String.t()} | {:error, :unknown}
@@ -274,6 +276,7 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:southbound), do: {:ok, "Southbound"}
   def destination_to_ad_hoc_string(:eastbound), do: {:ok, "Eastbound"}
   def destination_to_ad_hoc_string(:westbound), do: {:ok, "Westbound"}
+  def destination_to_ad_hoc_string(:union_square), do: {:ok, "Union Square"}
   def destination_to_ad_hoc_string(_unknown), do: {:error, :unknown}
 
   @spec route_to_ad_hoc_string(String.t()) :: {:ok, String.t()} | {:error, :unknown}

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -193,6 +193,7 @@ defmodule PaEss.Utilities do
   def destination_var(:reservoir), do: {:ok, "4076"}
   def destination_var(:riverside), do: {:ok, "4084"}
   def destination_var(:heath_street), do: {:ok, "4204"}
+  def destination_var(:union_square), do: {:ok, "695"}
   def destination_var(_), do: {:error, :unknown}
 
   @spec headsign_to_destination(String.t()) :: {:ok, PaEss.destination()} | {:error, :unknown}

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6239,12 +6239,22 @@
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [],
     "type": "realtime",
     "source_config": [
       [
         {
           "stop_id": "70503",
+          "direction_id": 0,
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70504",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
           "routes": ["Green-E"],
@@ -6260,12 +6270,22 @@
     "id": "union_sq_west",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
-    "read_loop_offset": 90,
+    "read_loop_offset": 30,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": ["e", "w", "m"],
     "type": "realtime",
     "source_config": [
       [
+        {
+          "stop_id": "70503",
+          "direction_id": 0,
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        },
         {
           "stop_id": "70504",
           "direction_id": 0,
@@ -6283,9 +6303,9 @@
     "id": "union_sq_mezzanine",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
-    "read_loop_offset": 120,
+    "read_loop_offset": 30,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [],
     "type": "realtime",
     "source_config": [
       [

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6234,7 +6234,7 @@
     ]
   },
   {
-    "id": "union_sq_north",
+    "id": "union_sq_track_one",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,
@@ -6267,7 +6267,7 @@
     ]
   },
   {
-    "id": "union_sq_south",
+    "id": "union_sq_track_two",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 90,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6234,7 +6234,7 @@
     ]
   },
   {
-    "id": "union_sq_east",
+    "id": "union_sq_north",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,
@@ -6267,7 +6267,7 @@
     ]
   },
   {
-    "id": "union_sq_west",
+    "id": "union_sq_south",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6155,7 +6155,30 @@
     ]
   },
   {
-    "id": "lechmere_green_line",
+    "id": "lechmere_green_line_eastbound",
+    "headway_group": "green_trunk",
+    "pa_ess_loc": "GLEC",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": ["e"],
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70501",
+          "direction_id": 1,
+          "headway_direction_name": "Eastbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
+  },
+  {
+    "id": "lechmere_green_line_westbound",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 90,
@@ -6165,12 +6188,45 @@
     "source_config": [
       [
         {
-          "stop_id": "70210",
+          "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "headway_direction_name": "Westbound",
+          "routes": ["Green-D", "Green-E"],
           "platform": null,
-          "terminal": true,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
+  },
+  {
+    "id": "lechmere_green_line_mezzanine",
+    "headway_group": "green_trunk",
+    "pa_ess_loc": "GLEC",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": ["m"],
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70501",
+          "direction_id": 1,
+          "headway_direction_name": "Eastbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70502",
+          "direction_id": 0,
+          "headway_direction_name": "Westbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
           "announce_arriving": false,
           "announce_boarding": false
         }

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6227,7 +6227,7 @@
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
-          "announce_arriving": false,
+          "announce_arriving": true,
           "announce_boarding": false
         }
       ]

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6232,5 +6232,84 @@
         }
       ]
     ]
+  },
+  {
+    "id": "union_sq_eastbound",
+    "headway_group": "green_trunk",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 30,
+    "text_zone": "e",
+    "audio_zones": ["e"],
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70503",
+          "direction_id": 1,
+          "headway_direction_name": "Eastbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
+  },
+  {
+    "id": "union_sq_westbound",
+    "headway_group": "green_trunk",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 90,
+    "text_zone": "w",
+    "audio_zones": ["w"],
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70504",
+          "direction_id": 0,
+          "headway_direction_name": "Westbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
+  },
+  {
+    "id": "union_sq_mezzanine",
+    "headway_group": "green_trunk",
+    "pa_ess_loc": "GUNS",
+    "read_loop_offset": 120,
+    "text_zone": "m",
+    "audio_zones": ["m"],
+    "type": "realtime",
+    "source_config": [
+      [
+        {
+          "stop_id": "70503",
+          "direction_id": 1,
+          "headway_direction_name": "Eastbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70504",
+          "direction_id": 0,
+          "headway_direction_name": "Westbound",
+          "routes": ["Green-D", "Green-E"],
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
   }
 ]

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6270,9 +6270,9 @@
     "id": "union_sq_south",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
-    "read_loop_offset": 30,
+    "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["e", "w", "m"],
+    "audio_zones": [],
     "type": "realtime",
     "source_config": [
       [
@@ -6303,9 +6303,9 @@
     "id": "union_sq_mezzanine",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
-    "read_loop_offset": 30,
+    "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": [],
+    "audio_zones": ["e", "w", "m"],
     "type": "realtime",
     "source_config": [
       [

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6167,8 +6167,8 @@
         {
           "stop_id": "70501",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Union Square",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6190,8 +6190,8 @@
         {
           "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6213,8 +6213,8 @@
         {
           "stop_id": "70501",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Union Square",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6223,8 +6223,8 @@
         {
           "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6234,7 +6234,7 @@
     ]
   },
   {
-    "id": "union_sq_eastbound",
+    "id": "union_sq_east",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,
@@ -6245,9 +6245,9 @@
       [
         {
           "stop_id": "70503",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-D", "Green-E"],
+          "direction_id": 0,
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6257,7 +6257,7 @@
     ]
   },
   {
-    "id": "union_sq_westbound",
+    "id": "union_sq_west",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 90,
@@ -6269,8 +6269,8 @@
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6291,9 +6291,9 @@
       [
         {
           "stop_id": "70503",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": ["Green-D", "Green-E"],
+          "direction_id": 0,
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6302,8 +6302,8 @@
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": ["Green-D", "Green-E"],
+          "headway_direction_name": "Heath Street",
+          "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6171,7 +6171,7 @@
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
-          "announce_arriving": false,
+          "announce_arriving": true,
           "announce_boarding": false
         }
       ]
@@ -6194,7 +6194,7 @@
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
-          "announce_arriving": false,
+          "announce_arriving": true,
           "announce_boarding": false
         }
       ]
@@ -6217,7 +6217,7 @@
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
-          "announce_arriving": false,
+          "announce_arriving": true,
           "announce_boarding": false
         },
         {
@@ -6249,7 +6249,7 @@
           "headway_direction_name": "Heath Street",
           "routes": ["Green-E"],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -6272,7 +6272,7 @@
           "headway_direction_name": "Heath Street",
           "routes": ["Green-E"],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -6295,7 +6295,7 @@
           "headway_direction_name": "Heath Street",
           "routes": ["Green-E"],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": false
         },
@@ -6305,7 +6305,7 @@
           "headway_direction_name": "Heath Street",
           "routes": ["Green-E"],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": false
         }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Updates to realtime-signs](https://app.asana.com/0/1199504266721641/1200959142579185/f)

This PR adds source configs for the new Lechmere and Union Square stations. Also adds a new headsign name in `PaEss.Utilities` for Union Sq, which will only be used for Lechmere until the new stations open for revenue service.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
