### PR TITLE
Filter out JFK predictions > 5 min

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -59,7 +59,7 @@ defmodule Content.Audio.NextTrainCountdown do
               {:canned, {"142", [dest_var, platform_var(audio), verb_var(audio)], :audio}}
 
             audio.destination == :alewife and audio.station_code == "RJFK" and audio.zone == "m" and
-                audio.minutes >= 20 ->
+                audio.minutes > 5 ->
               platform_tbd_params(audio, dest_var)
 
             true ->

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -88,7 +88,9 @@ defmodule Content.Audio.Predictions do
           minutes: predictions.minutes,
           verb: if(src.terminal?, do: :departs, else: :arrives),
           track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform
+          platform: src.platform,
+          station_code: predictions.station_code,
+          zone: predictions.zone
         }
     end
   end

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -66,7 +66,9 @@ defmodule Content.Audio.Predictions do
           minutes: 1,
           verb: if(src.terminal?, do: :departs, else: :arrives),
           track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform
+          platform: src.platform,
+          station_code: predictions.station_code,
+          zone: predictions.zone
         }
 
       predictions.minutes == :max_time ->

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -151,10 +151,10 @@ defmodule Content.Message.Predictions do
           platform_name = Content.Utilities.stop_platform_name(stop_id)
 
           {headsign_message, platform_message} =
-            unless minutes == :max_time or (is_integer(minutes) and minutes > 5) do
-              {headsign <> " (#{String.slice(platform_name, 0..0)})", " (#{platform_name} plat)"}
-            else
+            if minutes == :max_time or (is_integer(minutes) and minutes > 5) do
               {headsign, " (Platform TBD)"}
+            else
+              {headsign <> " (#{String.slice(platform_name, 0..0)})", " (#{platform_name} plat)"}
             end
 
           [

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -151,11 +151,11 @@ defmodule Content.Message.Predictions do
           platform_name = Content.Utilities.stop_platform_name(stop_id)
 
           {headsign_message, platform_message} =
-            if minutes == :max_time,
-              do: {headsign, " (Platform TBD)"},
-              else:
-                {headsign <> " (#{String.slice(platform_name, 0..0)})",
-                 " (#{platform_name} plat)"}
+            unless minutes == :max_time or (is_integer(minutes) and minutes > 5) do
+              {headsign <> " (#{String.slice(platform_name, 0..0)})", " (#{platform_name} plat)"}
+            else
+              {headsign, " (Platform TBD)"}
+            end
 
           [
             {Content.Utilities.width_padded_string(

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -235,7 +235,7 @@ defmodule Content.Message.PredictionsTest do
     test "Includes Ashmont platform when northbound to JFK/UMass Mezzanine" do
       prediction = %Predictions.Prediction{
         stop_id: "70086",
-        seconds_until_arrival: 125,
+        seconds_until_arrival: 300,
         direction_id: 1,
         route_id: "Red",
         stopped?: false,
@@ -245,7 +245,7 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
 
       assert Content.Message.to_string(msg) == [
-               {"Alewife (A)  2 min", 6},
+               {"Alewife (A)  5 min", 6},
                {"Alewife (Ashmont plat)", 6}
              ]
     end
@@ -253,7 +253,7 @@ defmodule Content.Message.PredictionsTest do
     test "Includes Braintree platform when northbound to JFK/UMass Mezzanine" do
       prediction = %Predictions.Prediction{
         stop_id: "70096",
-        seconds_until_arrival: 125,
+        seconds_until_arrival: 300,
         direction_id: 1,
         route_id: "Red",
         stopped?: false,
@@ -263,15 +263,15 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
 
       assert Content.Message.to_string(msg) == [
-               {"Alewife (B)  2 min", 6},
+               {"Alewife (B)  5 min", 6},
                {"Alewife (Braintree plat)", 6}
              ]
     end
 
-    test "Platform TBD when northbound to JFK/UMass Mezzanine and over 20 min" do
+    test "Platform TBD when northbound to JFK/UMass Mezzanine and over 5 min" do
       prediction = %Predictions.Prediction{
         stop_id: "70096",
-        seconds_until_arrival: 1200,
+        seconds_until_arrival: 360,
         direction_id: 1,
         route_id: "Red",
         stopped?: false,
@@ -281,7 +281,7 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
 
       assert Content.Message.to_string(msg) == [
-               {"Alewife    20+ min", 6},
+               {"Alewife      6 min", 6},
                {"Alewife (Platform TBD)", 6}
              ]
     end


### PR DESCRIPTION
Upon revisiting JFK/UMass predictions and doing a finer-grained analysis, we found that platform predictions at JFK/UMass tend to get less accurate after around the 5 minute threshold. This adjustment is a response to that research.

When the next Alewife train is more than 5 minutes away, we will use the "Platform TBD" message to encourage riders to wait in the mezzanine until the next train is closer.
