### PR TITLE
Enable monitoring of Live PA Software

### DIFF
--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -1,21 +1,45 @@
 defmodule Monitoring.Uptime do
   require Logger
 
-  @spec monitor_device_uptime(list(map()), integer()) :: :ok
-  def monitor_device_uptime(nodes, timestamp) do
+  @spec monitor_node_uptime(list(map()), integer()) :: :ok
+  def monitor_node_uptime(nodes, timestamp) do
     {:ok, date_time} = DateTime.from_unix(timestamp, :second)
 
     {splunk_time, :ok} =
       :timer.tc(fn ->
         Enum.each(nodes, fn node ->
-          log_device_status(node, date_time)
+          log_node_status(node, date_time)
         end)
       end)
 
     Logger.info("arinc_status_to_splunk_ms: #{div(splunk_time, 1000)}")
   end
 
-  defp log_device_status(
+  defp log_node_status(
+         %{"sw_component" => _, "is_online" => is_online, "status" => status} = node,
+         date_time
+       ) do
+    case get_software_component_type(node) do
+      :live_pa ->
+        Logger.info([
+          "software_uptime: ",
+          "date_time=",
+          DateTime.to_string(date_time),
+          " application=live_pa",
+          " is_online=",
+          is_online,
+          " status=",
+          status
+        ])
+
+      _ ->
+        Logger.warn(
+          "Received uptime info of a node with an unknown or unspecified type #{inspect(node)}"
+        )
+    end
+  end
+
+  defp log_node_status(
          %{"description" => description, "is_online" => is_online} = node,
          date_time
        ) do
@@ -116,6 +140,16 @@ defmodule Monitoring.Uptime do
         Logger.warn(
           "Received uptime info of a node with an unknown or unspecified type #{inspect(node)}"
         )
+    end
+  end
+
+  defp get_software_component_type(%{"sw_component" => sw_component}) do
+    case sw_component do
+      "Live PA" ->
+        :live_pa
+
+      _ ->
+        :unknown
     end
   end
 

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -7,8 +7,8 @@ defmodule RealtimeSignsWeb.MonitoringController do
         conn,
         %{"time" => timestamp, "data" => %{"nodes" => nodes}} = _params
       ) do
-    Logger.info("Received device statuses from ARINC: Device count=#{Enum.count(nodes)}")
-    monitor_device_uptime(nodes, timestamp)
+    Logger.info("Received uptime statuses from ARINC: Node count=#{Enum.count(nodes)}")
+    monitor_node_uptime(nodes, timestamp)
     send_resp(conn, 200, "")
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Enable LivePA application status monitoring](https://app.asana.com/0/1201786812162837/1202938907907698/f)

ARINC is ready to send us Live PA software statuses alongside the current Sign, SCU, and audio equipment statuses they're sending us. This PR expands the module for logging these statuses to account for software components. I made the changes in a way where it would be easy to add the logging of additional software components, although there aren't necessarily plans to add anymore for the time being.

Example log of live PA software status:
`11:36:31.174 [info]  software_uptime: date_time=2022-09-07 10:52:14Z application=live_pa is_online=true status=RUNNING`

