### PR TITLE
add bus sign type and get bus predictions

### DIFF
--- a/lib/engine/bus_predictions.ex
+++ b/lib/engine/bus_predictions.ex
@@ -1,0 +1,122 @@
+defmodule Engine.BusPredictions do
+  use GenServer
+  require Logger
+
+  def predictions_for_stop(id) do
+    GenServer.call(__MODULE__, {:predictions_for_stop, id})
+  end
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  def init(_) do
+    schedule_update(self())
+    {:ok, %{predictions: %{}}}
+  end
+
+  def handle_info(:update, state) do
+    schedule_update(self())
+    api_url = Application.get_env(:realtime_signs, :api_v3_url)
+    api_key = Application.get_env(:realtime_signs, :api_v3_key)
+    http_client = Application.get_env(:realtime_signs, :http_client)
+
+    with {:ok, req} <-
+           http_client.get(
+             api_url <> "/predictions",
+             if api_key do
+               [{"x-api-key", api_key}]
+             else
+               []
+             end,
+             timeout: 2000,
+             recv_timeout: 2000,
+             params: %{
+               "include" => "trip,vehicle",
+               "fields[prediction]" => "departure_time,direction_id",
+               "fields[trip]" => "headsign",
+               "fields[vehicle]" => "updated_at",
+               "filter[stop]" => Enum.join(Signs.Utilities.SignsConfig.all_bus_stop_ids(), ",")
+             }
+           ),
+         %{status_code: 200, body: body} <- req,
+         {:ok, %{"data" => data, "included" => included}} <- Jason.decode(body) do
+      vehicles_lookup =
+        for %{
+              "type" => "vehicle",
+              "id" => id,
+              "attributes" => %{"updated_at" => updated_at}
+            } <- included do
+          %{id: id, updated_at: updated_at}
+        end
+        |> index_by(& &1.id)
+
+      trips_lookup =
+        for %{
+              "type" => "trip",
+              "id" => id,
+              "attributes" => %{"headsign" => headsign},
+              "relationships" => %{
+                "route" => %{"data" => %{"id" => route_id}}
+              }
+            } <- included do
+          %{id: id, headsign: headsign, route_id: route_id}
+        end
+        |> index_by(& &1.id)
+
+      new_predictions =
+        for %{
+              "attributes" => %{
+                "direction_id" => direction_id,
+                "departure_time" => departure_time
+              },
+              "relationships" => %{
+                "route" => %{"data" => %{"id" => route_id}},
+                "stop" => %{"data" => %{"id" => stop_id}},
+                "trip" => %{"data" => %{"id" => trip_id}},
+                "vehicle" => %{"data" => vehicle_data}
+              }
+            } <- data,
+            # Multi-route trips will have duplicate predictions for each route.
+            # To filter them out, we only keep the one whose route_id matches the trip's.
+            route_id == trips_lookup[trip_id].route_id do
+          %{
+            direction_id: direction_id,
+            departure_time: Timex.parse!(departure_time, "{ISO:Extended}"),
+            route_id: route_id,
+            stop_id: stop_id,
+            headsign: trips_lookup[trip_id].headsign,
+            updated_at:
+              case vehicle_data do
+                %{"id" => vehicle_id} -> vehicles_lookup[vehicle_id].updated_at
+                _ -> nil
+              end
+          }
+        end
+        |> Enum.group_by(& &1.stop_id)
+
+      {:noreply, %{state | predictions: new_predictions}}
+    else
+      err ->
+        Logger.error("Error getting bus predictions: #{inspect(err)}")
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn("Engine.BusPredictions unknown_message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  def handle_call({:predictions_for_stop, id}, _from, state) do
+    {:reply, state.predictions[id], state}
+  end
+
+  defp schedule_update(pid) do
+    Process.send_after(pid, :update, 1_000)
+  end
+
+  defp index_by(enum, key_fun) do
+    Enum.into(enum, %{}, &{key_fun.(&1), &1})
+  end
+end

--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -28,7 +28,7 @@ defmodule Engine.ScheduledHeadways do
       Keyword.put_new(
         opts,
         :stop_ids,
-        Signs.Utilities.SignsConfig.all_stop_ids()
+        Signs.Utilities.SignsConfig.all_train_stop_ids()
       ),
       name: name
     )

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -17,6 +17,7 @@ defmodule RealtimeSigns do
         Engine.Health,
         Engine.Config,
         Engine.Predictions,
