### PR TITLE
Switch D and C berthing positions

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6,12 +6,16 @@
     "pa_ess_loc": "MCED",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70263",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -29,12 +33,16 @@
     "pa_ess_loc": "MCED",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70264",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -52,12 +60,16 @@
     "pa_ess_loc": "MBUT",
     "read_loop_offset": 150,
     "text_zone": "c",
-    "audio_zones": ["c"],
+    "audio_zones": [
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70266",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -69,7 +81,9 @@
       [
         {
           "stop_id": "70265",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -87,12 +101,16 @@
     "pa_ess_loc": "MMIL",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70267",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -110,12 +128,16 @@
     "pa_ess_loc": "MMIL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70268",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -133,12 +155,16 @@
     "pa_ess_loc": "MCEN",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70269",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -156,12 +182,16 @@
     "pa_ess_loc": "MCEN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70270",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -179,12 +209,16 @@
     "pa_ess_loc": "MVAL",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70271",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Mattapan",
           "platform": null,
@@ -202,12 +236,16 @@
     "pa_ess_loc": "MVAL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70272",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -225,12 +263,16 @@
     "pa_ess_loc": "MCAP",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70274",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -248,12 +290,16 @@
     "pa_ess_loc": "BWON",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70059",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -271,12 +317,16 @@
     "pa_ess_loc": "BWON",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70059",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -294,12 +344,16 @@
     "pa_ess_loc": "BREV",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70058",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -317,12 +371,16 @@
     "pa_ess_loc": "BREV",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70058",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -334,7 +392,9 @@
       [
         {
           "stop_id": "70057",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -352,12 +412,16 @@
     "pa_ess_loc": "BREV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70057",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -375,12 +439,16 @@
     "pa_ess_loc": "BBEA",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70056",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -398,12 +466,16 @@
     "pa_ess_loc": "BBEA",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70055",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -421,12 +493,16 @@
     "pa_ess_loc": "BSUF",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70054",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -444,12 +520,16 @@
     "pa_ess_loc": "BSUF",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70053",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -467,12 +547,16 @@
     "pa_ess_loc": "BORH",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70052",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -490,12 +574,16 @@
     "pa_ess_loc": "BORH",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70052",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -507,7 +595,9 @@
       [
         {
           "stop_id": "70051",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -525,12 +615,16 @@
     "pa_ess_loc": "BORH",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70051",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -548,12 +642,16 @@
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70050",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -571,12 +669,16 @@
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70050",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -588,7 +690,9 @@
       [
         {
           "stop_id": "70049",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -606,12 +710,16 @@
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70049",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -629,12 +737,16 @@
     "pa_ess_loc": "BAIR",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70048",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -652,12 +764,16 @@
     "pa_ess_loc": "BAIR",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70047",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -675,12 +791,16 @@
     "pa_ess_loc": "BMAV",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70046",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -698,12 +818,16 @@
     "pa_ess_loc": "BMAV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70045",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -721,12 +845,16 @@
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70044",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -744,12 +872,16 @@
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70044",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -761,7 +893,9 @@
       [
         {
           "stop_id": "70043",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -779,12 +913,16 @@
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70043",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -802,12 +940,16 @@
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70042",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -825,12 +967,16 @@
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70042",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -842,7 +988,9 @@
       [
         {
           "stop_id": "70041",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -860,12 +1008,16 @@
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70041",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -883,12 +1035,16 @@
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70040",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -906,12 +1062,16 @@
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70040",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -923,7 +1083,9 @@
       [
         {
           "stop_id": "70039",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -941,12 +1103,16 @@
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70039",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Bowdoin",
           "platform": null,
@@ -964,12 +1130,16 @@
     "pa_ess_loc": "BBOW",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70038",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -987,12 +1157,16 @@
     "pa_ess_loc": "BBOW",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70038",
-          "routes": ["Blue"],
+          "routes": [
+            "Blue"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Wonderland",
           "platform": null,
@@ -1010,12 +1184,16 @@
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70036",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1026,7 +1204,9 @@
         },
         {
           "stop_id": "Oak Grove-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1036,7 +1216,9 @@
         },
         {
           "stop_id": "Oak Grove-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1054,12 +1236,16 @@
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70036",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1070,7 +1256,9 @@
         },
         {
           "stop_id": "Oak Grove-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1080,7 +1268,9 @@
         },
         {
           "stop_id": "Oak Grove-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1098,12 +1288,16 @@
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70036",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1114,7 +1308,9 @@
         },
         {
           "stop_id": "Oak Grove-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1124,7 +1320,9 @@
         },
         {
           "stop_id": "Oak Grove-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1142,12 +1340,16 @@
     "pa_ess_loc": "OMAL",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70035",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1159,7 +1361,9 @@
       [
         {
           "stop_id": "70034",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1177,12 +1381,16 @@
     "pa_ess_loc": "OMAL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70035",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1194,7 +1402,9 @@
       [
         {
           "stop_id": "70034",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1212,12 +1422,16 @@
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70033",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1229,7 +1443,9 @@
       [
         {
           "stop_id": "70032",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1247,12 +1463,16 @@
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70033",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1270,12 +1490,16 @@
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70032",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1285,7 +1509,9 @@
         },
         {
           "stop_id": "70032",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1303,12 +1529,16 @@
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70279",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1320,7 +1550,9 @@
       [
         {
           "stop_id": "70278",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1338,12 +1570,16 @@
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70279",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1361,12 +1597,16 @@
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70278",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1384,12 +1624,16 @@
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70031",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1401,7 +1645,9 @@
       [
         {
           "stop_id": "70030",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1419,12 +1665,16 @@
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70031",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1442,12 +1692,16 @@
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70030",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1465,12 +1719,16 @@
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70029",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1482,7 +1740,9 @@
       [
         {
           "stop_id": "70028",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1500,12 +1760,16 @@
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70029",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1523,12 +1787,16 @@
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70028",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1546,12 +1814,16 @@
     "pa_ess_loc": "ONST",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70027",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1569,12 +1841,16 @@
     "pa_ess_loc": "ONST",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70026",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1592,12 +1868,16 @@
     "pa_ess_loc": "ONST",
     "read_loop_offset": 150,
     "text_zone": "c",
-    "audio_zones": ["c"],
+    "audio_zones": [
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70027",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1609,7 +1889,9 @@
       [
         {
           "stop_id": "70026",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1627,12 +1909,16 @@
     "pa_ess_loc": "ONST",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70027",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1644,7 +1930,9 @@
       [
         {
           "stop_id": "70026",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1662,12 +1950,16 @@
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70025",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1679,7 +1971,9 @@
       [
         {
           "stop_id": "70024",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1697,12 +1991,16 @@
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70025",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1720,12 +2018,16 @@
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70024",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1743,12 +2045,16 @@
     "pa_ess_loc": "OSTN",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70023",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1760,7 +2066,9 @@
       [
         {
           "stop_id": "70022",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1778,12 +2086,16 @@
     "pa_ess_loc": "OSTN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70023",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1801,12 +2113,16 @@
     "pa_ess_loc": "OSTS",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70022",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1824,12 +2140,16 @@
     "pa_ess_loc": "ODTN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70021",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1847,12 +2167,16 @@
     "pa_ess_loc": "ODTS",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70020",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1870,12 +2194,16 @@
     "pa_ess_loc": "OCHN",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70019",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1893,12 +2221,16 @@
     "pa_ess_loc": "OCHS",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70018",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1916,12 +2248,16 @@
     "pa_ess_loc": "OCHN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70019",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1939,12 +2275,16 @@
     "pa_ess_loc": "OCHS",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70018",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1962,12 +2302,16 @@
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70017",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -1979,7 +2323,9 @@
       [
         {
           "stop_id": "70016",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -1997,12 +2343,16 @@
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70017",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2020,12 +2370,16 @@
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70016",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2043,12 +2397,16 @@
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70015",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2060,7 +2418,9 @@
       [
         {
           "stop_id": "70014",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2078,12 +2438,16 @@
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70015",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2101,12 +2465,16 @@
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70014",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2124,12 +2492,16 @@
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70013",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2141,7 +2513,9 @@
       [
         {
           "stop_id": "70012",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2159,12 +2533,16 @@
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70013",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2182,12 +2560,16 @@
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70012",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2205,12 +2587,16 @@
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70011",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2228,12 +2614,16 @@
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70010",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2251,12 +2641,16 @@
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 150,
     "text_zone": "c",
-    "audio_zones": ["c"],
+    "audio_zones": [
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70011",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2268,7 +2662,9 @@
       [
         {
           "stop_id": "70010",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2286,12 +2682,16 @@
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70011",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2303,7 +2703,9 @@
       [
         {
           "stop_id": "70010",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2321,12 +2723,16 @@
     "pa_ess_loc": "OROX",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70009",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2338,7 +2744,9 @@
       [
         {
           "stop_id": "70008",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2356,12 +2764,16 @@
     "pa_ess_loc": "OROX",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70009",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2379,12 +2791,16 @@
     "pa_ess_loc": "OROX",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70008",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2402,12 +2818,16 @@
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70007",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2419,7 +2839,9 @@
       [
         {
           "stop_id": "70006",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2437,12 +2859,16 @@
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70007",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2460,12 +2886,16 @@
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70006",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2483,12 +2913,16 @@
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70005",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2500,7 +2934,9 @@
       [
         {
           "stop_id": "70004",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2518,12 +2954,16 @@
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70005",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2541,12 +2981,16 @@
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70004",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2564,12 +3008,16 @@
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70003",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2581,7 +3029,9 @@
       [
         {
           "stop_id": "70002",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2599,12 +3049,16 @@
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70003",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2622,12 +3076,16 @@
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70002",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2645,12 +3103,16 @@
     "pa_ess_loc": "OFOR",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70001",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2661,7 +3123,9 @@
         },
         {
           "stop_id": "Forest Hills-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2671,7 +3135,9 @@
         },
         {
           "stop_id": "Forest Hills-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2689,12 +3155,16 @@
     "pa_ess_loc": "OFOR",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70001",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2705,7 +3175,9 @@
         },
         {
           "stop_id": "Forest Hills-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2715,7 +3187,9 @@
         },
         {
           "stop_id": "Forest Hills-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2733,12 +3207,16 @@
     "pa_ess_loc": "SFOR",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70001",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2749,7 +3227,9 @@
         },
         {
           "stop_id": "Forest Hills-01",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2759,7 +3239,9 @@
         },
         {
           "stop_id": "Forest Hills-02",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2777,12 +3259,16 @@
     "pa_ess_loc": "SRUG",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70011",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Forest Hills",
           "platform": null,
@@ -2794,7 +3280,9 @@
       [
         {
           "stop_id": "70010",
-          "routes": ["Orange"],
+          "routes": [
+            "Orange"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Oak Grove",
           "platform": null,
@@ -2812,12 +3300,16 @@
     "pa_ess_loc": "RALE",
     "read_loop_offset": 150,
     "text_zone": "c",
-    "audio_zones": ["c"],
+    "audio_zones": [
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70061",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2828,7 +3320,9 @@
         },
         {
           "stop_id": "Alewife-01",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2838,7 +3332,9 @@
         },
         {
           "stop_id": "Alewife-02",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2856,12 +3352,16 @@
     "pa_ess_loc": "RALE",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70061",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2872,7 +3372,9 @@
         },
         {
           "stop_id": "Alewife-01",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2882,7 +3384,9 @@
         },
         {
           "stop_id": "Alewife-02",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2900,12 +3404,16 @@
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70064",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -2917,7 +3425,9 @@
       [
         {
           "stop_id": "70063",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2935,12 +3445,16 @@
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70064",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -2958,12 +3472,16 @@
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70063",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -2981,12 +3499,16 @@
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70066",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -2998,7 +3520,9 @@
       [
         {
           "stop_id": "70065",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3016,12 +3540,16 @@
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70066",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3039,12 +3567,16 @@
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70065",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3062,12 +3594,16 @@
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70068",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3079,7 +3615,9 @@
       [
         {
           "stop_id": "70067",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3097,12 +3635,16 @@
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70068",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3120,12 +3662,16 @@
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70067",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3143,12 +3689,16 @@
     "pa_ess_loc": "RCEN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70070",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3166,12 +3716,16 @@
     "pa_ess_loc": "RCEN",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70069",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3189,12 +3743,16 @@
     "pa_ess_loc": "RKEN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70072",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3212,12 +3770,16 @@
     "pa_ess_loc": "RKEN",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70071",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3235,12 +3797,16 @@
     "pa_ess_loc": "RMGH",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70074",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3258,12 +3824,16 @@
     "pa_ess_loc": "RMGH",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70073",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3281,12 +3851,17 @@
     "pa_ess_loc": "RPRK",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n", "c"],
+    "audio_zones": [
+      "n",
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70076",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3304,12 +3879,17 @@
     "pa_ess_loc": "RPRK",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s", "c"],
+    "audio_zones": [
+      "s",
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70075",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3332,7 +3912,9 @@
       [
         {
           "stop_id": "70076",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3344,7 +3926,9 @@
       [
         {
           "stop_id": "70075",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3362,12 +3946,16 @@
     "pa_ess_loc": "RDTC",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70078",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3385,12 +3973,16 @@
     "pa_ess_loc": "RDTC",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70077",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3408,12 +4000,16 @@
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70080",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3425,7 +4021,9 @@
       [
         {
           "stop_id": "70079",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3443,12 +4041,16 @@
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70080",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3466,12 +4068,16 @@
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70079",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3489,12 +4095,16 @@
     "pa_ess_loc": "SSOU",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70080",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3506,7 +4116,9 @@
       [
         {
           "stop_id": "70079",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3524,12 +4136,16 @@
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70082",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3541,7 +4157,9 @@
       [
         {
           "stop_id": "70081",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3559,12 +4177,16 @@
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70082",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3582,12 +4204,16 @@
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70081",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3605,12 +4231,16 @@
     "pa_ess_loc": "RAND",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70084",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3622,7 +4252,9 @@
       [
         {
           "stop_id": "70083",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3640,12 +4272,16 @@
     "pa_ess_loc": "RAND",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70084",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3663,12 +4299,16 @@
     "pa_ess_loc": "RAND",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70083",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Southbound",
           "platform": null,
@@ -3686,12 +4326,16 @@
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70088",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3703,7 +4347,9 @@
       [
         {
           "stop_id": "70087",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3721,12 +4367,16 @@
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70088",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3744,12 +4394,16 @@
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70087",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3767,12 +4421,16 @@
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70090",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3784,7 +4442,9 @@
       [
         {
           "stop_id": "70089",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3802,12 +4462,16 @@
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70090",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3825,12 +4489,16 @@
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70089",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3848,12 +4516,16 @@
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70092",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3865,7 +4537,9 @@
       [
         {
           "stop_id": "70091",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3883,12 +4557,16 @@
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70092",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3906,12 +4584,16 @@
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70091",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -3929,12 +4611,16 @@
     "pa_ess_loc": "RASH",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70094",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3946,7 +4632,9 @@
       [
         {
           "stop_id": "70261",
-          "routes": ["Mattapan"],
+          "routes": [
+            "Mattapan"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3964,12 +4652,16 @@
     "pa_ess_loc": "RASH",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70094",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -3987,12 +4679,16 @@
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70098",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4004,7 +4700,9 @@
       [
         {
           "stop_id": "70097",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4022,12 +4720,16 @@
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70098",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4045,12 +4747,16 @@
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70097",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4068,12 +4774,16 @@
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70100",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4085,7 +4795,9 @@
       [
         {
           "stop_id": "70099",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4103,12 +4815,16 @@
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70100",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4126,12 +4842,16 @@
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70099",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4149,12 +4869,16 @@
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70102",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4166,7 +4890,9 @@
       [
         {
           "stop_id": "70101",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4184,12 +4910,16 @@
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70102",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4207,12 +4937,16 @@
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70101",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4230,12 +4964,16 @@
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70104",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4247,7 +4985,9 @@
       [
         {
           "stop_id": "70103",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4265,12 +5005,16 @@
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70104",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4288,12 +5032,16 @@
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70103",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4311,12 +5059,16 @@
     "pa_ess_loc": "RBRA",
     "read_loop_offset": 150,
     "text_zone": "c",
-    "audio_zones": ["c"],
+    "audio_zones": [
+      "c"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70105",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4327,7 +5079,9 @@
         },
         {
           "stop_id": "Braintree-01",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4337,7 +5091,9 @@
         },
         {
           "stop_id": "Braintree-02",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4355,12 +5111,16 @@
     "pa_ess_loc": "RBRA",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70105",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4371,7 +5131,9 @@
         },
         {
           "stop_id": "Braintree-01",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4381,7 +5143,9 @@
         },
         {
           "stop_id": "Braintree-02",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": null,
@@ -4399,12 +5163,16 @@
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70085",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Ashmont",
           "platform": null,
@@ -4422,12 +5190,16 @@
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70095",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 0,
           "headway_direction_name": "Braintree",
           "platform": null,
@@ -4445,12 +5217,16 @@
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70086",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": "ashmont",
@@ -4468,12 +5244,16 @@
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70096",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": "braintree",
@@ -4491,12 +5271,16 @@
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "source_config": [
       [
         {
           "stop_id": "70086",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "direction_id": 1,
           "headway_direction_name": "Alewife",
           "platform": "ashmont",
@@ -4508,7 +5292,9 @@
           "stop_id": "70096",
           "direction_id": 1,
           "headway_direction_name": "Alewife",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "platform": "braintree",
           "terminal": false,
           "announce_arriving": true,
@@ -4520,7 +5306,9 @@
           "stop_id": "70085",
           "direction_id": 0,
           "headway_direction_name": "Southbound",
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4532,7 +5320,9 @@
           "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
-          "routes": ["Red"],
+          "routes": [
+            "Red"
+          ],
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4545,7 +5335,9 @@
     "pa_ess_loc": "GRIV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4553,7 +5345,9 @@
           "stop_id": "70160",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -4568,7 +5362,9 @@
     "pa_ess_loc": "GWOO",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4576,7 +5372,9 @@
           "stop_id": "70162",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4591,7 +5389,9 @@
     "pa_ess_loc": "GWOO",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4599,7 +5399,9 @@
           "stop_id": "70163",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4614,7 +5416,9 @@
     "pa_ess_loc": "GWAB",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4622,7 +5426,9 @@
           "stop_id": "70164",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4637,7 +5443,9 @@
     "pa_ess_loc": "GWAB",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4645,7 +5453,9 @@
           "stop_id": "70165",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4660,7 +5470,9 @@
     "pa_ess_loc": "GELI",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4668,7 +5480,9 @@
           "stop_id": "70166",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4683,7 +5497,9 @@
     "pa_ess_loc": "GELI",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4691,7 +5507,9 @@
           "stop_id": "70167",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4706,7 +5524,9 @@
     "pa_ess_loc": "GNEH",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4714,7 +5534,9 @@
           "stop_id": "70168",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4729,7 +5551,9 @@
     "pa_ess_loc": "GNEH",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4737,7 +5561,9 @@
           "stop_id": "70169",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4752,7 +5578,9 @@
     "pa_ess_loc": "GNEC",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4760,7 +5588,9 @@
           "stop_id": "70170",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4775,7 +5605,9 @@
     "pa_ess_loc": "GNEC",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4783,7 +5615,9 @@
           "stop_id": "70171",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4798,7 +5632,9 @@
     "pa_ess_loc": "GCHE",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4806,7 +5642,9 @@
           "stop_id": "70172",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4821,7 +5659,9 @@
     "pa_ess_loc": "GCHE",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4829,7 +5669,9 @@
           "stop_id": "70173",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4844,7 +5686,9 @@
     "pa_ess_loc": "GRES",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4852,7 +5696,9 @@
           "stop_id": "70174",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4867,7 +5713,9 @@
     "pa_ess_loc": "GRES",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4875,7 +5723,9 @@
           "stop_id": "70175",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4890,7 +5740,9 @@
     "pa_ess_loc": "GBEA",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "uses_shuttles": false,
     "source_config": [
@@ -4899,7 +5751,9 @@
           "stop_id": "70176",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4914,7 +5768,9 @@
     "pa_ess_loc": "GBEA",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "uses_shuttles": false,
     "source_config": [
@@ -4923,7 +5779,9 @@
           "stop_id": "70177",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4938,7 +5796,9 @@
     "pa_ess_loc": "GBRH",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4946,7 +5806,9 @@
           "stop_id": "70178",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4961,7 +5823,9 @@
     "pa_ess_loc": "GBRH",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4969,7 +5833,9 @@
           "stop_id": "70179",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -4984,7 +5850,9 @@
     "pa_ess_loc": "GBRV",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -4992,7 +5860,9 @@
           "stop_id": "70180",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5007,7 +5877,9 @@
     "pa_ess_loc": "GBRV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5015,7 +5887,9 @@
           "stop_id": "70181",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5030,7 +5904,9 @@
     "pa_ess_loc": "GLON",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5038,7 +5914,9 @@
           "stop_id": "70182",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5053,7 +5931,9 @@
     "pa_ess_loc": "GLON",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5061,7 +5941,9 @@
           "stop_id": "70183",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5076,7 +5958,9 @@
     "pa_ess_loc": "GFEN",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5084,7 +5968,9 @@
           "stop_id": "70186",
           "direction_id": 1,
           "headway_direction_name": "North Station",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5099,7 +5985,9 @@
     "pa_ess_loc": "GFEN",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5107,7 +5995,9 @@
           "stop_id": "70187",
           "direction_id": 0,
           "headway_direction_name": "Riverside",
-          "routes": ["Green-D"],
+          "routes": [
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5122,7 +6012,9 @@
     "pa_ess_loc": "GBAB",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5130,7 +6022,9 @@
           "stop_id": "170136",
           "direction_id": 1,
           "headway_direction_name": "Government Center",
-          "routes": ["Green-B"],
+          "routes": [
+            "Green-B"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5145,7 +6039,9 @@
     "pa_ess_loc": "GBAB",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5153,7 +6049,9 @@
           "stop_id": "170137",
           "direction_id": 0,
           "headway_direction_name": "Boston College",
-          "routes": ["Green-B"],
+          "routes": [
+            "Green-B"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5168,7 +6066,9 @@
     "pa_ess_loc": "GAMO",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5176,7 +6076,9 @@
           "stop_id": "170140",
           "direction_id": 1,
           "headway_direction_name": "Government Center",
-          "routes": ["Green-B"],
+          "routes": [
+            "Green-B"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5191,7 +6093,9 @@
     "pa_ess_loc": "GAMO",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5199,7 +6103,9 @@
           "stop_id": "170141",
           "direction_id": 0,
           "headway_direction_name": "Boston College",
-          "routes": ["Green-B"],
+          "routes": [
+            "Green-B"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5214,7 +6120,9 @@
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5222,7 +6130,11 @@
           "stop_id": "71150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5237,7 +6149,9 @@
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5245,7 +6159,11 @@
           "stop_id": "71151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5260,7 +6178,9 @@
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5268,7 +6188,11 @@
           "stop_id": "70150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5283,7 +6207,9 @@
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 60,
     "text_zone": "s",
-    "audio_zones": ["s"],
+    "audio_zones": [
+      "s"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5291,7 +6217,11 @@
           "stop_id": "70151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5306,7 +6236,9 @@
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5314,7 +6246,12 @@
           "stop_id": "70150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5324,7 +6261,12 @@
           "stop_id": "71150",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5336,7 +6278,12 @@
           "stop_id": "70151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5346,7 +6293,12 @@
           "stop_id": "71151",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5361,7 +6313,9 @@
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5369,7 +6323,11 @@
           "stop_id": "70152",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5384,7 +6342,9 @@
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5392,7 +6352,11 @@
           "stop_id": "70153",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5407,7 +6371,9 @@
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5415,7 +6381,11 @@
           "stop_id": "70152",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5427,7 +6397,11 @@
           "stop_id": "70153",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5442,7 +6416,9 @@
     "pa_ess_loc": "GCOP",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5450,7 +6426,12 @@
           "stop_id": "70154",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5465,7 +6446,9 @@
     "pa_ess_loc": "GCOP",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5473,7 +6456,12 @@
           "stop_id": "70155",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5488,7 +6476,9 @@
     "pa_ess_loc": "GARL",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5496,7 +6486,12 @@
           "stop_id": "70156",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5511,7 +6506,9 @@
     "pa_ess_loc": "GARL",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5519,7 +6516,12 @@
           "stop_id": "70157",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5534,7 +6536,9 @@
     "pa_ess_loc": "GARL",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5542,7 +6546,12 @@
           "stop_id": "70156",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5554,7 +6563,12 @@
           "stop_id": "70157",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5569,7 +6583,9 @@
     "pa_ess_loc": "GBOY",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5577,7 +6593,12 @@
           "stop_id": "70158",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5592,7 +6613,9 @@
     "pa_ess_loc": "GBOY",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5600,7 +6623,12 @@
           "stop_id": "70159",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5615,7 +6643,9 @@
     "pa_ess_loc": "GSYM",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5623,7 +6653,9 @@
           "stop_id": "70242",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5638,7 +6670,9 @@
     "pa_ess_loc": "GSYM",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5646,7 +6680,9 @@
           "stop_id": "70241",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5661,7 +6697,9 @@
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5669,7 +6707,9 @@
           "stop_id": "70240",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5684,7 +6724,9 @@
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5692,7 +6734,9 @@
           "stop_id": "70239",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5707,7 +6751,9 @@
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5715,7 +6761,9 @@
           "stop_id": "70240",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5727,7 +6775,9 @@
           "stop_id": "70239",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5742,7 +6792,9 @@
     "pa_ess_loc": "GPRKE",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5750,7 +6802,12 @@
           "stop_id": "71199",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5761,7 +6818,12 @@
           "stop_id": "70200",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5776,7 +6838,9 @@
     "pa_ess_loc": "GPRKE",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5784,7 +6848,12 @@
           "stop_id": "71199",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5795,7 +6864,12 @@
           "stop_id": "70200",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5810,28 +6884,39 @@
     "pa_ess_loc": "GPRKW",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
         {
-          "stop_id": "70197",
+          "stop_id": "70198",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "platform": null,
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true,
-          "multi_berth": true,
-          "source_for_headway": true
+          "multi_berth": true
         },
         {
           "stop_id": "70199",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
           "platform": null,
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true,
@@ -5846,7 +6931,9 @@
     "pa_ess_loc": "GPRKW",
     "read_loop_offset": 0,
     "text_zone": "n",
-    "audio_zones": ["n"],
+    "audio_zones": [
+      "n"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5854,7 +6941,12 @@
           "stop_id": "70196",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -5863,27 +6955,34 @@
           "source_for_headway": true
         },
         {
-          "stop_id": "70198",
+          "stop_id": "70197",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true,
-          "multi_berth": true
+          "multi_berth": true,
+          "source_for_headway": true
         }
       ]
     ]
   },
-
   {
     "id": "green_government_center_eastbound",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5891,7 +6990,12 @@
           "stop_id": "70201",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -5906,7 +7010,9 @@
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5914,7 +7020,12 @@
           "stop_id": "70202",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -5929,7 +7040,9 @@
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5937,7 +7050,12 @@
           "stop_id": "70201",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5949,7 +7067,12 @@
           "stop_id": "70202",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5958,14 +7081,15 @@
       ]
     ]
   },
-
   {
     "id": "green_haymarket_eastbound",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GHAY",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5973,7 +7097,12 @@
           "stop_id": "70203",
           "direction_id": 1,
           "headway_direction_name": "Eastbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -5988,7 +7117,9 @@
     "pa_ess_loc": "GHAY",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -5996,7 +7127,12 @@
           "stop_id": "70204",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6005,14 +7141,15 @@
       ]
     ]
   },
-
   {
     "id": "green_north_station_eastbound",
     "headway_group": "green_trunk",
     "pa_ess_loc": "GNST",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6020,7 +7157,12 @@
           "stop_id": "70205",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6035,7 +7177,9 @@
     "pa_ess_loc": "GNST",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6043,7 +7187,12 @@
           "stop_id": "70206",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6058,7 +7207,9 @@
     "pa_ess_loc": "GNST",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6066,7 +7217,12 @@
           "stop_id": "70206",
           "direction_id": 0,
           "headway_direction_name": "Westbound",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
@@ -6081,7 +7237,9 @@
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6089,7 +7247,12 @@
           "stop_id": "70207",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6104,7 +7267,9 @@
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6112,7 +7277,12 @@
           "stop_id": "70208",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6127,7 +7297,9 @@
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6135,7 +7307,12 @@
           "stop_id": "70207",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6147,7 +7324,12 @@
           "stop_id": "70208",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-B", "Green-C", "Green-D", "Green-E"],
+          "routes": [
+            "Green-B",
+            "Green-C",
+            "Green-D",
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6162,7 +7344,9 @@
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 30,
     "text_zone": "e",
-    "audio_zones": ["e"],
+    "audio_zones": [
+      "e"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6170,7 +7354,9 @@
           "stop_id": "70501",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6185,7 +7371,9 @@
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 90,
     "text_zone": "w",
-    "audio_zones": ["w"],
+    "audio_zones": [
+      "w"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6193,7 +7381,9 @@
           "stop_id": "70502",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6208,7 +7398,9 @@
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["m"],
+    "audio_zones": [
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6216,7 +7408,9 @@
           "stop_id": "70501",
           "direction_id": 1,
           "headway_direction_name": "Union Square",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6226,7 +7420,9 @@
           "stop_id": "70502",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -6249,7 +7445,9 @@
           "stop_id": "70504",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -6272,7 +7470,9 @@
           "stop_id": "70504",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -6287,7 +7487,11 @@
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 120,
     "text_zone": "m",
-    "audio_zones": ["e", "w", "m"],
+    "audio_zones": [
+      "e",
+      "w",
+      "m"
+    ],
     "type": "realtime",
     "source_config": [
       [
@@ -6295,7 +7499,9 @@
           "stop_id": "70504",
           "direction_id": 0,
           "headway_direction_name": "Heath Street",
-          "routes": ["Green-E"],
+          "routes": [
+            "Green-E"
+          ],
           "platform": null,
           "terminal": true,
           "announce_arriving": false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Handle Park Street WB berth changes](https://app.asana.com/0/1185117109217413/1202081491413707/f)

The berth switch is slated to start at the beginning of the Summer rating which is Sunday, June 19th. This PR adjusts the sign configurations for the sourcing of the data so that the text and audio will go to the new sign zones that will reflect the berth switch.

Formatting changes are also getting mixed into this PR which makes the count of changed lines quite high, but the only configs that were actually changed were for `park_st_westbound_wall_track` and `park_st_westbound_fence_track`.

Before switch (Screenshot from Signs UI dev):
![Screen Shot 2022-06-13 at 4 24 40 PM](https://user-images.githubusercontent.com/16074540/173438973-67b0f2cd-462f-4146-b177-3a1f3e925d3b.png)


After switch (Screenshot from running Realtime Signs branch and Signs UI locally):
![Screen Shot 2022-06-13 at 4 14 23 PM](https://user-images.githubusercontent.com/16074540/173438787-cee186ff-5ea1-4466-a4a4-aecc682093f2.png)

### Deployment
Deployment should happen either very late on June 18th after the end of service, or very early on June 19th at the start of service.