### PR TITLE
Update headways for glx revenue service

### DIFF
--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -47,7 +47,14 @@ defmodule Content.Audio.TrainIsBoarding do
     end
 
     defp do_to_params(%{destination: destination, route_id: "Green-" <> _branch}, destination_var)
-         when destination in [:lechmere, :north_station, :government_center, :park_st, :kenmore] do
+         when destination in [
+                :lechmere,
+                :north_station,
+                :government_center,
+                :park_st,
+                :kenmore,
+                :union_square
+              ] do
       vars = [
         @the_next,
         @train_to,

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -69,7 +69,7 @@ defmodule Content.Utilities do
   def destination_for_prediction("Green-B", 1, _), do: {:ok, :government_center}
   def destination_for_prediction("Green-C", 1, _), do: {:ok, :government_center}
   def destination_for_prediction("Green-D", 1, _), do: {:ok, :north_station}
-  def destination_for_prediction("Green-E", 1, _), do: {:ok, :north_station}
+  def destination_for_prediction("Green-E", 1, _), do: {:ok, :union_square}
 
   def destination_for_prediction(_, _, _), do: {:error, :not_found}
 

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -54,6 +54,7 @@ defmodule Content.Utilities do
 
   def destination_for_prediction(_, 1, "70209"), do: {:ok, :lechmere}
   def destination_for_prediction(_, 1, "70205"), do: {:ok, :north_station}
+  def destination_for_prediction(_, 1, "70503"), do: {:ok, :union_square}
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}
   def destination_for_prediction(_, 1, "70200"), do: {:ok, :park_street}
   def destination_for_prediction(_, 1, "71199"), do: {:ok, :park_street}

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -52,7 +52,6 @@ defmodule Content.Utilities do
   def destination_for_prediction(_, 0, "70161"), do: {:ok, :riverside}
   def destination_for_prediction(_, 0, "70260"), do: {:ok, :heath_street}
 
-  def destination_for_prediction(_, 1, "70209"), do: {:ok, :lechmere}
   def destination_for_prediction(_, 1, "70205"), do: {:ok, :north_station}
   def destination_for_prediction(_, 1, "70503"), do: {:ok, :union_square}
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -336,7 +336,14 @@ defmodule PaEss.Utilities do
   end
 
   def ad_hoc_trip_description(destination, route_id)
-      when destination in [:lechmere, :north_station, :government_center, :park_street, :kenmore] and
+      when destination in [
+             :lechmere,
+             :north_station,
+             :government_center,
+             :park_street,
+             :kenmore,
+             :union_square
+           ] and
              route_id in ["Green-B", "Green-C", "Green-D", "Green-E"] do
     ad_hoc_trip_description(destination)
   end

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6134,7 +6134,7 @@
         {
           "stop_id": "70207",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "platform": null,
           "terminal": false,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1024,7 +1024,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Oak Grove-01",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -1033,8 +1033,8 @@
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
-	},
-	{
+        },
+        {
           "stop_id": "Oak Grove-02",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -1068,7 +1068,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Oak Grove-01",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -1077,8 +1077,8 @@
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
-	},
-	{
+        },
+        {
           "stop_id": "Oak Grove-02",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -1112,7 +1112,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Oak Grove-01",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -1121,8 +1121,8 @@
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
-  },
-	{
+        },
+        {
           "stop_id": "Oak Grove-02",
           "routes": ["Orange"],
           "direction_id": 0,
@@ -2659,7 +2659,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Forest Hills-01",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2669,7 +2669,7 @@
           "announce_arriving": false,
           "announce_boarding": true
         },
