### PR TITLE
Add check before displaying paging headways

### DIFF
--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -36,7 +36,13 @@ defmodule Signs.Utilities.Headways do
         %Content.Message.Empty{}
 
       headways ->
-        config |> source_list_destination() |> get_paging_headway_message(headways)
+        stop_ids = get_stop_ids(config)
+
+        if display_headways?(sign, stop_ids, current_time, headways) do
+          config |> source_list_destination() |> get_paging_headway_message(headways)
+        else
+          %Content.Message.Empty{}
+        end
     end
   end
 
@@ -55,6 +61,9 @@ defmodule Signs.Utilities.Headways do
   @spec get_stop_ids(Signs.Realtime.t(), SourceConfig.source() | nil) :: [String.t()]
   defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
   defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
+
+  @spec get_stop_ids(list(SourceConfig.source())) :: [String.t()]
+  defp get_stop_ids(sources), do: Enum.map(sources, & &1.stop_id)
 
   @spec source_list_destination(list(SourceConfig.source())) :: PaEss.destination() | nil
   def source_list_destination(config) do

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -36,9 +36,7 @@ defmodule Signs.Utilities.Headways do
         %Content.Message.Empty{}
 
       headways ->
-        stop_ids = get_stop_ids(config)
-
-        if display_headways?(sign, stop_ids, current_time, headways) do
+        if display_headways?(sign, Enum.map(config, & &1.stop_id), current_time, headways) do
           config |> source_list_destination() |> get_paging_headway_message(headways)
         else
           %Content.Message.Empty{}
@@ -61,9 +59,6 @@ defmodule Signs.Utilities.Headways do
   @spec get_stop_ids(Signs.Realtime.t(), SourceConfig.source() | nil) :: [String.t()]
   defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
   defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
-
-  @spec get_stop_ids(list(SourceConfig.source())) :: [String.t()]
-  defp get_stop_ids(sources), do: Enum.map(sources, & &1.stop_id)
 
   @spec source_list_destination(list(SourceConfig.source())) :: PaEss.destination() | nil
   def source_list_destination(config) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [New paging headways logic doesn't check against schedules data](https://app.asana.com/0/1201753694073608/1204118945498884/f)

This PR adds a check by calling `display_headways?` before deciding to show paging headways. The check uses schedules data to determine if we're within scheduled service hours and mirrors what we do for normal headway messages.

Tested by faking the current time as after service hours in the code itself. Result:
<img width="375" alt="Screenshot 2023-03-06 at 11 36 15 AM" src="https://user-images.githubusercontent.com/16074540/223173484-2a36a55b-98e8-4282-8e1b-19c4022b2917.png">

