### PR TITLE
support mezzanine mode for bus signs

### DIFF
--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -26,8 +26,10 @@ defmodule Signs.Utilities.SignsConfig do
 
   @spec all_bus_stop_ids() :: [String.t()]
   def all_bus_stop_ids do
-    for %{"type" => "bus", "sources" => sources} <- children_config(),
-        %{"stop_id" => stop_id} <- sources,
+    for %{"type" => "bus"} = sign <- children_config(),
+        source_list <- [sign["sources"], sign["top_sources"], sign["bottom_sources"]],
+        source_list,
+        %{"stop_id" => stop_id} <- source_list,
         uniq: true do
       stop_id
     end

--- a/scripts/transitway_engine/parse_config.exs
+++ b/scripts/transitway_engine/parse_config.exs
@@ -27,8 +27,9 @@ lines =
 {initialize_lines, lines} = Enum.split_while(lines, &(&1 != "  if (view_processRoutesFile())"))
 # TODO continue parsing audio zones
 
-routes_list =
-  for line <- station_lines do
+routes_lookup =
+  for line <- station_lines,
+      into: %{} do
     [id | source_strings] = String.split(line, ",")
 
     routes =
@@ -37,7 +38,7 @@ routes_list =
         Jason.OrderedObject.new(route_id: route_id, direction_id: String.to_integer(direction_id))
       end
 
-    %{id: id, routes: routes}
+    {id, routes}
   end
 
 for line <- route_lines do
@@ -50,21 +51,23 @@ end
 abbreviations_code =
   for [line1, line2] <- Enum.chunk_every(abbrev_lines, 2) do
     [headsign, _] = String.split(line1, ",")
+
     abbreviations =
       for abbrev <- String.split(line2, ",") do
         String.trim(abbrev)
       end
       |> Enum.uniq()
+
     %{headsign: headsign, abbreviations: abbreviations}
   end
-  |> Enum.map(fn (%{headsign: headsign, abbreviations: abbreviations}) ->
+  |> Enum.map(fn %{headsign: headsign, abbreviations: abbreviations} ->
     "    {#{inspect(headsign)}, #{inspect(abbreviations)}}"
   end)
   |> Enum.concat(["    {\"Silver Line Way\", [\"Slvr Ln Way\"]}"])
   |> Enum.join(",\n")
   |> (fn lines ->
-    "  @headsign_abbreviation_mappings [\n" <> lines <> "\n  ]"
-  end).()
+        "  @headsign_abbreviation_mappings [\n" <> lines <> "\n  ]"
+      end).()
 
 signs_json =
   for [line1, line2] <- Enum.chunk_every(initialize_lines, 2) do
@@ -75,23 +78,33 @@ signs_json =
       )
 
     Jason.OrderedObject.new(
-      id: id,
-      pa_ess_loc: pa_ess_loc,
-      text_zone: text_zone,
-      audio_zones:
-        for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
-            String.at(audio_zones, i) == "1" do
-          c
-        end,
-      type: "bus",
-      sources:
-        with [_, sid] <- Regex.run(~r/STOP_ID_(\d+)_/, stop_id),
-             %{routes: routes} <- Enum.find(routes_list, &match?(%{id: ^id}, &1)) do
-          [Jason.OrderedObject.new(stop_id: sid, routes: routes)]
+      [
+        id: id,
+        pa_ess_loc: pa_ess_loc,
+        text_zone: text_zone,
+        audio_zones:
+          for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
+              String.at(audio_zones, i) == "1" do
+            c
+          end,
+        type: "bus"
+      ] ++
+        if id == "Silver_Line.World_Trade_Ctr_mezz" do
+          top_routes = Map.fetch!(routes_lookup, "Silver_Line.World_Trade_Ctr_WB")
+          bottom_routes = Map.fetch!(routes_lookup, "Silver_Line.World_Trade_Ctr_EB")
+
+          [
+            top_sources: [Jason.OrderedObject.new(stop_id: "74615", routes: top_routes)],
+            bottom_sources: [Jason.OrderedObject.new(stop_id: "74613", routes: bottom_routes)]
+          ]
         else
-          _ -> []
-        end,
-      max_minutes: String.to_integer(max_minutes)
+          [_, sid] = Regex.run(~r/STOP_ID_(\d+)_/, stop_id)
+          routes = Map.fetch!(routes_lookup, id)
+          [sources: [Jason.OrderedObject.new(stop_id: sid, routes: routes)]]
+        end ++
+        [
+          max_minutes: String.to_integer(max_minutes)
+        ]
     )
   end
   |> Jason.encode!()


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement mezzanine mode for bus signs](https://app.asana.com/0/1201753694073608/1203913364994578/f)

Adds mezzanine mode for bus signs. Currently this only affects a single sign (WTC mezzanine). This mode fetches two separate prediction lists and displays them independently. Updates the bus json schema with two new keys, `top_sources` and `bottom_sources`, which are used to configure the sign in this mode.