### PR TITLE
Enable second line paging when headways or alerts

### DIFF
--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -1,0 +1,58 @@
+defmodule Content.Audio.NoServiceToDestination do
+  @moduledoc """
+  No service to [destination]
+  """
+
+  require Logger
+
+  @enforce_keys [:message]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          message: String.t()
+        }
+
+  def from_message(
+        %Content.Message.Alert.DestinationNoService{destination: destination} = message
+      ) do
+    case PaEss.Utilities.destination_to_ad_hoc_string(destination) do
+      {:ok, destination} ->
+        audio = "No service to #{destination}"
+
+        %__MODULE__{
+          message: audio
+        }
+
+      {:error, :unknown} ->
+        Logger.error(
+          "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
+        )
+
+        nil
+    end
+  end
+
+  def from_message(%Content.Message.Alert.NoServiceUseShuttle{destination: destination} = message) do
+    case PaEss.Utilities.destination_to_ad_hoc_string(destination) do
+      {:ok, destination} ->
+        audio = "No service to #{destination} use shuttle"
+
+        %__MODULE__{
+          message: audio
+        }
+
+      {:error, :unknown} ->
+        Logger.error(
+          "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
+        )
+
+        nil
+    end
+  end
+
+  defimpl Content.Audio do
+    def to_params(%Content.Audio.NoServiceToDestination{message: message}) do
+      {:ad_hoc, {message, :audio}}
+    end
+  end
+end

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -37,6 +37,13 @@ defmodule Content.Audio.VehiclesToDestination do
     nil
   end
 
+  def from_paging_headway_message(%Content.Message.Headways.Paging{
+        destination: destination,
+        range: range
+      }) do
+    create(:english, destination, range, nil)
+  end
+
   @spec create(
           Content.Audio.language(),
           PaEss.destination() | nil,

--- a/lib/content/message/alert/destination_no_service.ex
+++ b/lib/content/message/alert/destination_no_service.ex
@@ -1,0 +1,21 @@
+defmodule Content.Message.Alert.DestinationNoService do
+  @moduledoc """
+  A message displayed when a station is closed while including a destination
+  """
+
+  @enforce_keys [:destination]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{}
+
+  defimpl Content.Message do
+    @default_page_width 24
+    def to_string(%Content.Message.Alert.DestinationNoService{destination: destination}) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        "no service",
+        @default_page_width
+      )
+    end
+  end
+end

--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -1,0 +1,30 @@
+defmodule Content.Message.Alert.NoServiceUseShuttle do
+  @moduledoc """
+  A paging message displayed when a station is closed due to shuttles with a destination
+  """
+
+  @enforce_keys [:destination]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: Paess.destination()
+        }
+
+  defimpl Content.Message do
+    @default_page_width 24
+    def to_string(%Content.Message.Alert.NoServiceUseShuttle{destination: destination}) do
+      [
+        {Content.Utilities.width_padded_string(
+           PaEss.Utilities.destination_to_sign_string(destination),
+           "no service",
+           @default_page_width
+         ), 3},
+        {Content.Utilities.width_padded_string(
+           PaEss.Utilities.destination_to_sign_string(destination),
+           "use shuttle",
+           @default_page_width
+         ), 3}
+      ]
+    end
+  end
+end

--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -7,7 +7,7 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
-          destination: Paess.destination()
+          destination: PaEss.destination()
         }
 
   defimpl Content.Message do

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -16,7 +16,7 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {"#{signify_vehicle_type(type)} every", 3},
+        {"#{signify_vehicle_type(type) |> String.capitalize()} every", 3},
         {Headway.HeadwayDisplay.format_paging_headway_range(range), 3}
       ]
     end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -17,7 +17,7 @@ defmodule Content.Message.Headways.Paging do
         }) do
       [
         {"#{signify_vehicle_type(type) |> String.capitalize()} every", 3},
-        {Headway.HeadwayDisplay.format_paging_headway_range(range), 3}
+        {format_paging_headway_range(range), 3}
       ]
     end
 
