### PR TITLE
handle Chelsea bridge status on bus signs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,6 +16,8 @@ if config_env() != :test do
     s3_path: System.get_env("SIGNS_S3_PATH"),
     api_v3_url: System.get_env("API_V3_URL", "https://api-dev-green.mbtace.com"),
     api_v3_key: System.get_env("API_V3_KEY"),
+    chelsea_bridge_url: System.get_env("CHELSEA_BRIDGE_URL"),
+    chelsea_bridge_auth: System.get_env("CHELSEA_BRIDGE_AUTH"),
     filter_uncertain_predictions?: System.get_env("FILTER_UNCERTAIN_PREDICTIONS", "false") == "true",
     number_of_http_updaters: System.get_env("NUMBER_OF_HTTP_UPDATERS", "4") |> String.to_integer(),
     message_log_zip_url: System.get_env("MESSAGE_LOG_ZIP_URL"),

--- a/lib/engine/chelsea_bridge.ex
+++ b/lib/engine/chelsea_bridge.ex
@@ -1,0 +1,58 @@
+defmodule Engine.ChelseaBridge do
+  use GenServer
+  require Logger
+
+  def bridge_status() do
+    GenServer.call(__MODULE__, {:bridge_status})
+  end
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  def init(_) do
+    send(self(), :update)
+    {:ok, %{status: %{raised?: nil, estimate: nil}}}
+  end
+
+  def handle_info(:update, state) do
+    Process.send_after(self(), :update, 60_000)
+    url = Application.get_env(:realtime_signs, :chelsea_bridge_url)
+    auth = Application.get_env(:realtime_signs, :chelsea_bridge_auth)
+    http_client = Application.get_env(:realtime_signs, :http_client)
+
+    with {:ok, %{status_code: 200, body: body}} <-
+           http_client.get(url, [{"Authorization", "Basic #{auth}"}]),
+         {:ok, data} <- Jason.decode(body) do
+      %{"bridge" => %{"bridgeStatusId" => %{"status" => status}}} = data
+
+      estimate =
+        case data do
+          %{"lift_estimate" => %{"estimate_time" => estimate}} ->
+            String.replace(estimate, ~r/\.\d+$/, "")
+            |> Timex.parse!("{YYYY}-{M}-{D} {h24}:{m}:{s}")
+            |> DateTime.from_naive!("America/New_York")
+
+          _ ->
+            nil
+        end
+
+      new_status = %{raised?: status == "Raised", estimate: estimate}
+
+      {:noreply, %{state | status: new_status}}
+    else
+      err ->
+        Logger.error("Error getting bridge status: #{inspect(err)}")
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn("Engine.ChelseaBridge unknown_message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  def handle_call({:bridge_status}, _from, state) do
+    {:reply, state.status, state}
+  end
+end

--- a/lib/engine/chelsea_bridge.ex
+++ b/lib/engine/chelsea_bridge.ex
@@ -23,9 +23,8 @@ defmodule Engine.ChelseaBridge do
 
     with {:ok, %{status_code: 200, body: body}} <-
            http_client.get(url, [{"Authorization", "Basic #{auth}"}]),
-         {:ok, data} <- Jason.decode(body) do
-      %{"bridge" => %{"bridgeStatusId" => %{"status" => status}}} = data
-
+         {:ok, data} <- Jason.decode(body),
+         %{"bridge" => %{"bridgeStatusId" => %{"status" => status}}} <- data do
       estimate =
         case data do
           %{"lift_estimate" => %{"estimate_time" => estimate}} ->

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -81,7 +81,7 @@ defmodule RealtimeSigns do
   # They should be enabled and inlined once the work is complete.
   def bus_children do
     if Application.get_env(:realtime_signs, :test_bus_mode) do
-      [Engine.BusPredictions]
+      [Engine.BusPredictions, Engine.ChelseaBridge]
     else
       []
     end

--- a/scripts/transitway_engine/parse_config.exs
+++ b/scripts/transitway_engine/parse_config.exs
@@ -103,6 +103,11 @@ signs_json =
           routes = Map.fetch!(routes_lookup, id)
           [sources: [Jason.OrderedObject.new(stop_id: sid, routes: routes)]]
         end ++
+        if Enum.any?(["Eastern_Ave", "Box_District", "Bellingham_Square", "Chelsea"], &String.contains?(id, &1)) do
+          [chelsea_bridge: true]
+        else
+          []
+        end ++
         [
           max_minutes: String.to_integer(max_minutes)
         ]


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Handle Chelsea bridge logic](https://app.asana.com/0/1201753694073608/1203958349180920/f)

This adds a new engine to get the status of the Chelsea bridge, and displays that information on the relevant signs. The engine is disabled unless you're in "bus mode", and also requires setting a new environment variable with the encoded auth string, which can be found in the password vault.