### PR TITLE
Add configuration for RASH-s sign zone

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -4700,6 +4700,33 @@
     ]
   },
   {
+    "id": "red_ashmont_southbound",
+    "headway_group": "mattapan_trunk",
+    "type": "realtime",
+    "pa_ess_loc": "RASH",
+    "read_loop_offset": 60,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": [
+      [
+        {
+          "stop_id": "70261",
+          "routes": [
+            "Mattapan"
+          ],
+          "direction_id": 0,
+          "headway_direction_name": "Mattapan",
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": true,
+          "announce_boarding": true
+        }
+      ]
+    ]
+  },
+  {
     "id": "north_quincy_mezzanine",
     "headway_group": "red_braintree",
     "type": "realtime",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Blank countdown clocks on Ashmont drop-off platform display next 2 Mattapan Line departures](https://app.asana.com/0/1201786812162837/1203414051619270/f)

This PR adds the configuration necessary to have realtime-signs start sending Mattapan predictions to the Ashmont SB zone. The change goes hand-in-hand with this [Signs UI PR](https://github.com/mbta/signs_ui/pull/880)
