### PR TITLE
Remove logic for new OL trains

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -19,7 +19,6 @@ defmodule Content.Audio.Approaching do
 
   defimpl Content.Audio do
     @attention_passengers "783"
-    @now_approaching_new_ol_cars "785"
     @now_approaching_new_rl_cars "786"
     @space "21000"
 
@@ -56,11 +55,6 @@ defmodule Content.Audio.Approaching do
         nil ->
           to_params(%Content.Audio.Approaching{audio | new_cars?: false})
 
-        {destination_var, approaching_var} when route_id == "Orange" ->
-          # can't use take_message/2 directly as the spaces cause problems
-          vars = [@attention_passengers, destination_var, approaching_var]
-          {:canned, {PaEss.Utilities.take_message_id(vars), vars, :audio_visual}}
-
         {destination_var, approaching_var} when route_id == "Red" ->
           # Red Line message, however, requires one space.
           vars = [@attention_passengers, destination_var, @space, approaching_var]
@@ -90,8 +84,6 @@ defmodule Content.Audio.Approaching do
     defp destination_var(_destination, _platform, _route_id), do: nil
 
     @spec new_cars_vars(PaEss.destination(), String.t()) :: {String.t(), String.t()} | nil
-    defp new_cars_vars(:oak_grove, "Orange"), do: {"4022", @now_approaching_new_ol_cars}
-    defp new_cars_vars(:forest_hills, "Orange"), do: {"4043", @now_approaching_new_ol_cars}
     defp new_cars_vars(:alewife, "Red"), do: {"4000", @now_approaching_new_rl_cars}
     defp new_cars_vars(:ashmont, "Red"), do: {"4016", @now_approaching_new_rl_cars}
     defp new_cars_vars(:braintree, "Red"), do: {"4021", @now_approaching_new_rl_cars}

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -38,11 +38,11 @@ defmodule Content.Audio.ApproachingTest do
       assert Content.Audio.to_params(audio) == nil
     end
 
-    test "Returns params for new Orange Line cars" do
+    test "No longer returns params for new Orange Line cars" do
       audio = %Approaching{destination: :oak_grove, route_id: "Orange", new_cars?: true}
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"105", ["783", "4022", "785"], :audio_visual}}
+               {:canned, {"103", ["32122"], :audio_visual}}
     end
 
     test "Returns params for new Red Line cars" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove "The next orange line train is approaching with all new cars" from PA/ESS on the OL](https://app.asana.com/0/1185117109217422/1202942589486789/f)

This PR removes the use of the Message ID `785` which announces to riders that the approaching OL train has all new cars.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202963933316750