### PR TITLE
Trains predicted to 70501 will use Lechmere headway dest

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -54,8 +54,7 @@ defmodule Content.Utilities do
 
   def destination_for_prediction(_, 1, "70205"), do: {:ok, :north_station}
   def destination_for_prediction(_, 1, "70503"), do: {:ok, :union_square}
-  def destination_for_prediction(_, 1, "70501"), do: {:ok, :union_square}
-  def destination_for_prediction(_, 1, "70207"), do: {:ok, :union_square}
+  def destination_for_prediction(_, 1, "70501"), do: {:ok, :lechmere}
   def destination_for_prediction(_, 1, "70201"), do: {:ok, :government_center}
   def destination_for_prediction(_, 1, "70200"), do: {:ok, :park_street}
   def destination_for_prediction(_, 1, "71199"), do: {:ok, :park_street}
@@ -71,7 +70,7 @@ defmodule Content.Utilities do
   def destination_for_prediction("Green-B", 1, _), do: {:ok, :government_center}
   def destination_for_prediction("Green-C", 1, _), do: {:ok, :government_center}
   def destination_for_prediction("Green-D", 1, _), do: {:ok, :north_station}
-  def destination_for_prediction("Green-E", 1, _), do: {:ok, :union_square}
+  def destination_for_prediction("Green-E", 1, _), do: {:ok, :lechmere}
 
   def destination_for_prediction(_, _, _), do: {:error, :not_found}
 


### PR DESCRIPTION
E trains are now running as non-revenue to Medford/Tufts, but were still using Union Sq as the headway direction for trains being predicted to Lechmere because of a past hot-fix.

We can also remove another artifact from a past hot-fix where we used Union Sq as the destination for trains that were only being predicted out til Science Park, but were going to Union Sq.

And finally, we should update the catch-all function definition for E-line trains that was initially set to union sq when GLX branch 1 first opened. This will be updated once again once Branch 2 opens to be Medford/Tufts 

![Screen Shot 2022-11-02 at 4 31 07 PM](https://user-images.githubusercontent.com/16074540/199596549-b9567b9d-83c3-4595-87d4-5c1d8a60ae41.png)

