### PR TITLE
Revisit jfk umass platform announcements

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -32,7 +32,7 @@ defmodule Content.Audio.NextTrainCountdown do
     @minutes "505"
     @minute "532"
     @platform_soon "849"
-    @platform_when_closer ""
+    @platform_when_closer "857"
 
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -31,7 +31,8 @@ defmodule Content.Audio.NextTrainCountdown do
     @in_ "504"
     @minutes "505"
     @minute "532"
-    @platform_tbd "849"
+    @platform_soon "849"
+    @platform_when_closer ""
 
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do
@@ -56,7 +57,9 @@ defmodule Content.Audio.NextTrainCountdown do
 
             audio.destination == :alewife and audio.station_code == "RJFK" and audio.zone == "m" and
                 audio.minutes > 5 ->
-              platform_tbd_params(audio, dest_var)
+              if audio.minutes < 10,
+                do: platform_soon_params(audio, dest_var),
+                else: platform_when_closer_params(audio, dest_var)
 
             true ->
               {:canned,
@@ -128,7 +131,7 @@ defmodule Content.Audio.NextTrainCountdown do
       Utilities.take_message(vars, :audio)
     end
 
-    defp platform_tbd_params(audio, destination_var) do
+    defp platform_soon_params(audio, destination_var) do
       vars = [
         @the_next,
         @train_to,
@@ -137,7 +140,22 @@ defmodule Content.Audio.NextTrainCountdown do
         @in_,
         minutes_var(audio),
         minute_or_minutes(audio),
-        @platform_tbd
+        @platform_soon
+      ]
+
+      Utilities.take_message(vars, :audio)
+    end
+
+    defp platform_when_closer_params(audio, destination_var) do
+      vars = [
+        @the_next,
+        @train_to,
+        destination_var,
+        verb_var(audio),
+        @in_,
+        minutes_var(audio),
+        minute_or_minutes(audio),
+        @platform_when_closer
       ]
 
       Utilities.take_message(vars, :audio)

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -148,12 +148,12 @@ defmodule Content.Audio.NextTrainCountdownTest do
                {:canned, {"98", ["4000", "503", "5005", "4021"], :audio}}
     end
 
-    test "Next train to Alewife platform TBD (JFK/UMass Mezzanine only)" do
+    test "Next train to Alewife platform TBD soon (JFK/UMass Mezzanine only)" do
       audio = %Content.Audio.NextTrainCountdown{
         destination: :alewife,
         route_id: "Red",
         verb: :arrives,
-        minutes: 20,
+        minutes: 9,
         track_number: nil,
         platform: :braintree,
         station_code: "RJFK",
@@ -174,11 +174,45 @@ defmodule Content.Audio.NextTrainCountdownTest do
                    "21000",
                    "504",
                    "21000",
-                   "5020",
+                   "5009",
                    "21000",
                    "505",
                    "21000",
                    "849"
+                 ], :audio}}
+    end
+
+    test "Next train to Alewife platform TBD when train closer (JFK/UMass Mezzanine only)" do
+      audio = %Content.Audio.NextTrainCountdown{
+        destination: :alewife,
+        route_id: "Red",
+        verb: :arrives,
+        minutes: 10,
+        track_number: nil,
+        platform: :braintree,
+        station_code: "RJFK",
+        zone: "m"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"117",
+                 [
+                   "501",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4000",
+                   "21000",
+                   "503",
+                   "21000",
+                   "504",
+                   "21000",
+                   "5010",
+                   "21000",
+                   "505",
+                   "21000",
+                   "857"
                  ], :audio}}
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Revisit JFK/UMass platform prediction audio](https://app.asana.com/0/1201753694073608/1203683812842464/f)

This adds a tweak to the logic around JFK/UMass platform prediction audio announcements. When the train more than 5 but less than 10 minutes away, we will announce that the platform "will be announced soon". When the train is 10 minutes or more away, we will announce that the platform "will be announced when the train is closer".