### PR TITLE
implement misc bus features

### DIFF
--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -12,7 +12,8 @@ defmodule Fake.ExternalConfig.Local do
       %{
         "signs" => %{
           "some_custom_sign" => %{"line1" => "custom", "line2" => "", "expires" => nil}
-        }
+        },
+        "chelsea_bridge_announcements" => "off"
       }
     }
   end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -482,19 +482,20 @@ defmodule PaEss.Utilities do
   end
 
   @spec prediction_route_name(Predictions.BusPrediction.t()) :: String.t() | nil
-  # Don't display "SLW" route name when its outbound headsign already says "Silver Line Way".
-  def prediction_route_name(%{route_id: "746", headsign: "Silver Line Way"}), do: nil
-  # Heading inbound from Silver Line Way to South Station, all routes take the same path, so
-  # treat them as one unit and don't display route names.
-  def prediction_route_name(%{stop_id: stop_id, headsign: "South Station"})
-      when stop_id in ["74615", "74616"],
+  # Don't display route names for SL1, SL2, SL3, or SLW. This also has the effect of combining
+  # inbound predictions along the waterfront, where all routes follow the same path.
+  def prediction_route_name(%{route_id: route_id})
+      when route_id in ["741", "742", "743", "746"],
+      do: nil
+
+  # At Nubian platform A, all routes to Ruggles take the same path, so treat them as one unit
+  # and don't display route names.
+  def prediction_route_name(%{stop_id: "64000", headsign: "Ruggles", route_id: route_id})
+      when route_id in ["15", "23", "28", "44", "45"],
       do: nil
 
   def prediction_route_name(%{route_id: "749"}), do: "SL5"
   def prediction_route_name(%{route_id: "751"}), do: "SL4"
-  def prediction_route_name(%{route_id: "743"}), do: "SL3"
-  def prediction_route_name(%{route_id: "742"}), do: "SL2"
-  def prediction_route_name(%{route_id: "741"}), do: "SL1"
   def prediction_route_name(%{route_id: "77", headsign: "North Cambridge"}), do: "77A"
 
   def prediction_route_name(%{route_id: "2427", stop_id: "185", headsign: headsign}) do
@@ -646,6 +647,8 @@ defmodule PaEss.Utilities do
 
   @atom_take_lookup %{
     the_next_bus_to: "543",
+    the_next: "501",
+    the_following: "667",
     departs: "502",
     arrives: "503",
     in: "504",

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -393,8 +393,9 @@ defmodule Signs.Bus do
     period.(current_time) != period.(last_read_time)
   end
 
-  # In addition to periodic audio messages, we also read the drawbridge message by itself if all
-  # of the following are true:
+  # SL waterfront stops are impacted by the Chelsea bridge, but don't display a persistent visual
+  # message while it's up. To let people know about delays promptly, we read the drawbridge message
+  # by itself if all of the following are true:
   # 1. the drawbridge just went up
   # 2. drawbridge messages are enabled
   # 3. we are at a stop that is impacted, but does not show visual drawbridge messages

--- a/scripts/transitway_engine/parse_config.exs
+++ b/scripts/transitway_engine/parse_config.exs
@@ -157,9 +157,13 @@ signs_json =
         read_loop_offset: offset * 60,
         text_zone: text_zone,
         audio_zones:
-          for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
-              String.at(audio_zones, i) == "1" do
-            c
+          if id == "bus.Nubian_Platform_E_west" do
+            []
+          else
+            for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
+                String.at(audio_zones, i) == "1" do
+              c
+            end
           end,
         type: "bus"
       ] ++
@@ -174,7 +178,19 @@ signs_json =
         else
           [_, sid] = Regex.run(~r/STOP_ID_(\d+)_/, stop_id)
           routes = Map.fetch!(routes_lookup, id)
-          [sources: [Jason.OrderedObject.new(stop_id: sid, routes: routes)]]
+
+          [sources: [Jason.OrderedObject.new(stop_id: sid, routes: routes)]] ++
+            if id == "bus.Nubian_Platform_E_east" do
+              extra_routes = Map.fetch!(routes_lookup, "bus.Nubian_Platform_E_west")
+
+              [
+                extra_audio_sources: [
+                  Jason.OrderedObject.new(stop_id: "64000", routes: extra_routes)
+                ]
+              ]
+            else
+              []
+            end
         end ++
         cond do
           Enum.any?(

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -104,6 +104,15 @@ defmodule Engine.ConfigTest do
       assert Engine.Config.sign_config(:config_test_headway, "headway_test") == :headway
     end
 
+    test "loads chelsea bridge config" do
+      initialize_test_state(%{
+        table_name_chelsea_bridge: :bridge_off,
+        current_version: "new_format"
+      })
+
+      assert Engine.Config.chelsea_bridge_config(:bridge_off) == :off
+    end
+
     test "logs a when an unknown message is received" do
       log =
         capture_log([level: :info], fn ->
@@ -127,6 +136,7 @@ defmodule Engine.ConfigTest do
         %{
           table_name_signs: :test_signs,
           table_name_headways: :test_headways,
+          table_name_chelsea_bridge: :test_chelsea_bridge,
           current_version: nil,
           time_fetcher: &DateTime.utc_now/0
         },


### PR DESCRIPTION
#### Summary of changes

This includes several smaller features:
* "Debounces" prediction times, to ensure that stale predictions are never revived later due to changes around the zero mark (see `prediction_stale?`)
* Suppresses all SL route names, as well as route names at Nubian A (per decision)
* Loads the Chelsea bridge flag from the config and uses it to control the bridge messages (see `bridge_enabled?`)
* Implements combined audio readout for both sides of Nubian E (see `extra_audio_sources`)
* Implements immediate bridge announcement at waterfront stops when the status changes to raised (see `should_announce_drawbridge?`)
* Fixes a math bug in the bridge status calculation