### PR TITLE
Automate cutover to backup headend server

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,7 +7,6 @@ config :realtime_signs, RealtimeSignsWeb.Endpoint,
 
 if config_env() != :test do
   config :realtime_signs,
-    sign_head_end_host: System.get_env("SIGN_HEAD_END_HOST"),
     sign_ui_url: System.get_env("SIGN_UI_URL"),
     sign_ui_api_key: System.get_env("SIGN_UI_API_KEY"),
     trip_update_url: System.get_env("TRIP_UPDATE_URL", "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json"),
@@ -23,7 +22,8 @@ if config_env() != :test do
     message_log_zip_url: System.get_env("MESSAGE_LOG_ZIP_URL"),
     message_log_s3_bucket: System.get_env("MESSAGE_LOG_S3_BUCKET"),
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
-    message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER")
+    message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
+    s3_active_headend_path: System.get_env("HEADEND_S3_PATH")
 end
 
 message_log_job =

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -15,7 +15,8 @@ defmodule Engine.Config do
           table_name_headways: term(),
           table_name_chelsea_bridge: term(),
           current_version: version_id,
-          time_fetcher: (() -> DateTime.t())
+          time_fetcher: (() -> DateTime.t()),
+          last_active_headend_ip: String.t()
         }
 
   @type sign_config :: :auto | :headway | :off | {:static_text, {String.t(), String.t()}}
@@ -61,10 +62,12 @@ defmodule Engine.Config do
       table_name_headways: @table_headways,
       table_name_chelsea_bridge: @table_chelsea_bridge,
       current_version: nil,
-      time_fetcher: opts[:time_fetcher] || fn -> DateTime.utc_now() end
+      time_fetcher: opts[:time_fetcher] || fn -> DateTime.utc_now() end,
+      last_active_headend_ip: nil
     }
 
     schedule_update(self())
+    send(self(), :update_active_headend)
 
     create_tables(state)
 
@@ -118,15 +121,30 @@ defmodule Engine.Config do
           state.current_version
       end
 
+    {:noreply, Map.put(state, :current_version, latest_version)}
+  end
+
+  def handle_info(:update_active_headend, state) do
+    schedule_update_active_headend(self())
+    updater = Application.get_env(:realtime_signs, :external_config_getter)
+
     case updater.get_active_headend_ip() do
       {:ok, active_headend_ip} ->
-        Application.put_env(:realtime_signs, :sign_head_end_host, active_headend_ip)
+        # Update active headend ip if startup or after at least two consecutive checks
+        if state.last_active_headend_ip == nil or
+             active_headend_ip == state.last_active_headend_ip do
+          Application.put_env(:realtime_signs, :sign_head_end_host, active_headend_ip)
+          Logger.info("active_headend_ip: current: #{active_headend_ip}")
+        else
+          Logger.info("active_headend_ip: pending update to: #{active_headend_ip}")
+        end
+
+        {:noreply, Map.put(state, :last_active_headend_ip, active_headend_ip)}
 
       _ ->
         Logger.warn("active_headend_ip: was not able to fetch active headend ip")
+        {:noreply, state}
     end
-
-    {:noreply, Map.put(state, :current_version, latest_version)}
   end
 
   def handle_info(msg, state) do
@@ -183,5 +201,9 @@ defmodule Engine.Config do
 
   defp schedule_update(pid, time \\ 1_000) do
     Process.send_after(pid, :update, time)
+  end
+
+  defp schedule_update_active_headend(pid, time \\ 10_000) do
+    Process.send_after(pid, :update_active_headend, time)
   end
 end

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -118,6 +118,14 @@ defmodule Engine.Config do
           state.current_version
       end
 
+    case updater.get_active_headend_ip() do
+      {:ok, active_headend_ip} ->
+        Application.put_env(:realtime_signs, :sign_head_end_host, active_headend_ip)
+
+      _ ->
+        Logger.warn("active_headend_ip: was not able to fetch active headend ip")
+    end
+
     {:noreply, Map.put(state, :current_version, latest_version)}
   end
 

