### PR TITLE
Increase task memory

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,7 +27,7 @@ jobs:
       on-prem-cluster: hsctd-dev-managers
       splunk-index: realtime-signs-dev
       task-cpu: .5
-      task-memory: 1024M
+      task-memory: 2048M
       task-port: 80
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,7 +27,7 @@ jobs:
       on-prem-cluster: hsctd-dev-managers
       splunk-index: realtime-signs-dev
       task-cpu: .5
-      task-memory: 2048M
+      task-memory: 1536M
       task-port: 80
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
ARINC has made their log collection more stable so we're now getting roughly 3x the data compared to before. (~38 MB on 2/8 compared to ~12 MB on 2/2 as a sample). We have a recurring nightly job that processes this data but it appears to be hitting memory limits and crashes given the example logs that happen when the job is scheduled to run:
```
2/9/23 8:15:58.352 AM | container_id=1928c824ed80 Crash dump is being written to: erl_crash.dump...done                                                                                                                                                                                                                                                     
2/9/23 8:15:26.351 AM | container_id=1928c824ed80 eheap_alloc: Cannot allocate 212907632 bytes of memory (of type "heap")
```

Increasing the task memory alleviates the issue (tested with a branch deploy to dev) but this solution doesn't scale. We should rework to the job in a subsequent task to be more efficient by batching and parallelizing some of the functions within the job.

Note: This doesn't need to be deployed to prod in any hurry because the job actually only runs on the dev instance of Realtime Signs.