+        # Engine.BusPredictions, # Disabled during initial development
         Engine.ScheduledHeadways,
         Engine.Departures,
         Engine.Static,

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -66,14 +66,17 @@ defmodule Signs.Bus do
           ) do
         prediction
       end
-      # Exclude predictions that are too old
-      |> Enum.reject(&Timex.before?(&1.departure_time, Timex.shift(current_time, seconds: -5)))
+      # Exclude predictions whose times are missing or out of bounds
+      |> Stream.reject(
+        &(!&1.departure_time ||
+            Timex.before?(&1.departure_time, Timex.shift(current_time, seconds: -5)))
+      )
       # Special case: exclude 89.2 OB to Davis
-      |> Enum.reject(&(&1.stop_id == "5104" && String.starts_with?(&1.headsign, "Davis")))
+      |> Stream.reject(&(&1.stop_id == "5104" && String.starts_with?(&1.headsign, "Davis")))
       # Special case: exclude routes terminating at Braintree (230.4 IB, 236.3 OB)
-      |> Enum.reject(&(&1.stop_id == "38671" && String.starts_with?(&1.headsign, "Braintree")))
+      |> Stream.reject(&(&1.stop_id == "38671" && String.starts_with?(&1.headsign, "Braintree")))
       # Special case: exclude routes terminating at Mattapan, in case those variants of route 24 come back.
