### PR TITLE
Update Green-D headway directions to Union Sq

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5371,7 +5371,7 @@
         {
           "stop_id": "70160",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5398,7 +5398,7 @@
         {
           "stop_id": "70162",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5452,7 +5452,7 @@
         {
           "stop_id": "70164",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5506,7 +5506,7 @@
         {
           "stop_id": "70166",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5560,7 +5560,7 @@
         {
           "stop_id": "70168",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5614,7 +5614,7 @@
         {
           "stop_id": "70170",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5668,7 +5668,7 @@
         {
           "stop_id": "70172",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5722,7 +5722,7 @@
         {
           "stop_id": "70174",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5777,7 +5777,7 @@
         {
           "stop_id": "70176",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5832,7 +5832,7 @@
         {
           "stop_id": "70178",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5940,7 +5940,7 @@
         {
           "stop_id": "70182",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5994,7 +5994,7 @@
         {
           "stop_id": "70186",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
+          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],


### PR DESCRIPTION
#### Summary of changes
A customer feedback came in this afternoon calling out that the countdown clocks at Riverside were using `North Sta` as the headway direction when using headways when in fact, D trains now run to Union Sq. We should update all of the D sign configs to use Union Sq as the headway direction name now.
