### PR TITLE
Change default days to analzye to 1

### DIFF
--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -26,7 +26,7 @@ defmodule Jobs.MessageLatencyReport do
   @spec generate_message_latency_reports(Date.t(), integer) :: :ok
   def generate_message_latency_reports(
         start_date \\ Date.utc_today() |> Date.add(-1),
-        days_to_analyze \\ 7
+        days_to_analyze \\ 1
       ) do
     Enum.each(0..(days_to_analyze - 1), fn diff ->
       date = start_date |> Date.add(-diff) |> Date.to_string()


### PR DESCRIPTION
Small tweak to make the default value for number of days to analyze for the message latency reporting job to be 1 day.

Running the job for 7 days worth of data at once is causing the heap to max out and the application to crash. Since we get logs from ARINC on a nightly basis and each report CSV that's generated is for one day's worth of data, there's no reason we can't just run the job on a nightly basis.

This PR changes the default value to 1 day to analyze so that when the job runs on it's CRON schedule, it just does the prior day.