@@ -56,9 +56,11 @@ defmodule Content.Message.Headways.Paging do
     defp destination_range_string(destination, range) do
       Content.Utilities.width_padded_string(
         PaEss.Utilities.destination_to_sign_string(destination),
-        Headway.HeadwayDisplay.format_paging_headway_range(range),
+        format_paging_headway_range(range),
         @default_page_width
       )
     end
+
+    defp format_paging_headway_range({x, y}), do: "#{x} to #{y} min"
   end
 end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -1,0 +1,61 @@
+defmodule Content.Message.Headways.Paging do
+  defstruct [:destination, :vehicle_type, :range]
+
+  @type vehicle_type :: :bus | :trolley | :train
+  @type t :: %__MODULE__{
+          destination: PaEss.destination() | nil,
+          vehicle_type: vehicle_type(),
+          range: Headway.HeadwayDisplay.headway_range() | nil
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.Headways.Paging{
+          destination: nil,
+          vehicle_type: type,
+          range: range
+        }) do
+      [
+        {type |> signify_vehicle_type |> String.capitalize(), 3},
+        {Headway.HeadwayDisplay.format_headway_range(range), 3}
+      ]
+    end
+
+    def to_string(%Content.Message.Headways.Paging{
+          destination: destination,
+          vehicle_type: type,
+          range: range
+        })
+        when type in [:bus] do
+      [
+        {"#{type |> signify_vehicle_type() |> String.capitalize()} to #{PaEss.Utilities.destination_to_sign_string(destination)}",
+         3},
+        {Headway.HeadwayDisplay.format_headway_range(range), 3}
+      ]
+    end
+
+    def to_string(%Content.Message.Headways.Paging{
+          destination: destination,
+          vehicle_type: type,
+          range: range
+        }) do
+      [
+        {"#{PaEss.Utilities.destination_to_sign_string(destination)} #{signify_vehicle_type(type)}",
+         3},
+        {Headway.HeadwayDisplay.format_headway_range(range), 3}
+      ]
+    end
+
+    @spec signify_vehicle_type(Content.Message.Headways.Top.vehicle_type()) :: String.t()
+    defp signify_vehicle_type(:train) do
+      "trains"
+    end
+
+    defp signify_vehicle_type(:bus) do
+      "buses"
+    end
+
+    defp signify_vehicle_type(:trolley) do
+      "trolleys"
+    end
+  end
+end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -1,10 +1,8 @@
 defmodule Content.Message.Headways.Paging do
-  defstruct [:destination, :vehicle_type, :range]
+  defstruct [:destination, :range]
 
-  @type vehicle_type :: :bus | :trolley | :train
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
-          vehicle_type: vehicle_type(),
           range: Headway.HeadwayDisplay.headway_range() | nil
         }
 
@@ -12,43 +10,28 @@ defmodule Content.Message.Headways.Paging do
     @default_page_width 24
     def to_string(%Content.Message.Headways.Paging{
           destination: nil,
-          vehicle_type: type,
           range: range
         }) do
       [
-        {"#{signify_vehicle_type(type) |> String.capitalize()} every", 3},
+        {"Trains every", 3},
         {format_paging_headway_range(range), 3}
       ]
     end
 
     def to_string(%Content.Message.Headways.Paging{
           destination: destination,
-          vehicle_type: vehicle_type,
           range: range
         }) do
       [
-        {destination_vehicle_string(destination, vehicle_type), 3},
+        {destination_trains_every_string(destination), 3},
         {destination_range_string(destination, range), 3}
       ]
     end
 
