### PR TITLE
fix health check test and speed up tests

### DIFF
--- a/test/engine/alerts_test.exs
+++ b/test/engine/alerts_test.exs
@@ -11,7 +11,7 @@ defmodule Engine.AlertsTest do
           routes_ets_table_name: :routes_ets_table_test
         )
 
-      Process.sleep(500)
+      Process.sleep(50)
       assert Process.alive?(pid)
 
       log =

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -6,21 +6,21 @@ defmodule Engine.ConfigTest do
     test "is auto when the sign is enabled" do
       Engine.Config.update()
 
-      :timer.sleep(100)
+      Process.sleep(50)
       assert Engine.Config.sign_config("chelsea_inbound") == :auto
     end
 
     test "is off when the sign is disabled" do
       Engine.Config.update()
 
-      :timer.sleep(100)
+      Process.sleep(50)
       assert Engine.Config.sign_config("chelsea_outbound") == :off
     end
 
     test "is auto when the sign is unspecified" do
       Engine.Config.update()
 
-      :timer.sleep(100)
+      Process.sleep(50)
       assert Engine.Config.sign_config("unspecified_sign") == :auto
     end
 
@@ -46,7 +46,7 @@ defmodule Engine.ConfigTest do
     test "properly returns headway mode" do
       Engine.Config.update()
 
-      :timer.sleep(100)
+      Process.sleep(50)
       assert Engine.Config.sign_config("headway_test") == :headway
     end
   end

--- a/test/engine/health_test.exs
+++ b/test/engine/health_test.exs
@@ -7,11 +7,11 @@ defmodule Engine.HealthTest do
   setup :verify_on_exit!
 
   test "logs pool stats" do
-    {:ok, _pid} = Engine.Health.start_link(period_ms: 500)
+    {:ok, _pid} = Engine.Health.start_link(period_ms: 50)
 
     log =
       capture_log(fn ->
-        Process.sleep(600)
+        Process.sleep(60)
       end)
 
     assert log =~ "event=pool_info"
@@ -72,6 +72,7 @@ defmodule Engine.HealthTest do
     log =
       capture_log(fn ->
         send(pid, :ssl_closed)
+        Process.sleep(50)
       end)
 
     assert log =~ "unknown_message"

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -20,7 +20,7 @@ defmodule Engine.ScheduledHeadwaysTest do
       log =
         capture_log([level: :warn], fn ->
           send(pid, :unknown_message)
-          Process.sleep(500)
+          Process.sleep(50)
         end)
 
       assert Process.alive?(pid)

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -333,7 +333,7 @@ defmodule PaEss.HttpUpdaterTest do
     test "internal counter resets and timestamp does change" do
       state = make_state(%{queue_mod: Fake.MessageQueue, internal_counter: 15})
 
-      :timer.sleep(500)
+      Process.sleep(500)
       {response, new_state} = PaEss.HttpUpdater.handle_info(:check_queue, state)
 
       assert response == :noreply

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -118,7 +118,7 @@ defmodule Signs.RealtimeTest do
       log =
         capture_log([level: :warn], fn ->
           send(pid, :foo)
-          :timer.sleep(50)
+          Process.sleep(50)
         end)
 
       assert Process.alive?(pid)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate and resolve intermittent health test errors](https://app.asana.com/0/1201753694073608/1203657802315715/f)

This should fix the intermittent failures on the health check test. The issue is a race condition, where we `send` a message to the module and then immediately check its logs for a response. This adds a short wait before checking, similar to how other tests handle this same situation.

This also reduces some unnecessarily long sleeps in the test code, which results in a ~1 second reduction in total time for `mix test` (3 sec down to 2 sec for me).

Also converts `:timer.sleep` to the more recent `Process.sleep`