### PR TITLE
send scheduled bus audio messages

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -164,6 +164,11 @@ defmodule PaEss.HttpUpdater do
 
   def process({:send_audio, [{station, zones}, audios, priority, timeout]}, state) do
     case audios do
+      list when is_list(list) ->
+        for audio <- list do
+          process_send_audio(station, zones, audio, priority, timeout, state)
+        end
+
       {a1, a2} ->
         process_send_audio(station, zones, a1, priority, timeout, state)
         process_send_audio(station, zones, a2, priority, timeout, state)

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -14,5 +14,8 @@ defmodule PaEss.Updater do
               {:ok, :sent} | {:error, any()}
             when priority: integer(),
                  timeout: integer(),
-                 audios: Content.Audio.t() | {Content.Audio.t(), Content.Audio.t()}
+                 audios:
+                   Content.Audio.t()
+                   | {Content.Audio.t(), Content.Audio.t()}
+                   | [Content.Audio.t()]
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Send bus audio messages](https://app.asana.com/0/1201753694073608/1204067334255204/f)

This closes the loop and sends out the computed bus audio messages on the specified schedule. Also corrects the predictions preamble for south station, and skips it if there are no predictions.