--- a/lib/external_config/local.ex
+++ b/lib/external_config/local.ex
@@ -16,4 +16,12 @@ defmodule ExternalConfig.Local do
       {etag, Jason.decode!(file)}
     end
   end
+
+  def get_active_headend_ip() do
+    nil
+  end
+
+  def put_active_headend_ip(_ip) do
+    nil
+  end
 end

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -30,4 +30,39 @@ defmodule ExternalConfig.S3 do
         {nil, %{}}
     end
   end
+
+  def get_active_headend_ip() do
+    s3_client = Application.get_env(:realtime_signs, :s3_client)
+    aws_client = Application.get_env(:realtime_signs, :aws_client)
+    bucket = Application.get_env(:realtime_signs, :s3_bucket)
+    path = Application.get_env(:realtime_signs, :s3_active_headend_path)
+
+    case s3_client.get_object(bucket, path)
+         |> aws_client.request() do
+      {:ok, response} ->
+        body = Jason.decode!(response.body)
+        {:ok, body["active_headend_ip"]}
+
+      {:error, e} ->
+        Logger.error("active_headend_ip: s3 response error: #{inspect(e)}")
+        {:error, nil}
+    end
+  end
+
+  def put_active_headend_ip(ip) do
+    s3_client = Application.get_env(:realtime_signs, :s3_client)
+    aws_client = Application.get_env(:realtime_signs, :aws_client)
+    bucket = Application.get_env(:realtime_signs, :s3_bucket)
+    path = Application.get_env(:realtime_signs, :s3_active_headend_path)
+
+    case s3_client.put_object(bucket, path, Jason.encode!(%{active_headend_ip: ip}))
+         |> aws_client.request() do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, e} ->
+        Logger.error("s3 response error: #{inspect(e)}")
+        {:error, nil}
+    end
+  end
 end

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -58,7 +58,7 @@ defmodule ExternalConfig.S3 do
     case s3_client.put_object(bucket, path, Jason.encode!(%{active_headend_ip: ip}))
          |> aws_client.request() do
       {:ok, response} ->
-        Logger.info("active_headend_ip: Updated to #{ip}")
+        Logger.info("active_headend_ip: changed: #{ip}")
         {:ok, response}
 
       {:error, e} ->

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -58,6 +58,7 @@ defmodule ExternalConfig.S3 do
     case s3_client.put_object(bucket, path, Jason.encode!(%{active_headend_ip: ip}))
          |> aws_client.request() do
       {:ok, response} ->
+        Logger.info("active_headend_ip: Updated to #{ip}")
         {:ok, response}
 
       {:error, e} ->

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -58,7 +58,8 @@ defmodule ExternalConfig.S3 do
     case s3_client.put_object(bucket, path, Jason.encode!(%{active_headend_ip: ip}))
          |> aws_client.request() do
       {:ok, response} ->
-        Logger.info("active_headend_ip: changed: #{ip}")
+        Logger.info("active_headend_ip: config changed to: #{ip}")
+        Application.put_env(:realtime_signs, :sign_head_end_host, ip)
         {:ok, response}
 
       {:error, e} ->

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -61,7 +61,7 @@ defmodule ExternalConfig.S3 do
         {:ok, response}
 
       {:error, e} ->
-        Logger.error("s3 response error: #{inspect(e)}")
+        Logger.error("active_headend_ip: s3 response error: #{inspect(e)}")
         {:error, nil}
     end
   end

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -59,7 +59,6 @@ defmodule ExternalConfig.S3 do
          |> aws_client.request() do
       {:ok, response} ->
         Logger.info("active_headend_ip: config changed to: #{ip}")
