### PR TITLE
chore: Update API dev-green URL

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,7 +41,7 @@ config :realtime_signs,
   s3_bucket: nil,
   s3_path: nil,
   api_v3_key: nil,
-  api_v3_url: "https://green.dev.api.mbtace.com",
+  api_v3_url: "https://api-dev-green.mbtace.com",
   number_of_http_updaters: 4,
   restart_fn: &Engine.Health.restart_noop/0
 

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -427,25 +427,25 @@ defmodule Fake.HTTPoison do
   end
 
   def mock_response(
-        "https://green.dev.api.mbtace.com/schedules?filter[stop]=500_error&filter[direction_id]=0,1"
+        "https://api-dev-green.mbtace.com/schedules?filter[stop]=500_error&filter[direction_id]=0,1"
       ) do
     {:ok, %HTTPoison.Response{status_code: 500, body: ""}}
   end
 
   def mock_response(
-        "https://green.dev.api.mbtace.com/schedules?filter[stop]=unknown_error&filter[direction_id]=0,1"
+        "https://api-dev-green.mbtace.com/schedules?filter[stop]=unknown_error&filter[direction_id]=0,1"
       ) do
     {:error, %HTTPoison.Error{reason: "Bad URL"}}
   end
 
   def mock_response(
-        "https://green.dev.api.mbtace.com/schedules?filter[stop]=parse_error&filter[direction_id]=0,1"
+        "https://api-dev-green.mbtace.com/schedules?filter[stop]=parse_error&filter[direction_id]=0,1"
       ) do
     {:ok, %HTTPoison.Response{status_code: 200, body: "BAD JSON"}}
   end
 
   def mock_response(
-        "https://green.dev.api.mbtace.com/schedules?filter[stop]=valid_json&filter[direction_id]=0,1"
+        "https://api-dev-green.mbtace.com/schedules?filter[stop]=valid_json&filter[direction_id]=0,1"
       ) do
     json = %{"data" => [%{"relationships" => "trip"}]}
     encoded = Jason.encode!(json)
@@ -456,13 +456,13 @@ defmodule Fake.HTTPoison do
     {:error, "unknown response"}
   end
 
-  def mock_response("https://green.dev.api.mbtace.com/schedules" <> _) do
+  def mock_response("https://api-dev-green.mbtace.com/schedules" <> _) do
     json = %{"data" => []}
     encoded = Jason.encode!(json)
     {:ok, %HTTPoison.Response{status_code: 200, body: encoded}}
   end
 
-  def mock_response("https://green.dev.api.mbtace.com/alerts") do
+  def mock_response("https://api-dev-green.mbtace.com/alerts") do
     response = %{
       "data" => [
         %{

--- a/test/headway/request_test.exs
+++ b/test/headway/request_test.exs
@@ -21,10 +21,10 @@ defmodule Headway.RequestTest do
   describe "build_request/1" do
     test "builds request with comma separated station ids and direction IDs" do
       assert build_request({~w[0 1], ["7022", "1123"]}) ==
-               "https://green.dev.api.mbtace.com/schedules?filter[stop]=7022,1123&filter[direction_id]=0,1"
+               "https://api-dev-green.mbtace.com/schedules?filter[stop]=7022,1123&filter[direction_id]=0,1"
 
       assert build_request({["1"], ["7022"]}) ==
-               "https://green.dev.api.mbtace.com/schedules?filter[stop]=7022&filter[direction_id]=1"
+               "https://api-dev-green.mbtace.com/schedules?filter[stop]=7022&filter[direction_id]=1"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** Part of [💳 terraform-ize API and move to ECS](https://app.asana.com/0/584764604969369/1200732284152245)

As part of the ECS migration, we're moving to a new URL: https://api-dev-green.mbtace.com from https://green.dev.api.mbtace.com. I did a search of CTD's repos and found the old URL hardcoded in a few places.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