-      |> Enum.reject(
+      |> Stream.reject(
         &(&1.stop_id in ["185", "18511"] && String.starts_with?(&1.headsign, "Mattapan"))
       )
 

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -1,0 +1,106 @@
+defmodule Signs.Bus do
+  use GenServer
+  require Logger
+
+  def start_link(sign, opts \\ []) do
+    %{
+      "type" => "bus",
+      "id" => id,
+      "pa_ess_loc" => pa_ess_loc,
+      "text_zone" => text_zone,
+      "audio_zones" => audio_zones,
+      "sources" => sources
+    } = sign
+
+    state = %{
+      sign: %{
+        id: id,
+        pa_ess_loc: pa_ess_loc,
+        text_zone: text_zone,
+        audio_zones: audio_zones,
+        sources:
+          for %{"stop_id" => stop_id, "routes" => routes} <- sources do
+            %{
+              stop_id: stop_id,
+              routes:
+                for %{"route_id" => route_id, "direction_id" => direction_id} <- routes do
+                  %{
+                    route_id: route_id,
+                    direction_id: direction_id
+                  }
+                end
+            }
+          end
+      },
+      config_engine: opts[:config_engine] || Engine.Config,
+      prediction_engine: opts[:prediction_engine] || Engine.BusPredictions
+    }
+
+    GenServer.start_link(__MODULE__, state)
+  end
+
+  def init(state) do
+    schedule_run_loop(self())
+    {:ok, state}
+  end
+
+  def handle_info(:run_loop, state) do
+    schedule_run_loop(self())
+    %{sign: sign, config_engine: config_engine, prediction_engine: predictions_engine} = state
+    config = config_engine.sign_config(sign.id)
+    current_time = Timex.now()
+
+    predictions =
+      for %{stop_id: stop_id, routes: routes} <- sign.sources,
+          prediction <- predictions_engine.predictions_for_stop(stop_id),
+          Enum.any?(
+            routes,
+            &(&1.route_id == prediction.route_id && &1.direction_id == prediction.direction_id)
+          ),
+          # Exclude predictions that are too old
+          prediction.departure_time >= Timex.shift(current_time, seconds: -5),
+          # Special case: exclude 89.2 OB to Davis
+          !(prediction.stop_id == "5104" && String.starts_with?(prediction.headsign, "Davis")),
+          # Special case: exclude routes terminating at Braintree (230.4 IB, 236.3 OB)
+          !(prediction.stop_id == "38671" && String.starts_with?(prediction.headsign, "Braintree")),
+          # Special case: exclude routes terminating at Mattapan, in case those variants of route 24 come back.
+          !(prediction.stop_id in ["185", "18511"] &&
+              String.starts_with?(prediction.headsign, "Mattapan")) do
+        prediction
+      end
+
+    # Exclude missing headsign and/or display route (error?)
+
+    # Hold prediction in case of count-up
+    # Special case: Hold prediction for inbound SL1 with stale prediction
+
+    _ = predictions
+    _ = config
+
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn("Signs.Bus unknown_message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  def schedule_run_loop(pid) do
+    Process.send_after(pid, :run_loop, 1_000)
+  end
+
+  # defp display_route(%{route_id: "749"}), do: "SL5"
+  # defp display_route(%{route_id: "751"}), do: "SL4"
+  # defp display_route(%{route_id: "743"}), do: "SL3"
+  # defp display_route(%{route_id: "742"}), do: "SL2"
+  # defp display_route(%{route_id: "741"}), do: "SL1"
+  # defp display_route(%{route_id: "77", headsign: "North Cambridge"}), do: "77A"
+  # defp display_route(%{route_id: "2427", stop_id: "185", headsign: headsign}) do
+  #  cond do
+  #    String.starts_with?(headsign, "Ashmont") -> "27"
+  #    String.starts_with?(headsign, "Wakefield Av") -> "24"
+  #    true -> "2427"
+  #  end
+  # end
+  # defp display_route(%{route_id: route_id}), do: route_id
+end

--- a/lib/signs/supervisor.ex
+++ b/lib/signs/supervisor.ex
@@ -12,11 +12,6 @@ defmodule Signs.Supervisor do
   its display message from (in priority order) Drupal static text,
   predictions if available, schedules for headways. We also support
   ...?
-
-  (If all the signs are similar "enough", maybe we only need one type of
-  GenServer. I'm forgetting all the use cases we discussed for how signs
-  could differ. One-liners vs. two? Stops Away vs time? GreenLine Park St
-  weird cases?)
   """
   require Signs.Utilities.SignsConfig
   use Supervisor
@@ -42,4 +37,5 @@ defmodule Signs.Supervisor do
   end
 
   defp sign_module(%{"type" => "realtime"}), do: Signs.Realtime
+  defp sign_module(%{"type" => "bus"}), do: Signs.Bus
 end

--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -13,14 +13,24 @@ defmodule Signs.Utilities.SignsConfig do
     |> Jason.decode!()
   end
 
-  @doc "Extracts every stop_id from the signs.json configuration"
-  @spec all_stop_ids() :: [String.t()]
-  def all_stop_ids do
+  @doc "Extracts every train stop_id from the signs.json configuration"
+  @spec all_train_stop_ids() :: [String.t()]
+  def all_train_stop_ids do
     children_config()
+    |> Enum.filter(&match?(%{"type" => "realtime"}, &1))
     |> Enum.map(&get_stop_ids_for_sign(&1))
     |> List.flatten()
     |> Enum.reject(fn x -> x == nil end)
     |> Enum.uniq()
+  end
+
+  @spec all_bus_stop_ids() :: [String.t()]
+  def all_bus_stop_ids do
+    for %{"type" => "bus", "sources" => sources} <- children_config(),
+        %{"stop_id" => stop_id} <- sources,
+        uniq: true do
+      stop_id
+    end
   end
 
   @spec get_stop_ids_for_sign(map()) :: [String.t()]

--- a/scripts/transitway_engine/parse_config.exs
+++ b/scripts/transitway_engine/parse_config.exs
@@ -1,0 +1,90 @@
+# This is a temporary script to help port Transitway Engine functionality. It parses the
+# code/config and transforms the data into a format that works for realtime_signs.
+
+# This script currently expects to be run from the root directory of realtime_signs,
+# with a copy of transitway_engine sitting in a sibling directory.
+
+# NOTE: This script will modify/overwrite files, so only run it with a clean working directory.
+
+Mix.install([{:jason, "~> 1.4.0"}])
+
+lines =
+  File.read!("../transitway_engine/config/transitwayRoutes.cfg")
+  |> String.split("\n")
+  |> Enum.filter(&String.match?(&1, ~r/^[^#]/))
+
+{[_ | station_lines], lines} = Enum.split_while(lines, &(&1 != "[Route takes]"))
+
+{[_ | route_lines], [_ | abbrev_lines]} =
+  Enum.split_while(lines, &(&1 != "[Visual destination strings]"))
+
+lines =
+  File.read!("../transitway_engine/View/view_SignageLogic.c")
+  |> String.split("\r\n")
+  |> Enum.filter(&(!String.match?(&1, ~r/^\s*$/) && !String.match?(&1, ~r/^\s*\/\//)))
+
+[_, _ | lines] = Enum.drop_while(lines, &(&1 != "int view_InitializeSignageLogic()"))
+{initialize_lines, lines} = Enum.split_while(lines, &(&1 != "  if (view_processRoutesFile())"))
+# TODO continue parsing audio zones
+
+routes_list =
+  for line <- station_lines do
+    [id | source_strings] = String.split(line, ",")
+
+    routes =
+      for str <- source_strings do
+        [route_id, direction_id] = String.split(str, "_")
+        Jason.OrderedObject.new(route_id: route_id, direction_id: String.to_integer(direction_id))
+      end
+
+    %{id: id, routes: routes}
+  end
+
+for line <- route_lines do
+  [name, number] = String.split(line, ",")
+  %{name: name, number: String.to_integer(number)}
+end
+
+# |> IO.inspect
+
+for [line1, line2] <- Enum.chunk_every(abbrev_lines, 2) do
+  [name, number] = String.split(line1, ",")
+  abbreviations = String.split(line2, ",")
+  %{name: name, number: String.to_integer(number), abbreviations: abbreviations}
+end
+
+# |> IO.inspect
+
+signs_json =
+  for [line1, line2] <- Enum.chunk_every(initialize_lines, 2) do
+    [_, id, pa_ess_loc, text_zone, audio_zones, stop_id, max_preds, max_minutes] =
+      Regex.run(
+        ~r/  InitializeStop\([^,]+, "([\w.]+)", "(\w+)", '(\w)', "(\d*)", ([^,]+), +(\d), (\d+)\)/,
+        line1 <> " " <> String.trim(line2)
+      )
+
+    Jason.OrderedObject.new(
+      id: id,
+      pa_ess_loc: pa_ess_loc,
+      text_zone: text_zone,
+      audio_zones:
+        for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
+            String.at(audio_zones, i) == "1" do
+          c
+        end,
+      type: "bus",
+      sources:
+        with [_, sid] <- Regex.run(~r/STOP_ID_(\d+)_/, stop_id),
+             %{routes: routes} <- Enum.find(routes_list, &match?(%{id: ^id}, &1)) do
+          [Jason.OrderedObject.new(stop_id: sid, routes: routes)]
+        else
+          _ -> []
+        end,
+      max_preds: String.to_integer(max_preds),
+      max_minutes: String.to_integer(max_minutes)
+    )
+  end
+  |> Jason.encode!()
+  |> Jason.Formatter.pretty_print()
+
+File.write!("priv/signs.json", signs_json)

--- a/test/signs/utilities/signs_config_test.exs
+++ b/test/signs/utilities/signs_config_test.exs
@@ -3,13 +3,19 @@ defmodule Signs.Utilities.SignsConfigTest do
 
   require Signs.Utilities.SignsConfig
 
-  describe "all_stop_ids" do
+  describe "all_train_stop_ids" do
     test "includes a platform sign" do
-      assert Enum.member?(Signs.Utilities.SignsConfig.all_stop_ids(), "70058")
+      assert Enum.member?(Signs.Utilities.SignsConfig.all_train_stop_ids(), "70058")
     end
 
     test "includes a mezzanine sign" do
-      assert Enum.member?(Signs.Utilities.SignsConfig.all_stop_ids(), "70056")
+      assert Enum.member?(Signs.Utilities.SignsConfig.all_train_stop_ids(), "70056")
+    end
+  end
+
+  describe "all_bus_stop_ids" do
+    test "empty for now" do
+      assert Signs.Utilities.SignsConfig.all_bus_stop_ids() == []
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Create a new "bus" sign type](https://app.asana.com/0/1201753694073608/1203670096087486/f)
**Asana Ticket:** [Get bus predictions](https://app.asana.com/0/1201753694073608/1203670096087488/f)

This adds some initial pieces of the Transitway Engine code base:
* A new "bus" sign type to differentiate the behavior
* A module that downloads bus predictions
* A script that parses bulk data directly from the TE code

NOTE: None of the new modules are enabled by this PR, so this should be a no-op in production.