### PR TITLE
Fix for alerts affecting B Line countdown clocks

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -3,7 +3,6 @@ defmodule Signs.Utilities.Messages do
   Helper functions for deciding which message a sign should
   be displaying
   """
-  require Logger
 
   @type sign_messages ::
           {{Signs.Utilities.SourceConfig.config() | nil, Content.Message.t()},
@@ -51,18 +50,16 @@ defmodule Signs.Utilities.Messages do
           Engine.Alerts.Fetcher.stop_status()
         ) :: sign_messages()
   defp get_headway_or_alert_messages(sign, current_time, alert_status) do
-    case get_alert_messages(alert_status, sign) do
+    case get_alert_messages(alert_status, sign.uses_shuttles) do
       nil -> Signs.Utilities.Headways.get_messages(sign, current_time)
       messages -> messages
     end
   end
 
-  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
+  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), boolean()) ::
           sign_messages() | nil
-  defp get_alert_messages(alert_status, sign) do
-    Logger.info("alert_status: #{alert_status} sign: #{inspect(sign)}")
-
-    case {alert_status, sign.uses_shuttles} do
+  defp get_alert_messages(alert_status, uses_shuttles) do
+    case {alert_status, uses_shuttles} do
       {:shuttles_transfer_station, _} ->
         {{nil, Content.Message.Empty.new()}, {nil, Content.Message.Empty.new()}}
 

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -3,6 +3,7 @@ defmodule Signs.Utilities.Messages do
   Helper functions for deciding which message a sign should
   be displaying
   """
+  require Logger
 
   @type sign_messages ::
           {{Signs.Utilities.SourceConfig.config() | nil, Content.Message.t()},
@@ -50,16 +51,18 @@ defmodule Signs.Utilities.Messages do
           Engine.Alerts.Fetcher.stop_status()
         ) :: sign_messages()
   defp get_headway_or_alert_messages(sign, current_time, alert_status) do
-    case get_alert_messages(alert_status, sign.uses_shuttles) do
+    case get_alert_messages(alert_status, sign) do
       nil -> Signs.Utilities.Headways.get_messages(sign, current_time)
       messages -> messages
     end
   end
 
-  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), boolean()) ::
+  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
           sign_messages() | nil
-  defp get_alert_messages(alert_status, uses_shuttles) do
-    case {alert_status, uses_shuttles} do
+  defp get_alert_messages(alert_status, sign) do
+    Logger.info("alert_status: #{alert_status} sign: #{inspect(sign)}")
+
+    case {alert_status, sign.uses_shuttles} do
       {:shuttles_transfer_station, _} ->
         {{nil, Content.Message.Empty.new()}, {nil, Content.Message.Empty.new()}}
 

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -65,6 +65,12 @@
     {"station": "G Fenway inbound", "stop_ids": ["70186"]},
     {"station": "G Kenmore inbound", "stop_ids": ["70150"]}
   ],
+  "Green-B": [
+    {"station": "G Babock eastbound", "stop_ids": ["170136"]},
+    {"station": "G Amory eastbound", "stop_ids": ["170140"]},
+    {"station": "G Amory westbound", "stop_ids": ["170141"]},
+    {"station": "G Babcock westbound", "stop_ids": ["170137"]}
+  ],
   "Mattapan": [
     {"station": "M Mattapan inbound", "stop_ids": ["70276"]},
     {"station": "M Capen St. inbound", "stop_ids": ["70274"]},

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -66,10 +66,12 @@
     {"station": "G Kenmore inbound", "stop_ids": ["70150"]}
   ],
   "Green-B": [
+    {"station": "G Kenmore eastbound", "stop_ids": ["71150"]},
     {"station": "G Babock eastbound", "stop_ids": ["170136"]},
     {"station": "G Amory eastbound", "stop_ids": ["170140"]},
     {"station": "G Amory westbound", "stop_ids": ["170141"]},
-    {"station": "G Babcock westbound", "stop_ids": ["170137"]}
+    {"station": "G Babcock westbound", "stop_ids": ["170137"]},
+    {"station": "G Kenmore westbound", "stop_ids": ["71151"]}
   ],
   "Mattapan": [
     {"station": "M Mattapan inbound", "stop_ids": ["70276"]},

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -67,7 +67,7 @@
   ],
   "Green-B": [
     {"station": "G Kenmore eastbound", "stop_ids": ["71150"]},
-    {"station": "G Babock eastbound", "stop_ids": ["170136"]},
+    {"station": "G Babcock eastbound", "stop_ids": ["170136"]},
     {"station": "G Amory eastbound", "stop_ids": ["170140"]},
     {"station": "G Amory westbound", "stop_ids": ["170141"]},
     {"station": "G Babcock westbound", "stop_ids": ["170137"]},


### PR DESCRIPTION
This config file affects how alerts are processed and applied to content displayed on countdown clocks.

Basically, we have to have the stops listed in sequence so that the logic can determine how the alert relates to the stop and therefore decide what content to choose. Without the list defined, the countdown clocks will just default to headway mode since there would be no predictions due to the alert (using a shuttle alert as an example here).

For an example of the logic working - if a stop is a where a shuttle alert begins, we blank out the clock to avoid misleading riders since we don't always know where the shuttles board whereas if a stop is along the route where the alert is in effect, we tell riders "No train service. Use shuttle bus".