-    @spec signify_vehicle_type(Content.Message.Headways.Paging.vehicle_type()) :: String.t()
-    defp signify_vehicle_type(:train) do
-      "trains"
-    end
-
-    defp signify_vehicle_type(:bus) do
-      "buses"
-    end
-
-    defp signify_vehicle_type(:trolley) do
-      "trolleys"
-    end
-
-    defp destination_vehicle_string(destination, vehicle_type) do
+    defp destination_trains_every_string(destination) do
       Content.Utilities.width_padded_string(
         PaEss.Utilities.destination_to_sign_string(destination),
-        "#{signify_vehicle_type(vehicle_type)} every",
+        "trains every",
         @default_page_width
       )
     end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -9,43 +9,30 @@ defmodule Content.Message.Headways.Paging do
         }
 
   defimpl Content.Message do
+    @default_page_width 24
     def to_string(%Content.Message.Headways.Paging{
           destination: nil,
           vehicle_type: type,
           range: range
         }) do
       [
-        {type |> signify_vehicle_type |> String.capitalize(), 3},
-        {Headway.HeadwayDisplay.format_headway_range(range), 3}
+        {"#{signify_vehicle_type(type)} every", 3},
+        {Headway.HeadwayDisplay.format_paging_headway_range(range), 3}
       ]
     end
 
     def to_string(%Content.Message.Headways.Paging{
           destination: destination,
-          vehicle_type: type,
-          range: range
-        })
-        when type in [:bus] do
-      [
-        {"#{type |> signify_vehicle_type() |> String.capitalize()} to #{PaEss.Utilities.destination_to_sign_string(destination)}",
-         3},
-        {Headway.HeadwayDisplay.format_headway_range(range), 3}
-      ]
-    end
-
-    def to_string(%Content.Message.Headways.Paging{
-          destination: destination,
-          vehicle_type: type,
+          vehicle_type: vehicle_type,
           range: range
         }) do
       [
-        {"#{PaEss.Utilities.destination_to_sign_string(destination)} #{signify_vehicle_type(type)}",
-         3},
-        {Headway.HeadwayDisplay.format_headway_range(range), 3}
+        {destination_vehicle_string(destination, vehicle_type), 3},
+        {destination_range_string(destination, range), 3}
       ]
     end
 
-    @spec signify_vehicle_type(Content.Message.Headways.Top.vehicle_type()) :: String.t()
+    @spec signify_vehicle_type(Content.Message.Headways.Paging.vehicle_type()) :: String.t()
     defp signify_vehicle_type(:train) do
       "trains"
     end
@@ -56,6 +43,22 @@ defmodule Content.Message.Headways.Paging do
 
     defp signify_vehicle_type(:trolley) do
       "trolleys"
+    end
+
+    defp destination_vehicle_string(destination, vehicle_type) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        "#{signify_vehicle_type(vehicle_type)} every",
+        @default_page_width
+      )
+    end
+
+    defp destination_range_string(destination, range) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        Headway.HeadwayDisplay.format_paging_headway_range(range),
+        @default_page_width
+      )
     end
   end
 end

--- a/lib/headway/headway_display.ex
+++ b/lib/headway/headway_display.ex
@@ -123,6 +123,8 @@ defmodule Headway.HeadwayDisplay do
   def format_headway_range({:up_to, x}), do: "Up to every #{x} min"
   def format_headway_range({x, y}), do: "Every #{x} to #{y} min"
 
+  def format_paging_headway_range({x, y}), do: "#{x} to #{y} min"
+
   @spec format_bottom(Content.Message.Headways.Bottom.t()) :: String.t()
   def format_bottom(%Content.Message.Headways.Bottom{prev_departure_mins: nil, range: range}) do
     format_headway_range(range)

--- a/lib/headway/headway_display.ex
+++ b/lib/headway/headway_display.ex
@@ -123,8 +123,6 @@ defmodule Headway.HeadwayDisplay do
   def format_headway_range({:up_to, x}), do: "Up to every #{x} min"
   def format_headway_range({x, y}), do: "Every #{x} to #{y} min"
 
