### PR TITLE
Trains predicted to Science Park or Lechmere to use Union Sq

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -54,6 +54,9 @@ defmodule Content.Utilities do
 
   def destination_for_prediction(_, 1, "70205"), do: {:ok, :north_station}
   def destination_for_prediction(_, 1, "70503"), do: {:ok, :union_square}
+  def destination_for_prediction(_, 1, "70501"), do: {:ok, :union_square}
+  def destination_for_prediction(_, 1, "70207"), do: {:ok, :union_square}
+
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}
   def destination_for_prediction(_, 1, "70200"), do: {:ok, :park_street}
   def destination_for_prediction(_, 1, "71199"), do: {:ok, :park_street}

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -62,6 +62,7 @@ defmodule Content.Utilities do
 
   def destination_for_prediction(_, _, "Government Center-Brattle"), do: {:ok, :government_center}
   def destination_for_prediction("Green-D", 1, "70207"), do: {:ok, :union_square}
+  def destination_for_prediction("Green-C", 1, "70207"), do: {:ok, :union_square}
 
   def destination_for_prediction("Green-B", 0, _), do: {:ok, :boston_college}
   def destination_for_prediction("Green-C", 0, _), do: {:ok, :cleveland_circle}

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -56,7 +56,6 @@ defmodule Content.Utilities do
   def destination_for_prediction(_, 1, "70503"), do: {:ok, :union_square}
   def destination_for_prediction(_, 1, "70501"), do: {:ok, :union_square}
   def destination_for_prediction(_, 1, "70207"), do: {:ok, :union_square}
-
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}
   def destination_for_prediction(_, 1, "70200"), do: {:ok, :park_street}
   def destination_for_prediction(_, 1, "71199"), do: {:ok, :park_street}
@@ -64,8 +63,6 @@ defmodule Content.Utilities do
   def destination_for_prediction(_, 1, "70174"), do: {:ok, :reservoir}
 
   def destination_for_prediction(_, _, "Government Center-Brattle"), do: {:ok, :government_center}
-  def destination_for_prediction("Green-D", 1, "70207"), do: {:ok, :union_square}
-  def destination_for_prediction("Green-C", 1, "70207"), do: {:ok, :union_square}
 
   def destination_for_prediction("Green-B", 0, _), do: {:ok, :boston_college}
   def destination_for_prediction("Green-C", 0, _), do: {:ok, :cleveland_circle}


### PR DESCRIPTION
Any train being predicted out to Science Park or Lechmere will use Union Sq as the headway destination