### PR TITLE
Update headway destination values for E, GLX stations, and North Station

### DIFF
--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -105,7 +105,14 @@ defmodule Content.Audio.VehiclesToDestination do
       case PaEss.Utilities.destination_to_ad_hoc_string(audio.destination) do
         {:ok, destination_string} ->
           vehicles_to_destination =
-            if audio.destination in [:northbound, :southbound, :eastbound, :westbound] do
+            if audio.destination in [
+                 :northbound,
+                 :southbound,
+                 :eastbound,
+                 :westbound,
+                 :inbound,
+                 :outbound
+               ] do
               destination_string <> " trains"
             else
               "Trains to " <> destination_string

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -69,7 +69,7 @@ defmodule Content.Utilities do
   def destination_for_prediction("Green-E", 0, _), do: {:ok, :heath_street}
   def destination_for_prediction("Green-B", 1, _), do: {:ok, :government_center}
   def destination_for_prediction("Green-C", 1, _), do: {:ok, :government_center}
-  def destination_for_prediction("Green-D", 1, _), do: {:ok, :north_station}
+  def destination_for_prediction("Green-D", 1, _), do: {:ok, :union_square}
   def destination_for_prediction("Green-E", 1, _), do: {:ok, :lechmere}
 
   def destination_for_prediction(_, _, _), do: {:error, :not_found}

--- a/lib/pa_ess.ex
+++ b/lib/pa_ess.ex
@@ -38,4 +38,6 @@ defmodule PaEss do
           | :southbound
           | :eastbound
           | :westbound
+          | :inbound
+          | :outbound
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -217,11 +217,13 @@ defmodule PaEss.Utilities do
   def headsign_to_destination("Reservoir"), do: {:ok, :reservoir}
   def headsign_to_destination("Riverside"), do: {:ok, :riverside}
   def headsign_to_destination("Heath Street"), do: {:ok, :heath_street}
+  def headsign_to_destination("Union Square"), do: {:ok, :union_square}
   def headsign_to_destination("Northbound"), do: {:ok, :northbound}
   def headsign_to_destination("Southbound"), do: {:ok, :southbound}
   def headsign_to_destination("Eastbound"), do: {:ok, :eastbound}
   def headsign_to_destination("Westbound"), do: {:ok, :westbound}
-  def headsign_to_destination("Union Square"), do: {:ok, :union_square}
+  def headsign_to_destination("Inbound"), do: {:ok, :inbound}
+  def headsign_to_destination("Outbound"), do: {:ok, :outbound}
   def headsign_to_destination(_unknown), do: {:error, :unknown}
 
   @spec destination_to_sign_string(PaEss.destination()) :: String.t()
@@ -245,11 +247,13 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string(:reservoir), do: "Reservoir"
   def destination_to_sign_string(:riverside), do: "Riverside"
   def destination_to_sign_string(:heath_street), do: "Heath St"
+  def destination_to_sign_string(:union_square), do: "Union Sq"
   def destination_to_sign_string(:northbound), do: "Northbound"
   def destination_to_sign_string(:southbound), do: "Southbound"
   def destination_to_sign_string(:eastbound), do: "Eastbound"
   def destination_to_sign_string(:westbound), do: "Westbound"
-  def destination_to_sign_string(:union_square), do: "Union Sq"
+  def destination_to_sign_string(:inbound), do: "Inbound"
+  def destination_to_sign_string(:outbound), do: "Outbound"
 
   @spec destination_to_ad_hoc_string(PaEss.destination()) ::
           {:ok, String.t()} | {:error, :unknown}
@@ -273,11 +277,13 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:reservoir), do: {:ok, "Reservoir"}
   def destination_to_ad_hoc_string(:riverside), do: {:ok, "Riverside"}
   def destination_to_ad_hoc_string(:heath_street), do: {:ok, "Heath Street"}
+  def destination_to_ad_hoc_string(:union_square), do: {:ok, "Union Square"}
   def destination_to_ad_hoc_string(:northbound), do: {:ok, "Northbound"}
   def destination_to_ad_hoc_string(:southbound), do: {:ok, "Southbound"}
   def destination_to_ad_hoc_string(:eastbound), do: {:ok, "Eastbound"}
   def destination_to_ad_hoc_string(:westbound), do: {:ok, "Westbound"}
-  def destination_to_ad_hoc_string(:union_square), do: {:ok, "Union Square"}
+  def destination_to_ad_hoc_string(:inbound), do: {:ok, "Inbound"}
+  def destination_to_ad_hoc_string(:outbound), do: {:ok, "Outbound"}
   def destination_to_ad_hoc_string(_unknown), do: {:error, :unknown}
 
   @spec route_to_ad_hoc_string(String.t()) :: {:ok, String.t()} | {:error, :unknown}

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6679,7 +6679,7 @@
         {
           "stop_id": "70242",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Lechmere",
           "routes": [
             "Green-E"
           ],
@@ -6733,7 +6733,7 @@
         {
           "stop_id": "70240",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Lechmere",
           "routes": [
             "Green-E"
           ],
@@ -6787,7 +6787,7 @@
         {
           "stop_id": "70240",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Lechmere",
           "routes": [
             "Green-E"
           ],

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7183,7 +7183,7 @@
         {
           "stop_id": "70205",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7213,7 +7213,7 @@
         {
           "stop_id": "70206",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7243,7 +7243,7 @@
         {
           "stop_id": "70206",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7273,7 +7273,7 @@
         {
           "stop_id": "70207",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7303,7 +7303,7 @@
         {
           "stop_id": "70208",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7333,7 +7333,7 @@
         {
           "stop_id": "70207",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7350,7 +7350,7 @@
         {
           "stop_id": "70208",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7380,7 +7380,7 @@
         {
           "stop_id": "70501",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7410,7 +7410,7 @@
         {
           "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7440,7 +7440,7 @@
         {
           "stop_id": "70501",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
+          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7455,7 +7455,7 @@
         {
           "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7483,9 +7483,9 @@
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Riverside",
           "routes": [
-            "Green-E"
+            "Green-D"
           ],
           "platform": null,
           "terminal": true,
@@ -7508,9 +7508,9 @@
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Riverside",
           "routes": [
-            "Green-E"
+            "Green-D"
           ],
           "platform": null,
           "terminal": true,
@@ -7537,9 +7537,9 @@
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
+          "headway_direction_name": "Riverside",
           "routes": [
-            "Green-E"
+            "Green-D"
           ],
           "platform": null,
           "terminal": true,


### PR DESCRIPTION
These changes only pertain to default values for signs set to headway mode 
- Headway mode for E Line only stations will use `Lechmere` as headway destination (Symphony and Prudential)
- Headway mode for Union Sq will use `Riverside` as headway destination because primarily D trains run out of there now
- Add `Inbound` and `Outbound` as possible values for headway destinations
- Green Line North Station will use `Inbound/Outbound`
- Science will use `Inbound/Outbound`
- Lechmere will use `Inbound/Outbound`

PIO Eryk Rotondo was made aware of and is ok with the use of Inbound/Outbound at these few stations https://mbta.slack.com/archives/C049FR1UQCV/p1667582256334679

Screenshots taken in dev:
![Screen Shot 2022-11-04 at 3 04 42 PM](https://user-images.githubusercontent.com/16074540/200055628-b7c40edb-2bee-4cf9-9124-58948674fda4.png)

![Screen Shot 2022-11-04 at 3 04 17 PM](https://user-images.githubusercontent.com/16074540/200055498-378145a0-09dd-44d3-86bc-16216a5958d9.png)

