### PR TITLE
update build_release script to use elixir 1.12

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -10,7 +10,7 @@ if [ $# -eq 0 ]; then
 fi
 
 ERL_DIR="erl10.7" # erlang/otp 22.3
-ELIXIR_DIR="elixir1.10.3"
+ELIXIR_DIR="elixir1.12.3"
 
 rm -rf _build-prev
 test -e "_build" && mv _build _build-prev


### PR DESCRIPTION
The script used to build the release must also be updated to use Elixir 1.12

Fortunately, Elixir 1.12.3 is already present on opstech3 so we won't need to download it and put it there ourselves.
![Screen Shot 2022-06-08 at 4 29 48 PM](https://user-images.githubusercontent.com/16074540/172711360-198ae956-9268-479d-8089-f90f156e432c.png)

