### PR TITLE
Update logging module to handle new DSP type

### DIFF
--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -137,9 +137,7 @@ defmodule Monitoring.Uptime do
         ])
 
       _ ->
-        Logger.warn(
-          "Received uptime info of a node with an unknown or unspecified type #{inspect(node)}"
-        )
+        Logger.info("unknown_node_type: #{inspect(node)}")
     end
   end
 
@@ -162,6 +160,9 @@ defmodule Monitoring.Uptime do
         :scu
 
       "P8810" ->
+        :dsp
+
+      "BLU-80" ->
         :dsp
 
       "C4200" ->


### PR DESCRIPTION
ARINC is installing new DSPs that are apparently configured with a new `node_type` field with the value `BLU-80`. This PR updates the logic to handle this new value.

Additionally, the warn logs for unknown node types were triggering an existing, more general alert and causing noise. We can change it to an info log and create a new, more specific alert that I can edit since the more general alert is not owned by me.