### PR TITLE
Union Square dest for D trains 

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -61,6 +61,7 @@ defmodule Content.Utilities do
   def destination_for_prediction(_, 1, "70174"), do: {:ok, :reservoir}
 
   def destination_for_prediction(_, _, "Government Center-Brattle"), do: {:ok, :government_center}
+  def destination_for_prediction("Green-D", 1, "70207"), do: {:ok, :union_square}
 
   def destination_for_prediction("Green-B", 0, _), do: {:ok, :boston_college}
   def destination_for_prediction("Green-C", 0, _), do: {:ok, :cleveland_circle}

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -18,12 +18,6 @@ defmodule Fake.HTTPoison do
       body =~ "bad_sign" ->
         {:ok, %HTTPoison.Response{status_code: 404}}
 
-      body =~ "uid=11" ->
-        {:ok, %HTTPoison.Response{status_code: 500}}
-
-      body =~ "uid=12" ->
-        {:error, %HTTPoison.Error{reason: :timeout}}
-
       body =~ "MsgType=SignContent&uid=" ->
         {:ok, %HTTPoison.Response{status_code: 200}}
 


### PR DESCRIPTION
Specific pattern for the select D trains that are going to Union Sq. We need to add a new pattern because the usual default for D trains is North Station. We're using Science park because that's as far as we're predicting for these trains.