-  def format_paging_headway_range({x, y}), do: "#{x} to #{y} min"
-
   @spec format_bottom(Content.Message.Headways.Bottom.t()) :: String.t()
   def format_bottom(%Content.Message.Headways.Bottom{prev_departure_mins: nil, range: range}) do
     format_headway_range(range)

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -201,15 +201,6 @@ defmodule Signs.Utilities.Audio do
   end
 
   defp get_audio(
-         {_, %Message.Predictions{}} = top,
-         {_, %Message.Headways.Paging{} = bottom},
-         multi_source?
-       ) do
-    {Audio.Predictions.from_sign_content(top, :top, multi_source?),
-     Audio.VehiclesToDestination.from_paging_headway_message(bottom)}
-  end
-
-  defp get_audio(
          {_, %Message.Predictions{minutes: :arriving, route_id: route_id}} = top_content,
          _bottom_content,
          multi_source?
@@ -282,6 +273,22 @@ defmodule Signs.Utilities.Audio do
 
   defp get_audio_for_line({_, %Message.Headways.Paging{} = message}, _line, _multi_source?) do
     Audio.VehiclesToDestination.from_paging_headway_message(message)
+  end
+
+  defp get_audio_for_line(
+         {_, %Message.Alert.DestinationNoService{} = message},
+         _line,
+         _multi_source?
+       ) do
+    Audio.NoServiceToDestination.from_message(message)
+  end
+
+  defp get_audio_for_line(
+         {_, %Message.Alert.NoServiceUseShuttle{} = message},
+         _line,
+         _multi_source?
+       ) do
+    Audio.NoServiceToDestination.from_message(message)
   end
 
   defp get_audio_for_line({_, %Message.Empty{}}, _line, _multi_source?) do

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -201,6 +201,15 @@ defmodule Signs.Utilities.Audio do
   end
 
   defp get_audio(
+         {_, %Message.Predictions{}} = top,
+         {_, %Message.Headways.Paging{} = bottom},
+         multi_source?
+       ) do
+    {Audio.Predictions.from_sign_content(top, :top, multi_source?),
+     Audio.VehiclesToDestination.from_paging_headway_message(bottom)}
+  end
+
+  defp get_audio(
          {_, %Message.Predictions{minutes: :arriving, route_id: route_id}} = top_content,
          _bottom_content,
          multi_source?

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -87,6 +87,18 @@ defmodule Signs.Utilities.Audio do
     false
   end
 
+  def should_interrupting_read?({_, %Content.Message.Headways.Paging{}}, _sign, _line) do
+    false
+  end
+
+  def should_interrupting_read?({_, %Content.Message.Alert.NoServiceUseShuttle{}}, _sign, _line) do
+    false
+  end
+
+  def should_interrupting_read?({_, %Content.Message.Alert.DestinationNoService{}}, _sign, _line) do
+    false
+  end
+
   def should_interrupting_read?(_content, _sign, _line) do
     true
   end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -280,6 +280,10 @@ defmodule Signs.Utilities.Audio do
     Audio.Predictions.from_sign_content(content, line, multi_source?)
   end
 
+  defp get_audio_for_line({_, %Message.Headways.Paging{} = message}, _line, _multi_source?) do
+    Audio.VehiclesToDestination.from_paging_headway_message(message)
+  end
+
   defp get_audio_for_line({_, %Message.Empty{}}, _line, _multi_source?) do
     nil
   end

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -84,7 +84,6 @@ defmodule Signs.Utilities.Headways do
     {config,
      %Content.Message.Headways.Paging{
        destination: destination,
-       vehicle_type: :train,
        range: {headways.range_low, headways.range_high}
      }}
   end

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -26,9 +26,13 @@ defmodule Signs.Utilities.Headways do
           DateTime.t()
         ) :: Content.Message.Headways.Paging.t()
   def get_paging_message(sign, config, current_time) do
-    headways = sign.config_engine.headway_config(sign.headway_group, current_time)
-    destination = source_list_destination(config)
-    get_paging_headway_message(destination, headways)
+    case sign.config_engine.headway_config(sign.headway_group, current_time) do
+      nil ->
+        %Content.Message.Empty{}
+
+      headways ->
+        config |> source_list_destination() |> get_paging_headway_message(headways)
+    end
   end
 
   @spec display_headways?(

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -46,7 +46,8 @@ defmodule Signs.Utilities.Headways do
     get_destination(config)
   end
 
-  @spec get_destination(SourceConfig.source() | List.t() | nil) :: PaEss.destination() | nil
+  @spec get_destination(SourceConfig.source() | list(SourceConfig.source()) | nil) ::
+          PaEss.destination() | nil
   defp get_destination(nil), do: nil
 
   defp get_destination(config) when is_list(config) do

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -22,7 +22,7 @@ defmodule Signs.Utilities.Headways do
 
   def get_paging_message(sign, config, current_time) do
     headways = sign.config_engine.headway_config(sign.headway_group, current_time)
-    destination = get_destination(config)
+    destination = source_list_destination(config)
     get_paging_headway_message(config, destination, headways)
   end
 
@@ -42,15 +42,8 @@ defmodule Signs.Utilities.Headways do
   defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
   defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
 
-  def get_headway_destination(config) do
-    get_destination(config)
-  end
-
-  @spec get_destination(SourceConfig.source() | list(SourceConfig.source()) | nil) ::
-          PaEss.destination() | nil
-  defp get_destination(nil), do: nil
-
-  defp get_destination(config) when is_list(config) do
+  @spec source_list_destination(list(SourceConfig.source())) :: PaEss.destination() | nil
+  def source_list_destination(config) do
     config
     |> Enum.map(& &1.headway_destination)
     |> Enum.uniq()
@@ -59,6 +52,10 @@ defmodule Signs.Utilities.Headways do
       _ -> nil
     end
   end
+
+  @spec get_destination(SourceConfig.source() | nil) ::
+          PaEss.destination() | nil
+  defp get_destination(nil), do: nil
 
   defp get_destination(config), do: config.headway_destination
 

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -42,6 +42,10 @@ defmodule Signs.Utilities.Headways do
   defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
   defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
 
+  def get_headway_destination(config) do
+    get_destination(config)
+  end
+
   @spec get_destination(SourceConfig.source() | List.t() | nil) :: PaEss.destination() | nil
   defp get_destination(nil), do: nil
 

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -20,10 +20,15 @@ defmodule Signs.Utilities.Headways do
     end
   end
 
+  @spec get_paging_message(
+          Signs.Realtime.t(),
+          list(SourceConfig.source()),
+          DateTime.t()
+        ) :: Content.Message.Headways.Paging.t()
   def get_paging_message(sign, config, current_time) do
     headways = sign.config_engine.headway_config(sign.headway_group, current_time)
     destination = source_list_destination(config)
-    get_paging_headway_message(config, destination, headways)
+    get_paging_headway_message(destination, headways)
   end
 
   @spec display_headways?(
@@ -77,12 +82,15 @@ defmodule Signs.Utilities.Headways do
       }}}
   end
 
