### PR TITLE
Add a dry run mode

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,3 +27,7 @@ config :realtime_signs, RealtimeSigns.Scheduler, jobs: scheduler_jobs
 if config_env() == :prod do
   config :realtime_signs, RealtimeSignsWeb.Endpoint, secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
 end
+
+if System.get_env("DRY_RUN") == "true" do
+  config :realtime_signs, sign_updater_mod: PaEss.Logger
+end

--- a/lib/pa_ess/logger.ex
+++ b/lib/pa_ess/logger.ex
@@ -1,6 +1,6 @@
 defmodule PaEss.Logger do
   @moduledoc """
-  A behaviour that signs can use to append their updates to a file,
+  A behaviour that signs can use to log their updates
   rather than sending it to the Pa/Ess HTTP server.
   """
 

--- a/lib/pa_ess/logger.ex
+++ b/lib/pa_ess/logger.ex
@@ -24,8 +24,6 @@ defmodule PaEss.Logger do
       "#{start_secs}"
     ]
 
-    File.mkdir("log")
-    File.write!("log/pa_ess_updates.log", line ++ ["\n"], [:append])
     Logger.info(line)
     {:ok, :sent}
   end
@@ -46,8 +44,6 @@ defmodule PaEss.Logger do
       "#{start_secs}"
     ]
 
-    File.mkdir("log")
-    File.write!("log/pa_ess_updates.log", line ++ ["\n"], [:append])
     Logger.info(line)
     {:ok, :sent}
   end
@@ -73,8 +69,6 @@ defmodule PaEss.Logger do
     ]
 
     Logger.info(line)
-    File.mkdir("log")
-    File.write!("log/pa_ess_updates.log", line ++ ["\n"], [:append])
     {:ok, :sent}
   end
 


### PR DESCRIPTION
Overrides default configs and uses the `PaEss.Logger` module as the sign updater module if an env variable `DRY_RUN` is set. 

This module has the same interface as `MessageQueue` which is used when we want to actually send http requests to the headend server. `MessageQueue` is the default for normal deploys to either dev or prod, but we can use this dry run feature when we are testing out deploying to the new on prem servers and don't want to risk potentially overwhelming the PAESS system with too many messages.
