### PR TITLE
Update Realtime Signs to log UTC time

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -49,7 +49,7 @@ config :ex_aws,
   access_key_id: [{:system, "SIGNS_S3_CONFIG_KEY"}, :instance_role],
   secret_access_key: [{:system, "SIGNS_S3_CONFIG_SECRET"}, :instance_role]
 
-config :logger, backends: [:console]
+config :logger, backends: [:console], utc_log: true
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Change Realtime Signs to log in UTC](https://app.asana.com/0/0/1201681770685699/f)

This change is so that the logger for Realtime Signs is configured to log UTC time rather than local time.

Before:
<img width="664" alt="Screen Shot 2022-01-20 at 6 05 37 PM" src="https://user-images.githubusercontent.com/16074540/150436265-7b9c9cb9-1d0e-4dba-9683-ba087479f8ef.png">

After:
<img width="671" alt="Screen Shot 2022-01-20 at 6 06 06 PM" src="https://user-images.githubusercontent.com/16074540/150436292-06fa7c1f-3835-447f-a104-5f51c63496ce.png">