### PR TITLE
Replace space with underscore in station names

### DIFF
--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -49,7 +49,7 @@ defmodule Monitoring.Uptime do
           " line=",
           line,
           " station=",
-          station,
+          String.replace(station, " ", "_"),
           " sign_id=",
           sign_id,
           " sign_zone=",

--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -31,7 +31,7 @@ defmodule Monitoring.Uptime do
           " line=",
           line,
           " station=",
-          station,
+          String.replace(station, " ", "_"),
           " scu_id=",
           scu_id,
           " is_online=",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[health mon] Log full values for device_uptime fields](https://app.asana.com/0/1201786812162837/1202586894360138/f)

This change only affects the status logs for Sign and SCU monitoring. The station name can't include spaces if we want to include the full name in the Splunk Dashboard or in e-mail alerts and mentioned in the Asana ticket.
