### PR TITLE
Increase base expiration time by 20 seconds

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -98,7 +98,7 @@ defmodule Signs.Realtime do
       tick_top: 130,
       tick_audit: 60,
       tick_read: 240 + Map.fetch!(config, "read_loop_offset"),
-      expiration_seconds: 130,
+      expiration_seconds: 150,
       read_period_seconds: 240,
       headway_stop_id: Map.get(config, "headway_stop_id"),
       uses_shuttles: Map.get(config, "uses_shuttles", true)


### PR DESCRIPTION
#### Summary of changes
There have been reports of signs (namely GLX signs and Green Line consolidated signs) periodically missing either the top or bottom lines. This is extra odd because sometimes different signs in the same zone show different things. It _is_ possible for blank messages to be sent to signs under certain conditions, but the splunk logs show that Realtime Signs is, in fact, consistently sending messages with the expected content at a time interval that is less than the expiration time. 

The leading hypothesis is that a potential mixture of message posting lag and messages expiring is causing lines on the countdown clocks to periodically be blank. As a short-term fix, we can try extending the timeout to see if that helps signs continue showing the right content without periods of missing data.
