### PR TITLE
Message latency reporting job

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,7 +28,7 @@ message_log_report_job =
     [
       {
         System.get_env("MESSAGE_LOG_REPORT_CRON_SCHEDULE"),
-        {Jobs.MessageLatencyReport, :generate_message_latency_report, []}
+        {Jobs.MessageLatencyReport, :generate_message_latency_reports, []}
       }
     ]
   else

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,9 +8,10 @@ config :realtime_signs, RealtimeSignsWeb.Endpoint,
 config :realtime_signs,
   message_log_zip_url: System.get_env("MESSAGE_LOG_ZIP_URL"),
   message_log_s3_bucket: System.get_env("MESSAGE_LOG_S3_BUCKET"),
-  message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER")
+  message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
+  message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER")
 
-scheduler_jobs =
+message_log_job =
   if System.get_env("MESSAGE_LOG_CRON_SCHEDULE") do
     [
       {
@@ -22,7 +23,20 @@ scheduler_jobs =
     []
   end
 
-config :realtime_signs, RealtimeSigns.Scheduler, jobs: scheduler_jobs
+message_log_report_job =
+  if System.get_env("MESSAGE_LOG_REPORT_CRON_SCHEDULE") do
+    [
+      {
+        System.get_env("MESSAGE_LOG_REPORT_CRON_SCHEDULE"),
+        {Jobs.MessageLatencyReport, :generate_message_latency_report, []}
+      }
+    ]
+  else
+    []
+  end
+
+
+config :realtime_signs, RealtimeSigns.Scheduler, jobs: message_log_job ++ message_log_report_job
 
 if config_env() == :prod do
   config :realtime_signs, RealtimeSignsWeb.Endpoint, secret_key_base: System.fetch_env!("SECRET_KEY_BASE")

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -1,15 +1,35 @@
 defmodule Jobs.MessageLatencyReport do
   @moduledoc """
+  This job is responsible for generating daily ARINC message latency reports based on
+  a provided start_date and days_to_analyze.
 
+  * start_date: The date from which the job should begin generating reports. The job
+  will work backwards from this date. Defaults to Date.utc_today() - 1 because those
+  will be the latest logs that we have when this job runs on its CRON schedule.
+  * days_to_analyze: The number of days to go back. This value will default to 7 because
+  we plan to schedule the job to run on a weekly basis.
+
+  The job will download the zip file containing message latency log files for each
+  station and calculate the 95th and 99th percentiles along with the total
+  row count for each one. It will aggregate the stats both for the combined logs
+  from every station as well as on a per station basis for a given day in a CSV file.
+  The job will then store this file in S3.
   """
   require Logger
 
   @percentile_95 0.95
   @percentile_99 0.99
 
-  def generate_message_latency_report(days_to_analyze \\ 7) do
-    Enum.each(1..days_to_analyze, fn diff ->
-      date = Date.utc_today() |> Date.add(-diff) |> Date.to_string()
+  @doc """
+  Generate message latency reports starting from start_date and going back days_to_analyze
+  """
+  @spec generate_message_latency_reports(Date.t(), integer) :: :ok
+  def generate_message_latency_reports(
+        start_date \\ Date.utc_today() |> Date.add(-1),
+        days_to_analyze \\ 7
+      ) do
+    Enum.each(0..(days_to_analyze - 1), fn diff ->
+      date = start_date |> Date.add(-diff) |> Date.to_string()
       Logger.info("Generating message latency report for #{date}...")
       analyze_files_for_date(date)
     end)
@@ -22,11 +42,8 @@ defmodule Jobs.MessageLatencyReport do
       # TODO: Switch this to Windows equivalent
       :os.cmd(:"cat #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
 
-      [
-        get_csv_row("#{unzipped_directory}/all.csv")
-        | Enum.map(files, &get_csv_row/1)
-      ]
-      |> get_csv_data()
+      [get_csv_row("#{unzipped_directory}/all.csv") | Enum.map(files, &get_csv_row/1)]
+      |> format_csv_data()
       |> put_csv_in_s3(date)
 
       Logger.info("Done processing. Deleting #{unzipped_directory}...")
@@ -39,7 +56,7 @@ defmodule Jobs.MessageLatencyReport do
         Logger.info("Unzip error: Occured while attempting to unzip")
 
       {:error, reason} ->
-        Logger.info("Message latency error: #{inspect(reason)}")
+        Logger.info("Message latency report error: #{inspect(reason)}")
     end
   end
 
@@ -53,14 +70,10 @@ defmodule Jobs.MessageLatencyReport do
   end
 
   defp get_csv_row(file) do
-    row = [
-      get_id_from_filename(file) | File.stream!(file) |> analyze_file()
-    ]
-
-    row
+    [get_id_from_filename(file) | File.stream!(file) |> get_stats()]
   end
 
-  defp analyze_file(file_contents) do
+  defp get_stats(file_contents) do
     rows_with_indices = parse_rows_and_add_indices(file_contents)
 
     num_rows = Enum.count(rows_with_indices)
@@ -91,6 +104,7 @@ defmodule Jobs.MessageLatencyReport do
         true
     end)
     |> Stream.map(fn [id, begin_date, end_date, count, seconds, station] ->
+      # Put into keyword list for easier accessing
       [
         id: id,
         begin_date: begin_date,
@@ -104,7 +118,7 @@ defmodule Jobs.MessageLatencyReport do
     |> Enum.with_index()
   end
 
-  defp get_csv_data(rows) do
+  defp format_csv_data(rows) do
     # Put the data in CSV format with header row
     Logger.info("Creating CSV rows...")
 
@@ -138,17 +152,17 @@ defmodule Jobs.MessageLatencyReport do
             "Message latency report was not able to be stored. Response: #{inspect(response)}"
           )
       end
-    end
 
-    Logger.info("Deleting file at path #{report_filename}")
-    File.rm!(report_filename)
+      Logger.info("Deleting file at path #{report_filename}")
+      File.rm!(report_filename)
+    end
   end
 
   defp get_id_from_filename(file_name) do
-    [_date, station_code] =
+    [_date, id] =
       file_name |> to_string |> String.upcase() |> String.trim(".CSV") |> String.split("/")
 
-    station_code
+    id
   end
 
   defp get_percentile_row(percentile_index, rows_with_index) do

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -1,0 +1,164 @@
+defmodule Jobs.MessageLatencyReport do
+  @moduledoc """
+
+  """
+  require Logger
+
+  @percentile_95 0.95
+  @percentile_99 0.99
+
+  def generate_message_latency_report(days_to_analyze \\ 7) do
+    Enum.each(1..days_to_analyze, fn diff ->
+      date = Date.utc_today() |> Date.add(-diff) |> Date.to_string()
+      Logger.info("Generating message latency report for #{date}...")
+      analyze_files_for_date(date)
+    end)
+  end
+
+  defp analyze_files_for_date(date) do
+    with {:ok, response} <- get_zip_file(date),
+         {:ok, files} <- :zip.unzip(response.body) do
+      Logger.info("Calculating results...")
+      Enum.map(files, &get_csv_row/1) |> put_csv_in_s3(date)
+    else
+      {:error, {:http_error, 404, _}} ->
+        Logger.info("S3 response error: Unable to find zip file")
+
+      {:error, :einval} ->
+        Logger.info("Unzip error: Occured while attempting to unzip")
+
+      {:error, reason} ->
+        Logger.info("Message latency error: #{inspect(reason)}")
+    end
+
+    Logger.info("Deleting folder #{date}")
+    File.rm_rf!(date |> String.replace("-", ""))
+  end
+
+  defp get_zip_file(date) do
+    s3_client = Application.get_env(:realtime_signs, :s3_client)
+    aws_client = Application.get_env(:realtime_signs, :aws_client)
+    path = "#{s3_paess_logs_path()}/#{date}.zip"
+
+    Logger.info("Getting message log files at #{path}")
+    s3_client.get_object(s3_bucket(), path) |> aws_client.request()
+  end
+
+  defp get_csv_row(file) do
+    row = [
+      get_station_code_from_filename(file) | File.stream!(file) |> analyze_file()
+    ]
+
+    row
+  end
+
+  defp analyze_file(file_contents) do
+    rows_with_indices = parse_rows_and_add_indices(file_contents)
+
+    num_rows = Enum.count(rows_with_indices)
+
+    percentile_95_row =
+      num_rows
+      |> calculate_percentile_index(@percentile_95)
+      |> get_percentile_row(rows_with_indices)
+
+    percentile_99_row =
+      num_rows
+      |> calculate_percentile_index(@percentile_99)
+      |> get_percentile_row(rows_with_indices)
+
+    [percentile_95_row[:seconds], percentile_99_row[:seconds], num_rows]
+  end
+
+  defp parse_rows_and_add_indices(file_contents) do
+    file_contents
+    |> Stream.map(&String.trim(&1, "\n"))
+    |> Stream.map(&String.split(&1, ","))
+    |> Stream.filter(fn
+      # Filter out header rows
+      ["id" | _] ->
+        false
+
+      _ ->
+        true
+    end)
+    |> Stream.map(fn [id, begin_date, end_date, count, seconds, station] ->
+      [
+        id: id,
+        begin_date: begin_date,
+        end_date: end_date,
+        count: count,
+        seconds: Float.parse(seconds) |> elem(0),
+        station: station
+      ]
+    end)
+    |> Enum.sort_by(fn row -> row[:seconds] end)
+    |> Enum.with_index()
+  end
+
+  defp put_csv_in_s3(rows, date) do
+    # Put the data in CSV format with header rows
+    Logger.info("Creating CSV File...")
+    csv_data =
+      for row <- rows, into: "station,95th_percentile,99th_percentile,count\n" do
+        Enum.join(row, ",") <> "\n"
+      end
+
+    report_filename = "#{date}-message_latency.csv"
+
+    with :ok <- File.write!(report_filename, csv_data) do
+      s3_client = Application.get_env(:realtime_signs, :s3_client)
+      aws_client = Application.get_env(:realtime_signs, :aws_client)
+
+      Logger.info(
+        "Storing report in S3 at #{s3_bucket()}/#{s3_paess_reports_path()}/#{report_filename}..."
+      )
+
+      case s3_client.put_object(
+             s3_bucket(),
+             "#{s3_paess_reports_path()}/#{report_filename}",
+             File.read!(report_filename)
+           )
+           |> aws_client.request() do
+        {:ok, _} ->
+          Logger.info("Message latency report was successfully stored in S3")
+
+        {:error, response} ->
+          Logger.error(
+            "Message latency report was not able to be stored. Response: #{inspect(response)}"
+          )
+      end
+    end
+
+    Logger.info("Deleting file at path #{report_filename}")
+    File.rm!(report_filename)
+  end
+
+  defp get_station_code_from_filename(file_name) do
+    [_date, station_code] =
+      file_name |> to_string |> String.upcase() |> String.trim(".CSV") |> String.split("/")
+
+    station_code
+  end
+
+  defp get_percentile_row(percentile_index, rows_with_index) do
+    {percentile_row, _index} =
+      Enum.find(rows_with_index, {[], nil}, fn {_row, index} ->
+        index == percentile_index
+      end)
+
+    percentile_row
+  end
+
+  defp calculate_percentile_index(num_rows, percentile) do
+    (num_rows - 1)
+    |> Kernel.*(percentile)
+    |> round()
+  end
+
+  defp s3_bucket, do: Application.get_env(:realtime_signs, :message_log_s3_bucket)
+  defp s3_paess_logs_path, do: Application.get_env(:realtime_signs, :message_log_s3_folder)
+
+  defp s3_paess_reports_path,
+    do: Application.get_env(:realtime_signs, :message_log_report_s3_folder)
+end

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -42,13 +42,14 @@ defmodule Jobs.MessageLatencyReport do
 
       case :os.type() do
         {:unix, _} ->
+          # Only useful for running the job locally since realtime_signs is deployed to a windows container
+          Logger.debug("OS is unix")
           :os.cmd(:"cat #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
 
         {:win32, _} ->
-          :os.cmd(:"type #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
+          Logger.debug("OS is windows")
+          :os.cmd(:"type #{unzipped_directory}\\*.csv > #{unzipped_directory}\\all.csv")
       end
-
-      :os.cmd(:"type #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
 
       [get_csv_row("#{unzipped_directory}/all.csv") | Enum.map(files, &get_csv_row/1)]
       |> format_csv_data()

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -39,8 +39,16 @@ defmodule Jobs.MessageLatencyReport do
     with {:ok, response} <- get_zip_file(date),
          {:ok, files} <- :zip.unzip(response.body) do
       unzipped_directory = String.replace(date, "-", "")
-      # TODO: Switch this to Windows equivalent
-      :os.cmd(:"cat #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
+
+      case :os.type() do
+        {:unix, _} ->
+          :os.cmd(:"cat #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
+
+        {:win32, _} ->
+          :os.cmd(:"type #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
+      end
+
+      :os.cmd(:"type #{unzipped_directory}/*.csv > #{unzipped_directory}/all.csv")
 
       [get_csv_row("#{unzipped_directory}/all.csv") | Enum.map(files, &get_csv_row/1)]
       |> format_csv_data()

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -9,10 +9,10 @@ defmodule Jobs.MessageLatencyReport do
   * days_to_analyze: The number of days to go back. This value will default to 7 because
   we plan to schedule the job to run on a weekly basis.
 
-  The job will download the zip file containing message latency log files for each
-  station and calculate the 95th and 99th percentiles along with the total
-  row count for each one. It will aggregate the stats both for the combined logs
-  from every station as well as on a per station basis for a given day in a CSV file.
+  The job downloads the zip file containing message latency log files for each
+  station and calculates the 95th and 99th percentiles along with the total
+  row count for each one. It then aggregates into a CSV file the stats both for the combined logs
+  from every station as well as on a per station basis for a given day.
   The job will then store this file in S3.
   """
   require Logger

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -20,4 +20,14 @@ defmodule RealtimeSignsWeb.MonitoringController do
     RealtimeSigns.MessageLogJob.get_and_store_logs(date)
     send_resp(conn, 200, "")
   end
+
+  @doc """
+  This method can be used to manually invoke a run of the job to generate a message latency report.
+
+  Param "days" is an integer used to tell the job how many days back it should analyze
+  """
+  def run_message_latency_report(conn, %{"days" => days} = _params) do
+    Jobs.MessageLatencyReport.generate_message_latency_report(String.to_integer(days))
+    send_resp(conn, 200, "")
+  end
 end

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -24,10 +24,19 @@ defmodule RealtimeSignsWeb.MonitoringController do
   @doc """
   This method can be used to manually invoke a run of the job to generate a message latency report.
 
+  Param "start_date" is where the job starts and should be in iso8601 format (YYYY-MM-DD)
   Param "days" is an integer used to tell the job how many days back it should analyze
   """
-  def run_message_latency_report(conn, %{"days" => days} = _params) do
-    Jobs.MessageLatencyReport.generate_message_latency_report(String.to_integer(days))
+  def run_message_latency_report(conn, %{"start_date" => start_date, "days" => days} = _params) do
+    Logger.info(
+      "Beginning manual run of message latency report starting from #{start_date} going back #{days} days"
+    )
+
+    Jobs.MessageLatencyReport.generate_message_latency_reports(
+      Date.from_iso8601!(start_date),
+      String.to_integer(days)
+    )
+
     send_resp(conn, 200, "")
   end
 end

--- a/lib/realtime_signs_web/router.ex
+++ b/lib/realtime_signs_web/router.ex
@@ -11,6 +11,11 @@ defmodule RealtimeSignsWeb.Router do
     pipe_through([:api])
     post("/uptime", MonitoringController, :uptime)
     get("/run_message_log_job/:date", MonitoringController, :run_message_log_job)
-    get("/run_message_latency_report/:days", MonitoringController, :run_message_latency_report)
+
+    get(
+      "/run_message_latency_report/:start_date/:days",
+      MonitoringController,
+      :run_message_latency_report
+    )
   end
 end

--- a/lib/realtime_signs_web/router.ex
+++ b/lib/realtime_signs_web/router.ex
@@ -11,5 +11,6 @@ defmodule RealtimeSignsWeb.Router do
     pipe_through([:api])
     post("/uptime", MonitoringController, :uptime)
     get("/run_message_log_job/:date", MonitoringController, :run_message_log_job)
+    get("/run_message_latency_report/:days", MonitoringController, :run_message_latency_report)
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Outline the message latency evaluation steps & outputs](https://app.asana.com/0/1201786812162837/1203092194190502/f)

This job is responsible for generating daily ARINC message latency reports based on a provided start_date and days_to_analyze.

### Params:
  * start_date: The date from which the job should begin generating reports. The job
  will work backwards from this date. Defaults to Date.utc_today() - 1 because those
  will be the latest logs that we have when this job runs on its CRON schedule.
  * days_to_analyze: The number of days to go back. This value will default to 7 because
  we plan to schedule the job to run on a weekly basis.

The job downloads the zip file containing message latency log files for each station and calculates the 95th and 99th percentiles along with the total row count for each one. It then aggregates into a CSV file the stats both for the combined logs from every station as well as on a per station basis for a given day. The job will then store this file in S3.

Example generated CSV:
[2022-10-31-message_latency(10).csv](https://github.com/mbta/realtime_signs/files/9914366/2022-10-31-message_latency.10.csv)

