### PR TITLE
Include platform info on JFK/UMass Mezzanine announcements

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -58,7 +58,8 @@ defmodule Content.Audio.NextTrainCountdown do
             audio.minutes == 1 ->
               {:canned, {"142", [dest_var, platform_var(audio), verb_var(audio)], :audio}}
 
-            audio.station_code == "RJFK" and audio.zone == "m" and audio.minutes >= 20 ->
+            audio.destination == :alewife and audio.station_code == "RJFK" and audio.zone == "m" and
+                audio.minutes >= 20 ->
               platform_tbd_params(audio, dest_var)
 
             true ->

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -4,7 +4,7 @@ defmodule Content.Audio.NextTrainCountdown do
   """
 
   @enforce_keys [:destination, :route_id, :verb, :minutes, :track_number]
-  defstruct @enforce_keys ++ [platform: nil]
+  defstruct @enforce_keys ++ [:station_code, :zone, platform: nil]
 
   @type verb :: :arrives | :departs
 
@@ -14,7 +14,9 @@ defmodule Content.Audio.NextTrainCountdown do
           verb: verb(),
           minutes: integer(),
           track_number: Content.Utilities.track_number() | nil,
-          platform: Content.platform() | nil
+          platform: Content.platform() | nil,
+          station_code: String.t() | nil,
+          zone: String.t() | nil
         }
 
   require Logger
@@ -29,6 +31,7 @@ defmodule Content.Audio.NextTrainCountdown do
     @in_ "504"
     @minutes "505"
     @minute "532"
+    @platform_tbd "849"
 
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do
@@ -54,6 +57,9 @@ defmodule Content.Audio.NextTrainCountdown do
 
             audio.minutes == 1 ->
               {:canned, {"142", [dest_var, platform_var(audio), verb_var(audio)], :audio}}
+
+            audio.station_code == "RJFK" and audio.zone == "m" and audio.minutes >= 20 ->
+              platform_tbd_params(audio, dest_var)
 
             true ->
               {:canned,
@@ -120,6 +126,21 @@ defmodule Content.Audio.NextTrainCountdown do
         minutes_var(audio),
         minute_or_minutes(audio),
         track(audio.track_number)
+      ]
+
+      Utilities.take_message(vars, :audio)
+    end
+
+    defp platform_tbd_params(audio, destination_var) do
+      vars = [
+        @the_next,
+        @train_to,
+        destination_var,
+        verb_var(audio),
+        @in_,
+        minutes_var(audio),
+        minute_or_minutes(audio),
+        @platform_tbd
       ]
 
       Utilities.take_message(vars, :audio)

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -76,7 +76,9 @@ defmodule Content.Audio.Predictions do
           minutes: div(Content.Utilities.max_time_seconds(), 60),
           verb: if(src.terminal?, do: :departs, else: :arrives),
           track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform
+          platform: src.platform,
+          station_code: predictions.station_code,
+          zone: predictions.zone
         }
 
       is_integer(predictions.minutes) ->

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -152,16 +152,14 @@ defmodule Content.Message.Predictions do
       cond do
         station_code == "RJFK" ->
           if destination == :alewife and zone == "m" do
-            platform =
-              case track_number do
-                1 -> "Ashmont"
-                2 -> "Braintree"
-              end
+            platform_name = Content.Utilities.stop_platform_name(stop_id)
 
             {headsign_message, platform_message} =
               if minutes == :max_time,
                 do: {headsign, " (Platform TBD)"},
-                else: {headsign <> " (#{String.slice(platform, 0..0)})", " (#{platform} plat)"}
+                else:
+                  {headsign <> " (#{String.slice(platform_name, 0..0)})",
+                   " (#{platform_name} plat)"}
 
             [
               {Content.Utilities.width_padded_string(

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -83,9 +83,10 @@ defmodule Content.Utilities do
   def stop_track_number("Forest Hills-02"), do: 2
   def stop_track_number("Oak Grove-01"), do: 1
   def stop_track_number("Oak Grove-02"), do: 2
-  def stop_track_number("70086"), do: 1
-  def stop_track_number("70096"), do: 2
   def stop_track_number(_), do: nil
+
+  def stop_platform_name("70086"), do: "Ashmont"
+  def stop_platform_name("70096"), do: "Braintree"
 
   @spec route_and_destination_branch_letter(String.t(), PaEss.destination()) ::
           green_line_branch() | nil

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -83,6 +83,8 @@ defmodule Content.Utilities do
   def stop_track_number("Forest Hills-02"), do: 2
   def stop_track_number("Oak Grove-01"), do: 1
   def stop_track_number("Oak Grove-02"), do: 2
+  def stop_track_number("70086"), do: 1
+  def stop_track_number("70096"), do: 2
   def stop_track_number(_), do: nil
 
   @spec route_and_destination_branch_letter(String.t(), PaEss.destination()) ::

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -12,20 +12,24 @@ defmodule Signs.Utilities.Predictions do
   @spec get_messages(Signs.Realtime.t()) ::
           {{SourceConfig.source() | nil, Content.Message.t()},
            {SourceConfig.source() | nil, Content.Message.t()}}
-  def get_messages(%{source_config: {top_line_sources, bottom_line_sources}} = sign) do
-    {top, _} = get_predictions(sign.prediction_engine, top_line_sources)
-    {bottom, _} = get_predictions(sign.prediction_engine, bottom_line_sources)
+  def get_messages(
+        %{source_config: {top_line_sources, bottom_line_sources}, text_id: {station_code, zone}} =
+          sign
+      ) do
+    {top, _} = get_predictions(sign.prediction_engine, top_line_sources, station_code, zone)
+    {bottom, _} = get_predictions(sign.prediction_engine, bottom_line_sources, station_code, zone)
+
     {top, bottom}
   end
 
-  def get_messages(%{source_config: {both_lines_sources}} = sign) do
-    get_predictions(sign.prediction_engine, both_lines_sources)
+  def get_messages(%{source_config: {both_lines_sources}, text_id: {station_code, zone}} = sign) do
+    get_predictions(sign.prediction_engine, both_lines_sources, station_code, zone)
   end
 
-  @spec get_predictions(module(), [Signs.Utilities.SourceConfig.source()]) ::
+  @spec get_predictions(module(), [Signs.Utilities.SourceConfig.source()], String.t(), String.t()) ::
           {{SourceConfig.source() | nil, Content.Message.t()},
            {SourceConfig.source() | nil, Content.Message.t()}}
-  defp get_predictions(prediction_engine, source_list) do
+  defp get_predictions(prediction_engine, source_list, station_code, zone) do
     source_list
     |> get_source_list_predictions(prediction_engine)
     |> Enum.filter(fn {_, p} ->
@@ -51,7 +55,7 @@ defmodule Signs.Utilities.Predictions do
           {source, Content.Message.Predictions.terminal(prediction)}
 
         true ->
-          {source, Content.Message.Predictions.non_terminal(prediction)}
+          {source, Content.Message.Predictions.non_terminal(prediction, station_code, zone)}
       end
     end)
     |> Enum.reject(fn {_source, message} -> is_nil(message) end)

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5277,32 +5277,6 @@
     "source_config": [
       [
         {
-          "stop_id": "70086",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": "ashmont",
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
-          "stop_id": "70096",
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "routes": [
-            "Red"
-          ],
-          "platform": "braintree",
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
           "stop_id": "70085",
           "direction_id": 0,
           "headway_direction_name": "Southbound",
@@ -5323,6 +5297,32 @@
           "routes": [
             "Red"
           ],
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ],
+      [
+        {
+          "stop_id": "70086",
+          "routes": [
+            "Red"
+          ],
+          "direction_id": 1,
+          "headway_direction_name": "Alewife",
+          "platform": "ashmont",
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        },
+        {
+          "stop_id": "70096",
+          "direction_id": 1,
+          "headway_direction_name": "Alewife",
+          "routes": [
+            "Red"
+          ],
+          "platform": "braintree",
+          "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -148,6 +148,40 @@ defmodule Content.Audio.NextTrainCountdownTest do
                {:canned, {"99", ["4000", "4021", "503", "5005"], :audio}}
     end
 
+    test "Next train to Alewife platform TBD (JFK/UMass Mezzanine only)" do
+      audio = %Content.Audio.NextTrainCountdown{
+        destination: :alewife,
+        route_id: "Red",
+        verb: :arrives,
+        minutes: 20,
+        track_number: nil,
+        platform: :braintree,
+        station_code: "RJFK",
+        zone: "m"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"117",
+                 [
+                   "501",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4000",
+                   "21000",
+                   "503",
+                   "21000",
+                   "504",
+                   "21000",
+                   "5020",
+                   "21000",
+                   "505",
+                   "21000",
+                   "849"
+                 ], :audio}}
+    end
+
     test "Next train to Braintree" do
       audio = %Content.Audio.NextTrainCountdown{
         destination: :braintree,

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -15,7 +15,7 @@ defmodule Content.Message.PredictionsTest do
 
       log =
         capture_log([level: :warn], fn ->
-          assert is_nil(Content.Message.Predictions.non_terminal(prediction))
+          assert is_nil(Content.Message.Predictions.non_terminal(prediction, "test", "m"))
         end)
 
       assert log =~ "no_destination_for_prediction"
@@ -31,7 +31,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -46,7 +46,7 @@ defmodule Content.Message.PredictionsTest do
         boarding_status: "Boarding"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -61,7 +61,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Mattapan       ARR"
     end
@@ -76,7 +76,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
@@ -91,7 +91,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
@@ -106,7 +106,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Mattapan   20+ min"
     end
@@ -121,7 +121,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, 15)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", 15)
       assert Content.Message.to_string(msg) == "Mattapan  9 min"
     end
 
@@ -135,7 +135,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
     end
@@ -150,7 +150,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
@@ -165,7 +165,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -180,7 +180,7 @@ defmodule Content.Message.PredictionsTest do
         boarding_status: "Boarding"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -195,7 +195,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
@@ -211,7 +211,7 @@ defmodule Content.Message.PredictionsTest do
         trip_id: "trip1"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert msg.trip_id == "trip1"
     end
@@ -227,7 +227,7 @@ defmodule Content.Message.PredictionsTest do
         new_cars?: true
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert msg.new_cars?
     end
@@ -433,7 +433,7 @@ defmodule Content.Message.PredictionsTest do
         new_cars?: true
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
 
       assert msg.new_cars?
     end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -231,6 +231,60 @@ defmodule Content.Message.PredictionsTest do
 
       assert msg.new_cars?
     end
+
+    test "Includes Ashmont platform when northbound to JFK/UMass Mezzanine" do
+      prediction = %Predictions.Prediction{
+        stop_id: "70086",
+        seconds_until_arrival: 125,
+        direction_id: 1,
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
+      }
+
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+
+      assert Content.Message.to_string(msg) == [
+               {"Alewife (A)  2 min", 3},
+               {"Alewife (Ashmont plat)", 3}
+             ]
+    end
+
+    test "Includes Braintree platform when northbound to JFK/UMass Mezzanine" do
+      prediction = %Predictions.Prediction{
+        stop_id: "70096",
+        seconds_until_arrival: 125,
+        direction_id: 1,
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
+      }
+
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+
+      assert Content.Message.to_string(msg) == [
+               {"Alewife (B)  2 min", 3},
+               {"Alewife (Braintree plat)", 3}
+             ]
+    end
+
+    test "Platform TBD when northbound to JFK/UMass Mezzanine and over 20 min" do
+      prediction = %Predictions.Prediction{
+        stop_id: "70096",
+        seconds_until_arrival: 1200,
+        direction_id: 1,
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
+      }
+
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+
+      assert Content.Message.to_string(msg) == [
+               {"Alewife    20+ min", 3},
+               {"Alewife (Platform TBD)", 3}
+             ]
+    end
   end
 
   describe "terminal/3" do

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -210,7 +210,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 2,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }},
                 {%Signs.Utilities.SourceConfig{
                    announce_arriving?: false,
@@ -228,7 +230,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 4,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }}}
     end
 
@@ -298,7 +302,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 2,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }},
                 {%Signs.Utilities.SourceConfig{
                    announce_arriving?: false,
@@ -316,7 +322,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 4,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }}}
     end
 
@@ -384,7 +392,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 2,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }},
                 {%Signs.Utilities.SourceConfig{
                    announce_arriving?: false,
@@ -402,7 +412,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 4,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }}}
     end
 
@@ -428,7 +440,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 2,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }},
                 {%Signs.Utilities.SourceConfig{
                    announce_arriving?: false,
@@ -446,7 +460,9 @@ defmodule Signs.Utilities.MessagesTest do
                    minutes: 4,
                    route_id: "Red",
                    stop_id: "1",
-                   width: 18
+                   width: 18,
+                   station_code: "TEST",
+                   zone: "x"
                  }}}
     end
 


### PR DESCRIPTION
This PR adds some custom logic and message formatting for the JFK/UMass Mezzanine sign. We are currently in violation of ADA standards by not giving riders enough info about which platform the next train will be arriving at.

The solution is admittedly a bit hacky by accounting for the `RJFK-m` case specifically, but this station is very unique for the T both in how the tracks work but also in that the tracks are labeled as "Ashmont" and "Braintree" rather than "Track 1" and "Track 2". Therefore, I found that it made more sense to add some hard coded logic rather than come up with something more generalized.

Presentation [here](https://mbta.sharepoint.com/:p:/r/sites/CTD/_layouts/15/Doc.aspx?sourcedoc=%7B12779A90-381D-4630-90A3-EA835AADE74D%7D&file=7.29%20Recommendation.pptx&action=edit&mobileredirect=true) that was given to SWA to summarize research findings and design proposals that led to the current solution.

Example:
![Screen Shot 2022-08-17 at 5 31 06 PM](https://user-images.githubusercontent.com/16074540/185520490-d8b152d0-9766-4e27-a4c9-e785f8376638.png)

![Screen Shot 2022-08-17 at 5 31 00 PM](https://user-images.githubusercontent.com/16074540/185520484-cca4fdaa-f30e-44cc-8618-9624dc9f34d5.png)