-        Application.put_env(:realtime_signs, :sign_head_end_host, ip)
         {:ok, response}
 
       {:error, e} ->

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -1,0 +1,11 @@
+defmodule Monitoring.Headend do
+  def update_active_headend_ip(ip) do
+    valid? = ip == "172.20.145.20" or ip == "172.20.145.22"
+
+    if valid? do
+      ExternalConfig.S3.put_active_headend_ip(ip)
+    else
+      {:bad_request, "Bad request"}
+    end
+  end
+end

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -1,10 +1,13 @@
 defmodule Monitoring.Headend do
+  require Logger
+
   def update_active_headend_ip(ip) do
     valid? = ip == "172.20.145.20" or ip == "172.20.145.22"
 
     if valid? do
       ExternalConfig.S3.put_active_headend_ip(ip)
     else
+      Logger.warn("active_headend_ip: Invalid IP provided: #{ip}")
       {:bad_request, "Bad request"}
     end
   end

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -3,12 +3,20 @@ defmodule Monitoring.Headend do
 
   def update_active_headend_ip(ip) do
     valid? = ip == "172.20.145.20" or ip == "172.20.145.22"
+    current_active_ip = Application.get_env(:realtime_signs, :sign_head_end_host)
+    change? = ip != current_active_ip
 
-    if valid? do
-      ExternalConfig.S3.put_active_headend_ip(ip)
-    else
-      Logger.warn("active_headend_ip: Invalid IP provided: #{ip}")
-      {:bad_request, "Bad request"}
+    cond do
+      not valid? ->
+        Logger.warn("active_headend_ip: invalid ip provided: #{ip}")
+        {:bad_request, "bad request"}
+
+      change? ->
+        ExternalConfig.S3.put_active_headend_ip(ip)
+
+      true ->
+        Logger.info("active_headend_ip: current value: #{current_active_ip}")
+        {:ok, "unchanged"}
     end
   end
 end

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -15,7 +15,7 @@ defmodule Monitoring.Headend do
         ExternalConfig.S3.put_active_headend_ip(ip)
 
       true ->
-        Logger.info("active_headend_ip: current value: #{current_active_ip}")
+        Logger.info("active_headend_ip: received: #{current_active_ip}")
         {:ok, "unchanged"}
     end
   end

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -3,8 +3,7 @@ defmodule Monitoring.Headend do
 
   def update_active_headend_ip(ip) do
     valid? = ip == "172.20.145.20" or ip == "172.20.145.22"
-    current_active_ip = Application.get_env(:realtime_signs, :sign_head_end_host)
-    change? = ip != current_active_ip
+    change? = ip != Application.get_env(:realtime_signs, :sign_head_end_host)
 
     cond do
       not valid? ->
@@ -15,7 +14,7 @@ defmodule Monitoring.Headend do
         ExternalConfig.S3.put_active_headend_ip(ip)
 
       true ->
-        Logger.info("active_headend_ip: received: #{current_active_ip}")
+        Logger.info("active_headend_ip: received: #{ip}")
         {:ok, "unchanged"}
     end
   end

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -22,11 +22,11 @@ defmodule RealtimeSigns do
         Engine.Static,
         Engine.Alerts,
         MessageQueue,
-        RealtimeSigns.Scheduler
+        RealtimeSigns.Scheduler,
+        RealtimeSignsWeb.Endpoint
       ] ++
         bus_children() ++
         http_updater_children() ++
-        monitor_sign_scu_uptime() ++
         [
           Signs.Supervisor
         ]
@@ -57,16 +57,6 @@ defmodule RealtimeSigns do
     Logger.info(
       "environment_variable VEHICLE_POSITIONS_URL=#{inspect(Application.get_env(:realtime_signs, :vehicle_positions_url))}"
     )
