### PR TITLE
Aggregate audio across zones

### DIFF
--- a/lib/content.ex
+++ b/lib/content.ex
@@ -1,5 +1,5 @@
 defmodule Content do
-  @type line_location :: :top | :bottom
+  @type line_location :: :top | :bottom | :neither
 
   @type platform :: :ashmont | :braintree
 end

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -49,7 +49,7 @@ defmodule Content.Audio.Predictions do
           route_id: predictions.route_id
         }
 
-      predictions.minutes == :approaching and (line == :top or multi_source?) and
+      predictions.minutes == :approaching and (line == :top or line == :neither or multi_source?) and
           predictions.route_id in @heavy_rail_routes ->
         %Approaching{
           destination: predictions.destination,

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -165,7 +165,7 @@ defmodule PaEss.HttpUpdater do
   def process({:send_audio, [{station, zones}, audios, priority, timeout]}, state) do
     case audios do
       list when is_list(list) ->
-        combined_audios = combine_audio(list) |> IO.inspect()
+        combined_audios = combine_audio(list)
 
         for audio <- combined_audios do
           process_send_combined_audio(station, zones, audio, priority, timeout, state)

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -166,6 +166,25 @@ defmodule Signs.Utilities.Audio do
     {audio, sign}
   end
 
+  def from_content_list(content_list) do
+    Enum.map(content_list, fn content ->
+      case content do
+        {_, %Content.Message.StoppedTrain{} = stopped_train} ->
+          Content.Audio.StoppedTrain.from_message(stopped_train)
+
+        {_, %Content.Message.Predictions{}} = prediction ->
+          Audio.Predictions.from_sign_content(prediction, :neither, false)
+
+        {_, %Content.Message.Headways.Paging{} = paging_headways} ->
+          Audio.VehiclesToDestination.from_paging_headway_message(paging_headways)
+
+        {{_, %Content.Message.Headways.Top{} = top},
+         {_, %Content.Message.Headways.Bottom{} = bottom}} ->
+          Audio.VehiclesToDestination.from_headway_message(top, bottom)
+      end
+    end)
+  end
+
   @spec sort_audio([Content.Audio.t()]) :: [Content.Audio.t()]
   defp sort_audio(audios) do
     Enum.sort_by(audios, fn audio ->


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate the ability to aggregate audio messages and play in succession](https://app.asana.com/0/1201753694073608/1203549328375594/f)

POC for aggregating audio across audio zones. It ends up skipping sending messages that don't use the "pure take id" format to the headend for simplicity. I think it's a relatively small subset of messages that don't do this, but large enough to where it would be a fair amount of work to convert all of them which isn't important at the moment.

This POC for now skips alert messages because I think those would require some more product discussion to determine how to handle. I stuck to the more straightforward ones that I felt I could come up with reasonable business logic about on my own. Currently, the logic prioritizes audio in the following order:

1. Top line stops away messages
2. Boarding predictions
3. Arriving predictions
4. Approaching predictions
5. Normal predictions
6. Bottom line stops away messages
7. Paging headways (these are always on a bottom line)
8. Normal, double-line headways
