### PR TITLE
add flag for testing bus code during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# local direnv configuration
+/.envrc

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,3 +2,8 @@ import Config
 
 config :logger,
   backends: [:console]
+
+config :realtime_signs,
+  # This flag enables testing of the in-progress bus work. It should be removed when the work
+  # is finished
+  test_bus_mode: System.get_env("TEST_BUS_MODE") == "true"

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -17,7 +17,6 @@ defmodule RealtimeSigns do
         Engine.Health,
         Engine.Config,
         Engine.Predictions,
-        # Engine.BusPredictions, # Disabled during initial development
         Engine.ScheduledHeadways,
         Engine.Departures,
         Engine.Static,
@@ -25,6 +24,7 @@ defmodule RealtimeSigns do
         MessageQueue,
         RealtimeSigns.Scheduler
       ] ++
+        bus_children() ++
         http_updater_children() ++
         monitor_sign_scu_uptime() ++
         [
@@ -74,6 +74,16 @@ defmodule RealtimeSigns do
 
     for i <- 1..num_children do
       {PaEss.HttpUpdater, i}
+    end
+  end
+
+  # These modules are specific to the in-progress bus work, and are disabled by default.
+  # They should be enabled and inlined once the work is complete.
+  def bus_children do
+    if Application.get_env(:realtime_signs, :test_bus_mode) do
+      [Engine.BusPredictions]
+    else
+      []
     end
   end
 end

--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -6,9 +6,13 @@ defmodule Signs.Utilities.SignsConfig do
   @doc "Pulls the entire signs.json configuration"
   @spec children_config() :: [map()]
   def children_config() do
+    # This override allows testing the in-progress bus work, and is off by default.
+    # It should be removed once the work is complete.
+    test_bus_mode = Application.get_env(:realtime_signs, :test_bus_mode)
+
     :realtime_signs
     |> :code.priv_dir()
-    |> Path.join("signs.json")
+    |> Path.join(if test_bus_mode, do: "bus-signs.json", else: "signs.json")
     |> File.read!()
     |> Jason.decode!()
   end


### PR DESCRIPTION
#### Summary of changes

This adds a flag that can be used to switch on the bus code paths, for ease of development. This is essentially what I've been doing locally, but this will make it easier to manage, especially as more pieces are added. The flag is explicitly documented everywhere, so should be easy to remove afterward.

Also adds arguments to the TE code parser to control what it generates.