### PR TITLE
Add error view

### DIFF
--- a/lib/realtime_signs_web.ex
+++ b/lib/realtime_signs_web.ex
@@ -7,6 +7,20 @@ defmodule RealtimeSignsWeb do
     end
   end
 
+  def view do
+    quote do
+      use Phoenix.View,
+        root: "lib/realtime_signs_web/templates",
+        namespace: RealtimeSignsWeb
+
+      # Import convenience functions from controllers
+      import Phoenix.Controller,
+        only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
+
+      use Phoenix.HTML
+    end
+  end
+
   def router do
     quote do
       use Phoenix.Router

--- a/lib/realtime_signs_web/views/error_view.ex
+++ b/lib/realtime_signs_web/views/error_view.ex
@@ -1,0 +1,16 @@
+defmodule RealtimeSignsWeb.ErrorView do
+  use RealtimeSignsWeb, :view
+
+  # If you want to customize a particular status code
+  # for a certain format, you may uncomment below.
+  # def render("500.html", _assigns) do
+  #   "Internal Server Error"
+  # end
+
+  # By default, Phoenix returns the status message from
+  # the template name. For example, "404.html" becomes
+  # "Not Found".
+  def template_not_found(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
+end


### PR DESCRIPTION
We get periodic exceptions when ARINC sends us equipment statuses. From the looks of the logs, it seems like ARINC may be occasionally sending requests to the wrong routes, but we should also probably not completely fail when we get bad requests since this triggers alerts and creates noise in the digital-ride-alerts channel.

Example alert: https://mbta.slack.com/files/USLACKBOT/F03TCBLTJBG/splunk_alert__realtime_signs_prod_errors
