### PR TITLE
move bus helpers to utils and add prediction types

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -12,6 +12,17 @@ defmodule Content.Utilities do
     "#{new_left} #{right}"
   end
 
+  @spec content_duration({Content.Message.t(), Content.Message.t()}) :: integer()
+  def content_duration({top, bottom}) do
+    for message <- [top, bottom] do
+      case Content.Message.to_string(message) do
+        pages when is_list(pages) -> Enum.map(pages, fn {_, n} -> n end) |> Enum.sum()
+        str when is_binary(str) -> 0
+      end
+    end
+    |> Enum.max()
+  end
+
   @spec destination_for_prediction(String.t(), 0 | 1, String.t()) ::
           {:ok, PaEss.destination()} | {:error, :not_found}
   def destination_for_prediction("Mattapan", 0, _), do: {:ok, :mattapan}

--- a/lib/engine/bus_predictions.ex
+++ b/lib/engine/bus_predictions.ex
@@ -85,7 +85,7 @@ defmodule Engine.BusPredictions do
               _ -> nil
             end
 
-          %{
+          %Predictions.BusPrediction{
             direction_id: direction_id,
             departure_time:
               if(departure_time, do: Timex.parse!(departure_time, "{ISO:Extended}")),

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -480,4 +480,30 @@ defmodule PaEss.Utilities do
       if String.starts_with?(headsign, prefix), do: abbreviations
     end)
   end
+
+  @spec prediction_route_name(Predictions.BusPrediction.t()) :: String.t() | nil
+  # Don't display "SLW" route name when its outbound headsign already says "Silver Line Way".
+  def prediction_route_name(%{route_id: "746", headsign: "Silver Line Way"}), do: nil
+  # Heading inbound from Silver Line Way to South Station, all routes take the same path, so
+  # treat them as one unit and don't display route names.
+  def prediction_route_name(%{stop_id: stop_id, headsign: "South Station"})
+      when stop_id in ["74615", "74616"],
+      do: nil
+
+  def prediction_route_name(%{route_id: "749"}), do: "SL5"
+  def prediction_route_name(%{route_id: "751"}), do: "SL4"
+  def prediction_route_name(%{route_id: "743"}), do: "SL3"
+  def prediction_route_name(%{route_id: "742"}), do: "SL2"
+  def prediction_route_name(%{route_id: "741"}), do: "SL1"
+  def prediction_route_name(%{route_id: "77", headsign: "North Cambridge"}), do: "77A"
+
+  def prediction_route_name(%{route_id: "2427", stop_id: "185", headsign: headsign}) do
+    cond do
+      String.starts_with?(headsign, "Ashmont") -> "27"
+      String.starts_with?(headsign, "Wakefield Av") -> "24"
+      true -> "2427"
+    end
+  end
+
+  def prediction_route_name(%{route_id: route_id}), do: route_id
 end

--- a/lib/predictions/bus_prediction.ex
+++ b/lib/predictions/bus_prediction.ex
@@ -1,0 +1,22 @@
+defmodule Predictions.BusPrediction do
+  @enforce_keys [
+    :direction_id,
+    :departure_time,
+    :route_id,
+    :stop_id,
+    :headsign,
+    :vehicle_id,
+    :updated_at
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          direction_id: 0 | 1,
+          departure_time: DateTime.t() | nil,
+          route_id: String.t(),
+          stop_id: String.t(),
+          headsign: String.t(),
+          vehicle_id: String.t() | nil,
+          updated_at: String.t() | nil
+        }
+end


### PR DESCRIPTION
#### Summary of changes

This moves a couple generic bus helpers out to the utility files to keep the main business logic clear. Also adds explicit types for bus predictions.