### PR TITLE
Fix incorrect stop_id for college ave

### DIFF
--- a/priv/stops.json
+++ b/priv/stops.json
@@ -36,7 +36,7 @@
     {"station": "G Gilman Square eastbound", "stop_ids": ["70505"]},
     {"station": "G Magoun Square eastbound", "stop_ids": ["70507"]},
     {"station": "G Ball Square eastbound", "stop_ids": ["70509"]},
-    {"station": "G College Ave eastbound", "stop_ids": ["70513"]}
+    {"station": "G College Ave eastbound", "stop_ids": ["70511"]}
   ],
   "Green-E-westbound": [
     {"station": "G Symphony westbound", "stop_ids": ["70241"]},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate how alert conditions affect RTS messages](https://app.asana.com/0/1201753694073608/1203683812842466/f)

`stops.json` basically defines stop neighbors which helps Realtime Signs understand if a station should be considered a fully closed stop or a shuttle transfer stop when an active alert includes the stop_id. In this case, the stop_id for college ave eastbound was incorrectly set and therefore realtime signs incorrectly thought that the only neighboring stop for East Somerville was Gilman Sq when in reality, Gilman Sq is **College Ave's** neighbor.

By fixing the id, alerts should now be correctly applied to East Somerville.
