### PR TITLE
Announce branch letter at all gl stops

### DIFF
--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -63,15 +63,7 @@ defmodule Content.Audio.FollowingTrain do
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do
         {:ok, dest_var} ->
-          green_line_branch =
-            if audio.station_code == "GKEN" do
-              Content.Utilities.route_branch_letter(audio.route_id)
-            else
-              Content.Utilities.route_and_destination_branch_letter(
-                audio.route_id,
-                audio.destination
-              )
-            end
+          green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
 
           cond do
             !is_nil(green_line_branch) ->

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -36,15 +36,7 @@ defmodule Content.Audio.NextTrainCountdown do
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do
         {:ok, dest_var} ->
-          green_line_branch =
-            if audio.station_code == "GKEN" do
-              Content.Utilities.route_branch_letter(audio.route_id)
-            else
-              Content.Utilities.route_and_destination_branch_letter(
-                audio.route_id,
-                audio.destination
-              )
-            end
+          green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
 
           cond do
             !is_nil(audio.track_number) ->

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -67,14 +67,11 @@ defmodule Content.Audio.TrainIsBoarding do
     end
 
     defp do_to_params(
-           %{destination: destination, route_id: route_id, track_number: track_number},
+           %{route_id: route_id, track_number: track_number},
            destination_var
          ) do
       vars =
-        case {Content.Utilities.route_and_destination_branch_letter(
-                route_id,
-                destination
-              ), track_number} do
+        case {Content.Utilities.route_branch_letter(route_id), track_number} do
           {nil, nil} ->
             [
               @the_next,

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -99,18 +99,10 @@ defmodule Content.Utilities do
   def stop_platform_name("70086"), do: "Ashmont"
   def stop_platform_name("70096"), do: "Braintree"
 
-  @spec route_and_destination_branch_letter(String.t(), PaEss.destination()) ::
-          green_line_branch() | nil
-  def route_and_destination_branch_letter("Green-B", :boston_college), do: :b
-  def route_and_destination_branch_letter("Green-C", :cleveland_circle), do: :c
-  def route_and_destination_branch_letter("Green-D", :riverside), do: :d
-  def route_and_destination_branch_letter("Green-D", :reservoir), do: :d
-  def route_and_destination_branch_letter("Green-E", :heath_street), do: :e
-  def route_and_destination_branch_letter(_route_id, _destination), do: nil
-
-  @spec route_branch_letter(String.t()) :: green_line_branch()
+  @spec route_branch_letter(String.t()) :: green_line_branch() | nil
   def route_branch_letter("Green-B"), do: :b
   def route_branch_letter("Green-C"), do: :c
   def route_branch_letter("Green-D"), do: :d
   def route_branch_letter("Green-E"), do: :e
+  def route_branch_letter(_), do: nil
 end

--- a/test/content/audio/following_train_test.exs
+++ b/test/content/audio/following_train_test.exs
@@ -131,7 +131,7 @@ defmodule Content.Audio.FollowingTrainTest do
                  ], :audio}}
     end
 
-    test "Eastbound Green Line trains don't get branch letters" do
+    test "Eastbound Green Line trains also get branch letters" do
       audio = %Content.Audio.FollowingTrain{
         destination: :park_street,
         route_id: "Green-B",
@@ -139,7 +139,26 @@ defmodule Content.Audio.FollowingTrainTest do
         minutes: 5
       }
 
-      assert Content.Audio.to_params(audio) == {:canned, {"160", ["4007", "503", "5005"], :audio}}
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"117",
+                 [
+                   "667",
+                   "21000",
+                   "536",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4007",
+                   "21000",
+                   "503",
+                   "21000",
+                   "504",
+                   "21000",
+                   "5005",
+                   "21000",
+                   "505"
+                 ], :audio}}
     end
 
     test "returns ad_hoc audio when the destination is 'southbound'" do

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -272,7 +272,7 @@ defmodule Content.Audio.NextTrainCountdownTest do
                  ], :audio}}
     end
 
-    test "Eastbound Green Line trains don't get branch letters" do
+    test "Eastbound Green Line trains also get branch letters" do
       audio = %Content.Audio.NextTrainCountdown{
         destination: :park_street,
         route_id: "Green-B",
@@ -282,7 +282,26 @@ defmodule Content.Audio.NextTrainCountdownTest do
         platform: nil
       }
 
-      assert Content.Audio.to_params(audio) == {:canned, {"90", ["4007", "503", "5005"], :audio}}
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"117",
+                 [
+                   "501",
+                   "21000",
+                   "536",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4007",
+                   "21000",
+                   "503",
+                   "21000",
+                   "504",
+                   "21000",
+                   "5005",
+                   "21000",
+                   "505"
+                 ], :audio}}
     end
 
     test "Next train to Braintree on track 1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update audio announcements ~at Kenmore~ on all of GL](https://app.asana.com/0/1201753694073608/1203674455933121/f)

This PR makes a change so that we _always_ announce the branch letter for Green Line trains. We already do this for westbound trains so this essentially expands the behavior for eastbound trains as well.