### PR TITLE
refactor config engine test

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -55,12 +55,14 @@ defmodule Engine.Config do
 
     schedule_update(self())
 
-    @table_signs =
-      :ets.new(state.table_name_signs, [:set, :protected, :named_table, read_concurrency: true])
-
-    @table_headways = Headways.create_table(@table_headways)
+    create_tables(state)
 
     {:ok, state}
+  end
+
+  def create_tables(state) do
+    :ets.new(state.table_name_signs, [:set, :protected, :named_table, read_concurrency: true])
+    Headways.create_table(state.table_name_headways)
   end
 
   @spec handle_info(:update, state) :: {:noreply, state}


### PR DESCRIPTION
#### Summary of changes

This reworks the config engine test to abstract away knowledge of the underlying ETS tables. The goal is to free the tests from having to explicitly create tables during setup. This should reduce spontaneous failures when the internal implementation of the engine changes.