-  defp get_paging_headway_message(config, destination, headways) do
-    {config,
-     %Content.Message.Headways.Paging{
-       destination: destination,
-       range: {headways.range_low, headways.range_high}
-     }}
+  @spec get_paging_headway_message(
+          PaEss.destination() | nil,
+          Engine.Config.Headway.t()
+        ) :: Content.Message.Headways.Paging.t()
+  defp get_paging_headway_message(destination, headways) do
+    %Content.Message.Headways.Paging{
+      destination: destination,
+      range: {headways.range_low, headways.range_high}
+    }
   end
 
   @spec get_empty_messages(SourceConfig.source() | nil) ::

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -42,7 +42,7 @@ defmodule Signs.Utilities.Headways do
   defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
   defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
 
-  @spec get_destination(SourceConfig.source() | nil) :: PaEss.destination() | nil
+  @spec get_destination(SourceConfig.source() | List.t() | nil) :: PaEss.destination() | nil
   defp get_destination(nil), do: nil
 
   defp get_destination(config) when is_list(config) do

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -38,6 +38,9 @@ defmodule Signs.Utilities.Messages do
           {{nil, %Content.Message.Empty{}}, {nil, %Content.Message.Empty{}}} ->
             get_headway_or_alert_messages(sign, current_time, alert_status)
 
