### PR TITLE
Start using re-worded platform arrival message

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -64,7 +64,7 @@ defmodule Content.Audio.NextTrainCountdown do
 
             true ->
               {:canned,
-               {"99", [dest_var, platform_var(audio), verb_var(audio), minutes_var(audio)],
+               {"98", [dest_var, verb_var(audio), minutes_var(audio), platform_var(audio)],
                 :audio}}
           end
 

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -118,7 +118,7 @@ defmodule Content.Audio.NextTrainCountdownTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"99", ["4000", "4016", "503", "5005"], :audio}}
+               {:canned, {"98", ["4000", "503", "5005", "4016"], :audio}}
     end
 
     test "Next train to Alewife on the Ashmont platform arrives in one minute" do
@@ -145,7 +145,7 @@ defmodule Content.Audio.NextTrainCountdownTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"99", ["4000", "4021", "503", "5005"], :audio}}
+               {:canned, {"98", ["4000", "503", "5005", "4021"], :audio}}
     end
 
     test "Next train to Alewife platform TBD (JFK/UMass Mezzanine only)" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update next train arrival wording](https://app.asana.com/0/1201786812162837/1202857146305305/f)

We added a new message with wording that will improve clarity for platform arrival messages. This message is primarily used, if not exclusively, at JFK/UMass.

Old wording: `The next [stations] train on the [stations] platform [arrives/departs] in [x] minutes`

New wording: `The next [stations] train [arrives/departs] in [x] minutes on the [stations] platform`

Luckily, the new wording uses the same sound bites and parameters just in a different order, so the code changes are minimal.

From Andrew Daniels from ARINC explaining the message:
> The new message has been added to the system. It is MSG ID 98.
>
>The next [stations] train [arrives/departs] in [x] minutes on the [stations] platform
>
>[stations] : TAKE_ID = 4000 – 4028
>[arrives] : TAKE_ID = 503
>[departs] : TAKE_ID = 502
>[x] : TAKE_ID = 5001 - 5099