-  end
-
-  def monitor_sign_scu_uptime do
-    if Application.get_env(:realtime_signs, RealtimeSignsWeb.Endpoint)
-       |> Keyword.get(:http)
-       |> Keyword.get(:port) do
-      [RealtimeSignsWeb.Endpoint]
-    else
-      []
-    end
   end
 
   def http_updater_children do

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -44,15 +44,12 @@ defmodule RealtimeSignsWeb.MonitoringController do
   def update_active_headend(conn, %{"active_ip" => active_ip} = _params) do
     case Headend.update_active_headend_ip(active_ip) do
       {:ok, _} ->
-        Logger.info("active_headend_ip: Updated to #{active_ip}")
         send_resp(conn, 200, "ok")
 
       {:bad_request, message} ->
-        Logger.warn("active_headend_ip: Failed to update to #{active_ip}")
         send_resp(conn, 400, message)
 
       {:error, _} ->
-        Logger.warn("active_headend_ip: Failed to update to #{active_ip}")
         send_resp(conn, 500, "Internal server error")
     end
   end

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -41,7 +41,7 @@ defmodule RealtimeSignsWeb.MonitoringController do
     send_resp(conn, 200, "")
   end
 
-  def update_active_headend(conn, %{"active_ip" => active_ip} = _params) do
+  def update_active_headend(conn, %{"ip" => active_ip} = _params) do
     case Headend.update_active_headend_ip(active_ip) do
       {:ok, _} ->
         send_resp(conn, 200, "ok")

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -1,14 +1,15 @@
 defmodule RealtimeSignsWeb.MonitoringController do
   require Logger
   use RealtimeSignsWeb, :controller
-  import Monitoring.Uptime
+  alias Monitoring.Headend
+  alias Monitoring.Uptime
 
   def uptime(
         conn,
         %{"time" => timestamp, "data" => %{"nodes" => nodes}} = _params
       ) do
     Logger.info("Received uptime statuses from ARINC: Node count=#{Enum.count(nodes)}")
-    monitor_node_uptime(nodes, timestamp)
+    Uptime.monitor_node_uptime(nodes, timestamp)
     send_resp(conn, 200, "")
   end
 
@@ -38,5 +39,21 @@ defmodule RealtimeSignsWeb.MonitoringController do
     )
 
     send_resp(conn, 200, "")
+  end
+
+  def update_active_headend(conn, %{"active_ip" => active_ip} = _params) do
+    case Headend.update_active_headend_ip(active_ip) do
+      {:ok, _} ->
+        Logger.info("active_headend_ip: Updated to #{active_ip}")
+        send_resp(conn, 200, "ok")
+
+      {:bad_request, message} ->
+        Logger.warn("active_headend_ip: Failed to update to #{active_ip}")
+        send_resp(conn, 400, message)
+
+      {:error, _} ->
+        Logger.warn("active_headend_ip: Failed to update to #{active_ip}")
+        send_resp(conn, 500, "Internal server error")
+    end
   end
 end

--- a/lib/realtime_signs_web/router.ex
+++ b/lib/realtime_signs_web/router.ex
@@ -17,5 +17,7 @@ defmodule RealtimeSignsWeb.Router do
       MonitoringController,
       :run_message_latency_report
     )
+
+    get("/update_active_headend/:ip", MonitoringController, :update_active_headend)
   end
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[#1558] Improve failover process for Realtime Signs](https://app.asana.com/0/1189528452014899/1202213418523535/f)

This PR is adding two main features
1. A URL that ARINC can utilize to point Realtime Signs at a different headend server
2. Logic to the config engine that polls the value of the active headend server from S3

The config value will only be updated in S3 if it is valid and different from what is was before.

The value will only be read into the app config if the application is just starting up, or if there have been at least two reads from S3 with the same value. The latter is a safeguard against potential (albeit unlikely) false positives as suggested by Andrew Daniels from ARINC.

A few things will be needed as follow-up steps
1. Set up ahead of time a `headend.json` file for realtime signs prod containing the required value 
2. Update S3 permissions in Terraform
3. ARINC starts their script that will ping us consistently with the currently active host's ip
4. Remove SIGN_HEAD_END_HOST from secrets