+          {top_message, {nil, %Content.Message.Empty{}}} ->
+            {top_message, get_paging_headway_message(sign, current_time)}
+
           messages ->
             messages
         end
@@ -54,6 +57,22 @@ defmodule Signs.Utilities.Messages do
       nil -> Signs.Utilities.Headways.get_messages(sign, current_time)
       messages -> messages
     end
+  end
+
+  # If the sign sources is a single list, then it's most likely going to
+  # be redundant to page the headways on the second line so skip it
+  defp get_paging_headway_message(
+         %Signs.Realtime{source_config: {[_config]}} = _sign,
+         _current_time
+       ) do
+    {nil, %Content.Message.Empty{}}
+  end
+
+  defp get_paging_headway_message(
+         %Signs.Realtime{source_config: {_, second_line_config}} = sign,
+         current_time
+       ) do
+    Signs.Utilities.Headways.get_paging_message(sign, second_line_config, current_time)
   end
 
   @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), boolean()) ::

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -107,7 +107,7 @@ defmodule Signs.Utilities.Messages do
         get_paging_alert_message(
           alert_status,
           sign.uses_shuttles,
-          Signs.Utilities.Headways.get_headway_destination(source_config)
+          Signs.Utilities.Headways.source_list_destination(source_config)
         )
       end
     end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -59,17 +59,20 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
-  # If the sign sources is a single list, then it's most likely going to
-  # be redundant to page the headways on the second line so skip it
+  # If the sign source is a single list, then it most likely means
+  # all predictions are in the same direction. In this case, it's redundant
+  # to show headways on the second line.
   defp get_paging_headway_message(
-         %Signs.Realtime{source_config: {[_config]}} = _sign,
+         %Signs.Realtime{source_config: {_config}} = _sign,
          _current_time
        ) do
     {nil, %Content.Message.Empty{}}
   end
 
   defp get_paging_headway_message(
-         %Signs.Realtime{source_config: {_, second_line_config}} = sign,
+         %Signs.Realtime{
+           source_config: {_, second_line_config}
+         } = sign,
          current_time
        ) do
     Signs.Utilities.Headways.get_paging_message(sign, second_line_config, current_time)

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -83,6 +83,12 @@ defmodule Signs.Utilities.Messages do
   defp has_single_source_list?(%Signs.Realtime{source_config: {_}} = _sign), do: true
   defp has_single_source_list?(_), do: false
 