-	{
+        {
           "stop_id": "Forest Hills-02",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2703,7 +2703,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Forest Hills-01",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2713,7 +2713,7 @@
           "announce_arriving": false,
           "announce_boarding": true
         },
-	{
+        {
           "stop_id": "Forest Hills-02",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2747,7 +2747,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Forest Hills-01",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2757,7 +2757,7 @@
           "announce_arriving": false,
           "announce_boarding": true
         },
-	{
+        {
           "stop_id": "Forest Hills-02",
           "routes": ["Orange"],
           "direction_id": 1,
@@ -2826,7 +2826,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Alewife-01",
           "routes": ["Red"],
           "direction_id": 0,
@@ -2835,8 +2835,8 @@
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
-	},
-	{
+        },
+        {
           "stop_id": "Alewife-02",
           "routes": ["Red"],
           "direction_id": 0,
@@ -2870,7 +2870,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Alewife-01",
           "routes": ["Red"],
           "direction_id": 0,
@@ -2879,8 +2879,8 @@
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
-	},
-	{
+        },
+        {
           "stop_id": "Alewife-02",
           "routes": ["Red"],
           "direction_id": 0,
@@ -4325,7 +4325,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Braintree-01",
           "routes": ["Red"],
           "direction_id": 1,
@@ -4335,7 +4335,7 @@
           "announce_arriving": false,
           "announce_boarding": true
         },
-	{
+        {
           "stop_id": "Braintree-02",
           "routes": ["Red"],
           "direction_id": 1,
@@ -4369,7 +4369,7 @@
           "announce_boarding": true,
           "source_for_headway": true
         },
-	{
+        {
           "stop_id": "Braintree-01",
           "routes": ["Red"],
           "direction_id": 1,
@@ -4379,7 +4379,7 @@
           "announce_arriving": false,
           "announce_boarding": true
         },
-	{
+        {
           "stop_id": "Braintree-02",
           "routes": ["Red"],
           "direction_id": 1,
@@ -5218,7 +5218,7 @@
     "type": "realtime",
     "source_config": [
       [
-	{
+        {
           "stop_id": "71150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
@@ -5241,7 +5241,7 @@
     "type": "realtime",
     "source_config": [
       [
-	{
+        {
           "stop_id": "71151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
@@ -5320,7 +5320,7 @@
           "announce_arriving": true,
           "announce_boarding": false
         },
-	{
+        {
           "stop_id": "71150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
@@ -5342,7 +5342,7 @@
           "announce_arriving": true,
           "announce_boarding": false
         },
-	{
+        {
           "stop_id": "71151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
@@ -5622,7 +5622,7 @@
         {
           "stop_id": "70242",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
@@ -5668,7 +5668,7 @@
         {
           "stop_id": "70240",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
@@ -5714,7 +5714,7 @@
         {
           "stop_id": "70240",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-E"],
           "platform": null,
           "terminal": false,
@@ -5746,7 +5746,7 @@
     "type": "realtime",
     "source_config": [
       [
-	{
+        {
           "stop_id": "71199",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
@@ -5756,7 +5756,7 @@
           "announce_arriving": true,
           "announce_boarding": false,
           "source_for_headway": true
-	},
+        },
         {
           "stop_id": "70200",
           "direction_id": 1,
@@ -5780,7 +5780,7 @@
     "type": "realtime",
     "source_config": [
       [
-	{
+        {
           "stop_id": "71199",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
@@ -5790,7 +5790,7 @@
           "announce_arriving": true,
           "announce_boarding": false,
           "source_for_headway": true
-	},
+        },
         {
           "stop_id": "70200",
           "direction_id": 1,
@@ -6019,7 +6019,7 @@
         {
           "stop_id": "70205",
           "direction_id": 1,
-          "headway_direction_name": "Lechmere",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "platform": null,
           "terminal": false,
@@ -6088,7 +6088,7 @@
         {
           "stop_id": "70207",
           "direction_id": 1,
-          "headway_direction_name": "Lechmere",
+          "headway_direction_name": "Union Square",
           "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "platform": null,
           "terminal": false,

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -9,6 +9,12 @@
     {"station": "G Government Center eastbound", "stop_ids": ["70201"]},
     {"station": "G Haymarket eastbound", "stop_ids": ["70203"]},
     {"station": "G North Station eastbound", "stop_ids": ["70205"]},
+    {"station": "G Science Park eastbound", "stop_ids": ["70207"]},
+    {"station": "G Lechmere eastbound", "stop_ids": ["70501"]},
+    {"station": "G Union Square eastbound", "stop_ids": ["70503"]},
+    {"station": "G Union Square westbound", "stop_ids": ["70504"]},
+    {"station": "G Lechmere westbound", "stop_ids": ["70502"]},
+    {"station": "G Science Park westbound", "stop_ids": ["70208"]},
     {"station": "G North Station westbound", "stop_ids": ["70206"]},
     {"station": "G Haymarket westbound", "stop_ids": ["70204"]},
     {"station": "G Government Center westbound", "stop_ids": ["70202"]},
@@ -22,18 +28,12 @@
   "Green-E-eastbound": [
     {"station": "G Symphony eastbound", "stop_ids": ["70242"]},
     {"station": "G Prudential eastbound", "stop_ids": ["70240"]},
-    {"station": "G Copley eastbound", "stop_ids": ["70154"]},
-    {"station": "G Science Park eastbound", "stop_ids": ["70207"]},
-    {"station": "G Lechmere eastbound", "stop_ids": ["70501"]},
-    {"station": "G Union Square eastbound", "stop_ids": ["70503"]}
+    {"station": "G Copley eastbound", "stop_ids": ["70154"]}
   ],
   "Green-E-westbound": [
     {"station": "G Symphony westbound", "stop_ids": ["70241"]},
     {"station": "G Prudential westbound", "stop_ids": ["70239"]},
-    {"station": "G Copley westbound", "stop_ids": ["70155"]},
-    {"station": "G Science Park westbound", "stop_ids": ["70208"]},
-    {"station": "G Lechmere westbound", "stop_ids": ["70502"]},
-    {"station": "G Union Square westbound", "stop_ids": ["70504"]}
+    {"station": "G Copley westbound", "stop_ids": ["70155"]}
   ],
   "Green-D": [
     {"station": "G Kenmore outbound", "stop_ids": ["70151"]},

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -9,10 +9,6 @@
     {"station": "G Government Center eastbound", "stop_ids": ["70201"]},
     {"station": "G Haymarket eastbound", "stop_ids": ["70203"]},
     {"station": "G North Station eastbound", "stop_ids": ["70205"]},
-    {"station": "G Science Park eastbound", "stop_ids": ["70207"]},
-    {"station": "G Lechmere eastbound", "stop_ids": ["70209"]},
-    {"station": "G Lechmere westbound", "stop_ids": ["70210"]},
-    {"station": "G Science Park westbound", "stop_ids": ["70208"]},
     {"station": "G North Station westbound", "stop_ids": ["70206"]},
     {"station": "G Haymarket westbound", "stop_ids": ["70204"]},
     {"station": "G Government Center westbound", "stop_ids": ["70202"]},
@@ -26,12 +22,18 @@
   "Green-E-eastbound": [
     {"station": "G Symphony eastbound", "stop_ids": ["70242"]},
     {"station": "G Prudential eastbound", "stop_ids": ["70240"]},
-    {"station": "G Copley eastbound", "stop_ids": ["70154"]}
+    {"station": "G Copley eastbound", "stop_ids": ["70154"]},
+    {"station": "G Science Park eastbound", "stop_ids": ["70207"]},
+    {"station": "G Lechmere eastbound", "stop_ids": ["70501"]},
+    {"station": "G Union Square eastbound", "stop_ids": ["70503"]}
   ],
   "Green-E-westbound": [
     {"station": "G Symphony westbound", "stop_ids": ["70241"]},
     {"station": "G Prudential westbound", "stop_ids": ["70239"]},
-    {"station": "G Copley westbound", "stop_ids": ["70155"]}
+    {"station": "G Copley westbound", "stop_ids": ["70155"]},
+    {"station": "G Science Park westbound", "stop_ids": ["70208"]},
+    {"station": "G Lechmere westbound", "stop_ids": ["70502"]},
+    {"station": "G Union Square westbound", "stop_ids": ["70504"]}
   ],
   "Green-D": [
     {"station": "G Kenmore outbound", "stop_ids": ["70151"]},

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -59,6 +59,7 @@ defmodule Content.Audio.UtilitiesTest do
     assert destination_var(:reservoir) == {:ok, "4076"}
     assert destination_var(:riverside) == {:ok, "4084"}
     assert destination_var(:wonderland) == {:ok, "4044"}
+    assert destination_var(:union_square) == {:ok, "695"}
   end
 
   test "headsign_to_destination/1" do
@@ -72,6 +73,7 @@ defmodule Content.Audio.UtilitiesTest do
     assert headsign_to_destination("Government Center") == {:ok, :government_center}
     assert headsign_to_destination("Heath Street") == {:ok, :heath_street}
     assert headsign_to_destination("Lechmere") == {:ok, :lechmere}
+    assert headsign_to_destination("Union Square") == {:ok, :union_square}
     assert headsign_to_destination("Mattapan") == {:ok, :mattapan}
     assert headsign_to_destination("North Station") == {:ok, :north_station}
     assert headsign_to_destination("Oak Grove") == {:ok, :oak_grove}


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update e-line with new headway directions to Union Square](https://app.asana.com/0/1185117109217413/1201714031001944/f)

This PR adds updates to the config and certain audio-related modules which will enable Union Square as a destination and headway direction on the E-Line for PA/ESS. This change shouldn't be deployed until revenue service is officially beginning, which is currently planned for March 21st, 2022.