### PR TITLE
Add config for bowdoin dropoff zone

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1151,6 +1151,33 @@
     ]
   },
   {
+    "id": "bowdoin_drop_off",
+    "headway_group": "blue_trunk",
+    "type": "realtime",
+    "pa_ess_loc": "BBOW",
+    "read_loop_offset": 60,
+    "text_zone": "w",
+    "audio_zones": [
+      "w"
+    ],
+    "source_config": [
+      [
+        {
+          "stop_id": "70038",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "headway_direction_name": "Wonderland",
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": false
+        }
+      ]
+    ]
+  },
+  {
     "id": "bowdoin_mezzanine",
     "headway_group": "blue_trunk",
     "type": "realtime",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add Bowdoin zone "W" to match what's installed](https://app.asana.com/0/1201786812162837/1203208997479587/f)

Adds source config for the Bowdoin drop off zone. This will enable realtime-signs to propagate messages to the ARINC headend server as well as Signs UI's renderings of the countdown clock.

Goes hand in hand with [this Signs UI PR](https://github.com/mbta/signs_ui/pull/855) and should be deployed soon after the Signs UI change is live