+  @spec get_paging_headway_or_alert_messages(
+          Signs.Realtime.t(),
+          DateTime.t(),
+          Engine.Alerts.Fetcher.stop_status(),
+          :top | :bottom
+        ) :: {Signs.Utilities.SourceConfig.config() | nil, Content.Message.t()}
   defp get_paging_headway_or_alert_messages(
          sign,
          current_time,
@@ -102,7 +108,8 @@ defmodule Signs.Utilities.Messages do
         end
 
       if alert_status == :none do
-        Signs.Utilities.Headways.get_paging_message(sign, source_config, current_time)
+        {sign.source_config,
+         Signs.Utilities.Headways.get_paging_message(sign, source_config, current_time)}
       else
         get_paging_alert_message(
           alert_status,

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -107,15 +107,17 @@ defmodule Signs.Utilities.Messages do
           bottom_line_source
         end
 
-      if alert_status == :none do
-        {sign.source_config,
-         Signs.Utilities.Headways.get_paging_message(sign, source_config, current_time)}
-      else
-        get_paging_alert_message(
-          alert_status,
-          sign.uses_shuttles,
-          Signs.Utilities.Headways.source_list_destination(source_config)
-        )
+      case get_paging_alert_message(
+             alert_status,
+             sign.uses_shuttles,
+             Signs.Utilities.Headways.source_list_destination(source_config)
+           ) do
+        nil ->
+          {source_config,
+           Signs.Utilities.Headways.get_paging_message(sign, source_config, current_time)}
+
+        alert_message ->
+          alert_message
       end
     end
   end

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7478,7 +7478,9 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
-        },
+        }
+      ],
+      [
         {
           "stop_id": "70502",
           "direction_id": 0,
@@ -7651,7 +7653,9 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
-        },
+        }
+      ],
+      [
         {
           "stop_id": "70514",
           "direction_id": 0,
@@ -7744,7 +7748,9 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
-        },
+        }
+      ],
+      [
         {
           "stop_id": "70506",
           "direction_id": 0,
@@ -7837,7 +7843,9 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
-        },
+        }
+      ],
+      [
         {
           "stop_id": "70508",
           "direction_id": 0,
@@ -7930,7 +7938,9 @@
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
-        },
+        }
+      ],
+      [
         {
           "stop_id": "70510",
           "direction_id": 0,

--- a/test/content/audio/no_service_to_destination_test.exs
+++ b/test/content/audio/no_service_to_destination_test.exs
@@ -1,0 +1,25 @@
+defmodule Content.Audio.NoServiceToDestinationTest do
+  use ExUnit.Case, async: true
+
+  test "Inserts destination into audio for no service" do
+    message = %Content.Message.Alert.DestinationNoService{
+      destination: :medford_tufts
+    }
+
+    assert Content.Audio.NoServiceToDestination.from_message(message) ==
+             %Content.Audio.NoServiceToDestination{
+               message: "No service to Medford/Tufts"
+             }
+  end
+
+  test "Inserts destination into audio for paging shuttle alert" do
+    message = %Content.Message.Alert.NoServiceUseShuttle{
+      destination: :medford_tufts
+    }
+
+    assert Content.Audio.NoServiceToDestination.from_message(message) ==
+             %Content.Audio.NoServiceToDestination{
+               message: "No service to Medford/Tufts use shuttle"
+             }
+  end
+end

--- a/test/content/messages/alert/destination_no_service_test.exs
+++ b/test/content/messages/alert/destination_no_service_test.exs
@@ -1,0 +1,10 @@
+defmodule Content.Message.Alert.DestinationNoServiceTest do
+  use ExUnit.Case, async: true
+
+  describe "to_string" do
+    test "serializes correctly" do
+      msg = %Content.Message.Alert.DestinationNoService{destination: :medford_tufts}
+      assert Content.Message.to_string(msg) == "Medfd/Tufts   no service"
+    end
+  end
+end

--- a/test/content/messages/alert/no_service_use_shuttle_test.exs
+++ b/test/content/messages/alert/no_service_use_shuttle_test.exs
@@ -1,0 +1,14 @@
+defmodule Content.Message.Alert.NoServiceUseShuttleTest do
+  use ExUnit.Case, async: true
+
+  describe "to_string" do
+    test "serializes pages correctly" do
+      msg = %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
+
+      assert Content.Message.to_string(msg) == [
+               {"Medfd/Tufts   no service", 3},
+               {"Medfd/Tufts  use shuttle", 3}
+             ]
+    end
+  end
+end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -1,0 +1,27 @@
+defmodule Content.Message.Headways.PagingTest do
+  use ExUnit.Case, async: true
+
+  describe "to_string/1" do
+    test "When destination is not nil, page headways with destination" do
+      assert Content.Message.to_string(%Content.Message.Headways.Paging{
+               destination: :heath_street,
+               vehicle_type: :train,
+               range: {5, 7}
+             }) == [
+               {"Heath St    Trains every", 3},
+               {"Heath St      5 to 7 min", 3}
+             ]
+    end
+
+    test "When destination is nil, page generic headway message" do
+      assert Content.Message.to_string(%Content.Message.Headways.Paging{
+               destination: nil,
+               vehicle_type: :train,
+               range: {5, 7}
+             }) == [
+               {"Trains every", 3},
+               {"5 to 7 min", 3}
+             ]
+    end
+  end
+end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -8,7 +8,7 @@ defmodule Content.Message.Headways.PagingTest do
                vehicle_type: :train,
                range: {5, 7}
              }) == [
-               {"Heath St    Trains every", 3},
+               {"Heath St    trains every", 3},
                {"Heath St      5 to 7 min", 3}
              ]
     end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -5,7 +5,6 @@ defmodule Content.Message.Headways.PagingTest do
     test "When destination is not nil, page headways with destination" do
       assert Content.Message.to_string(%Content.Message.Headways.Paging{
                destination: :heath_street,
-               vehicle_type: :train,
                range: {5, 7}
              }) == [
                {"Heath St    trains every", 3},
@@ -16,7 +15,6 @@ defmodule Content.Message.Headways.PagingTest do
     test "When destination is nil, page generic headway message" do
       assert Content.Message.to_string(%Content.Message.Headways.Paging{
                destination: nil,
-               vehicle_type: :train,
                range: {5, 7}
              }) == [
                {"Trains every", 3},

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -279,7 +279,6 @@ defmodule Signs.Utilities.AudioTest do
             {@src,
              %Message.Headways.Paging{
                destination: :heath_street,
-               vehicle_type: :train,
                range: {5, 7}
              }}
       }

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -270,6 +270,25 @@ defmodule Signs.Utilities.AudioTest do
                %Audio.FollowingTrain{destination: :ashmont, minutes: 4}}, ^sign} = from_sign(sign)
     end
 
