### PR TITLE
Optimize message latency report job

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,7 +27,7 @@ jobs:
       on-prem-cluster: hsctd-dev-managers
       splunk-index: realtime-signs-dev
       task-cpu: .5
-      task-memory: 1536M
+      task-memory: 1024M
       task-port: 80
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -94,6 +94,9 @@ defmodule Jobs.MessageLatencyReport do
       |> Stream.filter(&filter_by_date(&1, date))
       |> Stream.map(fn row -> row[:seconds] end)
       |> Enum.sort()
+      |> tap(fn _ ->
+        Logger.info("message_latency_report: Memory in use after sort: #{:erlang.memory(:total)}")
+      end)
       |> Stream.with_index()
       |> get_percentile_rows()
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Optimize Message latency job](https://app.asana.com/0/1201753694073608/1203923825770741/f)

This PR makes some memory optimizations to the message latency report job. Initially, I thought we might be able to batch process the CSVs but it turns out that it's primarily just one CSV that is causing the memory bottleneck which is the `all.csv` file that the script generates by combining all of the CSVs. Given the way percentiles work, we need all of the rows in memory so that we can sort them and calculate where the percentiles land and since `Enum.sort`'s space complexity is O(n), this single file uses the same amount of memory at one time as all of the others combined throughout the course of a run of the job. Therefore, batching likely won't be of much help here.

I did make a change to find the 95th and 99th percentiles in a single pass rather than two to help time efficiency a bit. But to help space complexity, I simply removed a number of fields that we don't need from the data structure that the script works with which slimmed things down quite a bit. The script now uses about 1/3-1/4 of the memory it was using before which is still a good improvement.

I also added a tag to the logs to make it easier to query logs related to this job as well as logging around the total size of the data we get to ARINC which can help us monitor how much data we're actually getting from them without having to manually check S3.
