### PR TITLE
Use Elixir 1.12

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 22.3.4
-elixir v1.10.3-otp-22
+elixir v1.12.3-otp-22

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -22,8 +22,8 @@ defmodule Engine.Config do
   @table_signs :config_engine_signs
   @table_headways :config_engine_headways
 
-  def start_link(name \\ __MODULE__) do
-    GenServer.start_link(__MODULE__, [], name: name)
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   @spec sign_config(:ets.tab(), String.t()) :: sign_config()

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -19,7 +19,8 @@ defmodule Engine.Predictions do
 
   @trip_updates_table :trip_updates
 
-  def start_link do
+  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link([]) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/engine/static.ex
+++ b/lib/engine/static.ex
@@ -1,8 +1,8 @@
 defmodule Engine.Static do
   use GenServer
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [])
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
   end
 
   def init([]) do

--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -24,7 +24,7 @@ defmodule MessageQueue do
   use GenServer
   require Logger
 
-  def start_link do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -15,18 +15,18 @@ defmodule RealtimeSigns do
       [
         :hackney_pool.child_spec(:default, []),
         :hackney_pool.child_spec(:arinc_pool, []),
-        worker(Engine.Health, []),
-        worker(Engine.Config, []),
-        worker(Engine.Predictions, []),
-        worker(Engine.ScheduledHeadways, []),
-        worker(Engine.Departures, []),
-        worker(Engine.Static, []),
-        worker(Engine.Alerts, []),
-        worker(MessageQueue, [])
+        Engine.Health,
+        Engine.Config,
+        Engine.Predictions,
+        Engine.ScheduledHeadways,
+        Engine.Departures,
+        Engine.Static,
+        Engine.Alerts,
+        MessageQueue
       ] ++
         http_updater_children() ++
         [
-          supervisor(Signs.Supervisor, [])
+          Signs.Supervisor
         ]
 
     opts = [strategy: :one_for_one, name: __MODULE__]

--- a/lib/signs/supervisor.ex
+++ b/lib/signs/supervisor.ex
@@ -19,9 +19,15 @@ defmodule Signs.Supervisor do
   weird cases?)
   """
   require Signs.Utilities.SignsConfig
+  use Supervisor
 
-  def start_link do
-    Supervisor.start_link(children(), name: __MODULE__, strategy: :one_for_one)
+  def start_link([]) do
+    Supervisor.start_link(__MODULE__, name: __MODULE__, strategy: :one_for_one)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    Supervisor.init(children(), strategy: :one_for_one)
   end
 
   defp children() do


### PR DESCRIPTION
Upgrade Realtime Signs to use Elixir 1.12 so that we can use Quantum to set up a CRON job. Elixir 1.11 included deprecations for ways to specify children processes under a Supervisor so there are some needed code changes here to address those.

The CRON job mentioned will be used to download and store log files that we get from ARINC as part of the effort to improve monitoring of the PA/ESS system.