+    test "If top line prediction and bottom line paging headways, announce both" do
+      sign = %{
+        @sign
+        | current_content_top:
+            {@src, %Message.Predictions{destination: :medford_tufts, minutes: 3}},
+          current_content_bottom:
+            {@src,
+             %Message.Headways.Paging{
+               destination: :heath_street,
+               vehicle_type: :train,
+               range: {5, 7}
+             }}
+      }
+
+      assert {{%Audio.NextTrainCountdown{destination: :medford_tufts, minutes: 3},
+               %Audio.VehiclesToDestination{destination: :heath_street, headway_range: {5, 7}}},
+              ^sign} = from_sign(sign)
+    end
+
     test "Ignores 'following train' if same headsign but it's arriving (we don't have audio)" do
       sign = %{
         @sign


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Mezzanine sign improvement for headways/alerts](https://app.asana.com/0/1201753694073608/1203773782529108/f)

This PR enables paging of headways on the second line of a countdown clock when there are predictions for the top line, only when the source configs are pinned to either line. This provides riders with some indication of service levels even when there are no live predictions for the second line.

The change also enables paging of "no service" or "no service, use shuttle" messages on the second line when there is an alert active in only one direction.

Paging will always happen on the second line to take advantage of the 6 extra characters.

A few example screen captures:


https://user-images.githubusercontent.com/16074540/214908943-7432ddf3-df9b-4f85-bf9c-fefbb2777706.mov


https://user-images.githubusercontent.com/16074540/214907862-236cd786-77ec-42e9-ab87-788c8d48aefb.mov


https://user-images.githubusercontent.com/16074540/214908076-1a680cca-5afe-4c95-b78b-41625552c155.mov


