### PR TITLE
Add special casing for Kenmore inbound announcements

### DIFF
--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -3,8 +3,8 @@ defmodule Content.Audio.FollowingTrain do
   The following train to [destination] arrives in [n] minutes.
   """
 
-  @enforce_keys [:destination, :route_id, :verb, :minutes, :station_code]
-  defstruct @enforce_keys
+  @enforce_keys [:destination, :route_id, :verb, :minutes]
+  defstruct @enforce_keys ++ [station_code: nil]
 
   @type verb :: :arrives | :departs
 
@@ -13,7 +13,7 @@ defmodule Content.Audio.FollowingTrain do
           route_id: String.t(),
           verb: verb(),
           minutes: integer(),
-          station_code: String.t()
+          station_code: String.t() | nil
         }
 
   require Logger

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -37,10 +37,14 @@ defmodule Content.Audio.NextTrainCountdown do
       case Utilities.destination_var(audio.destination) do
         {:ok, dest_var} ->
           green_line_branch =
-            Content.Utilities.route_and_destination_branch_letter(
-              audio.route_id,
-              audio.destination
-            )
+            if audio.station_code == "GKEN" do
+              Content.Utilities.route_branch_letter(audio.route_id)
+            else
+              Content.Utilities.route_and_destination_branch_letter(
+                audio.route_id,
+                audio.destination
+              )
+            end
 
           cond do
             !is_nil(audio.track_number) ->

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -97,4 +97,10 @@ defmodule Content.Utilities do
   def route_and_destination_branch_letter("Green-D", :reservoir), do: :d
   def route_and_destination_branch_letter("Green-E", :heath_street), do: :e
   def route_and_destination_branch_letter(_route_id, _destination), do: nil
+
+  @spec route_branch_letter(String.t()) :: green_line_branch()
+  def route_branch_letter("Green-B"), do: :b
+  def route_branch_letter("Green-C"), do: :c
+  def route_branch_letter("Green-D"), do: :d
+  def route_branch_letter("Green-E"), do: :e
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update audio announcements at Kenmore](https://app.asana.com/0/1201753694073608/1203674455933121/f)

This special case logic is aimed to help improve clarity for blind/low-vision riders at Kenmore, which has a unique platform setup and can sometimes be confusing to riders. The new logic will ensure that whenever we're announcing the next or following train at Kenmore that we include the branch letter along with it. So for example, we would announce something like "The next C train to Gov't center arrives in 2 minutes. The following D train to Union Square arrives in 4 minutes". We already announce the branch letter in the westbound direction so there would be no change there.

Example of an audio request announcing the next C train to Gov't Center
- `MsgType=Canned&uid=563932713&mid=117&var=501%2C21000%2C537%2C21000%2C507%2C21000%2C4061%2C21000%2C503%2C21000%2C504%2C21000%2C5007%2C21000%2C505&typ=1&sta=GKEN001000&pri=5&tim=60`

Example of an audio request announcing a following B train to Gov't Center
- `MsgType=Canned&uid=563986502&mid=117&var=667%2C21000%2C536%2C21000%2C507%2C21000%2C4061%2C21000%2C503%2C21000%2C504%2C21000%2C5006%2C21000%2C505&typ=1&sta=GKEN000010&pri=5&tim=60`
