### PR TITLE
Add trains to union square audio

### DIFF
--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -48,6 +48,7 @@ defmodule Content.Audio.TrainIsArriving do
     defp audio_params(%{destination: :forest_hills}), do: {"103", ["32103"]}
     defp audio_params(%{destination: :oak_grove}), do: {"103", ["32102"]}
     defp audio_params(%{destination: :lechmere}), do: {"90016", []}
+    defp audio_params(%{destination: :union_square}), do: {"90019", []}
     defp audio_params(%{destination: :north_station}), do: {"90017", []}
     defp audio_params(%{destination: :government_center}), do: {"90015", []}
     defp audio_params(%{destination: :park_street}), do: {"90014", []}

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -144,6 +144,7 @@ defmodule Content.Audio.VehiclesToDestination do
     defp message_id(%{language: :english, destination: :forest_hills}), do: "176"
     defp message_id(%{language: :english, destination: :oak_grove}), do: "177"
     defp message_id(%{language: :english, destination: :lechmere}), do: "170"
+    defp message_id(%{language: :english, destination: :union_square}), do: "194"
     defp message_id(%{language: :english, destination: :north_station}), do: "169"
     defp message_id(%{language: :english, destination: :government_center}), do: "167"
     defp message_id(%{language: :english, destination: :park_street}), do: "168"

--- a/lib/pa_ess.ex
+++ b/lib/pa_ess.ex
@@ -24,6 +24,7 @@ defmodule PaEss do
           | :chelsea
           | :south_station
           | :lechmere
+          | :union_square
           | :north_station
           | :government_center
           | :park_street

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5221,7 +5221,7 @@
 	{
           "stop_id": "71150",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Eastbound",
           "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5221,7 +5221,7 @@
 	{
           "stop_id": "71150",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-B", "Green-C", "Green-D"],
           "platform": null,
           "terminal": false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update Realtime Signs with new Message Ids](https://app.asana.com/0/1185117109217413/1201759923497483/f)

This PR adds new message Ids for audio messages that will be triggered by Realtime Signs for the new Union Square Terminus.

The two messages being added to the code map to **"Trains to Union Square"** and **"The next train to Union Square is now Arriving"** and can be referenced in this excel sheet https://mbta.sharepoint.com/:x:/s/CTD/ERDhKqom2ZVFv-w83p8_ZMMBVUsEiZwiuq23LUOmhI0srA?e=bIoD0j



#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
