### PR TITLE
Calculate max send rate and avg wait time at runtime

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -40,7 +40,6 @@ defmodule PaEss.HttpUpdater do
       http_poster: http_poster,
       queue_mod: queue_mod,
       updater_index: opts[:updater_index],
-      max_send_rate_per_sec: max_send_rate_per_sec,
       avg_ms_between_sends: avg_ms_between_sends
     )
   end
@@ -55,7 +54,6 @@ defmodule PaEss.HttpUpdater do
        updater_index: opts[:updater_index],
        internal_counter: 0,
        timestamp: div(System.system_time(:millisecond), 500),
-       max_send_rate_per_sec: opts[:max_send_rate_per_sec],
        avg_ms_between_sends: opts[:avg_ms_between_sends]
      }}
   end

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -14,12 +14,6 @@ defmodule PaEss.HttpUpdater do
   @type post_result ::
           {:ok, :sent} | {:ok, :no_audio} | {:error, :bad_status} | {:error, :post_error}
 
-  # Normally an anti-pattern! But we mix compile --force with every deploy
-  @max_send_rate_per_sec (32 / Application.compile_env(:realtime_signs, :number_of_http_updaters))
-                         |> Float.ceil()
-                         |> Kernel.trunc()
-  @avg_ms_between_sends round(1000 / @max_send_rate_per_sec)
-
   use GenServer
   require Logger
 
@@ -34,11 +28,20 @@ defmodule PaEss.HttpUpdater do
     http_poster = opts[:http_poster] || Application.get_env(:realtime_signs, :http_poster_mod)
     queue_mod = opts[:queue_mod] || MessageQueue
 
+    max_send_rate_per_sec =
+      (32 / Application.get_env(:realtime_signs, :number_of_http_updaters))
+      |> Float.ceil()
+      |> Kernel.trunc()
+
+    avg_ms_between_sends = round(1000 / max_send_rate_per_sec)
+
     GenServer.start_link(
       __MODULE__,
       http_poster: http_poster,
       queue_mod: queue_mod,
-      updater_index: opts[:updater_index]
+      updater_index: opts[:updater_index],
+      max_send_rate_per_sec: max_send_rate_per_sec,
+      avg_ms_between_sends: avg_ms_between_sends
     )
   end
 
@@ -51,7 +54,9 @@ defmodule PaEss.HttpUpdater do
        queue_mod: opts[:queue_mod],
        updater_index: opts[:updater_index],
        internal_counter: 0,
-       timestamp: div(System.system_time(:millisecond), 500)
+       timestamp: div(System.system_time(:millisecond), 500),
+       max_send_rate_per_sec: opts[:max_send_rate_per_sec],
+       avg_ms_between_sends: opts[:avg_ms_between_sends]
      }}
   end
 
@@ -63,7 +68,7 @@ defmodule PaEss.HttpUpdater do
     end
 
     send_time = System.monotonic_time(:millisecond) - before_time
-    wait_time = max(0, @avg_ms_between_sends - send_time)
+    wait_time = max(0, state.avg_ms_between_sends - send_time)
     schedule_check_queue(self(), wait_time)
 
     if state.internal_counter >= 15 do

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -349,7 +349,6 @@ defmodule PaEss.HttpUpdaterTest do
         updater_index: 1,
         internal_counter: 0,
         timestamp: div(System.system_time(:millisecond), 500),
-        max_send_rate_per_sec: 10,
         avg_ms_between_sends: 100
       },
       init

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -348,7 +348,9 @@ defmodule PaEss.HttpUpdaterTest do
         http_poster: Fake.HTTPoison,
         updater_index: 1,
         internal_counter: 0,
-        timestamp: div(System.system_time(:millisecond), 500)
+        timestamp: div(System.system_time(:millisecond), 500),
+        max_send_rate_per_sec: 10,
+        avg_ms_between_sends: 100
       },
       init
     )


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Chore: Revisit max send rate](https://app.asana.com/0/1201753694073608/1203627766980881/f)

In Elixir, module attributes are evaluated at compile time. This means that `@max_send_rate_per_sec` and `@avg_ms_between_sends` were being calculated based on compile time values which are just the defaults. The config value that we actually want to use gets set at runtime instead, which means that those values were not being utilized.

This PR moves the calculation of these values to the initialization step of the http_updater GenServers so that we will evaluate them at runtime.