### PR TITLE
Increase page durations for rail

### DIFF
--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -18,12 +18,12 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
            PaEss.Utilities.destination_to_sign_string(destination),
            "no service",
            @default_page_width
-         ), 3},
+         ), 4},
         {Content.Utilities.width_padded_string(
            PaEss.Utilities.destination_to_sign_string(destination),
            "use shuttle",
            @default_page_width
-         ), 3}
+         ), 4}
       ]
     end
   end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -13,8 +13,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {"Trains every", 3},
-        {format_paging_headway_range(range), 3}
+        {"Trains every", 4},
+        {format_paging_headway_range(range), 4}
       ]
     end
 
@@ -23,8 +23,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {destination_trains_every_string(destination), 3},
-        {destination_range_string(destination, range), 3}
+        {destination_trains_every_string(destination), 4},
+        {destination_range_string(destination, range), 4}
       ]
     end
 

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -168,8 +168,8 @@ defmodule Content.Message.Predictions do
 
         track_number ->
           [
-            {Content.Utilities.width_padded_string(headsign, duration_string, width), 3},
-            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 3}
+            {Content.Utilities.width_padded_string(headsign, duration_string, width), 4},
+            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 4}
           ]
 
         true ->

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -55,9 +55,9 @@ defmodule Content.Message.StoppedTrain do
       stop_word = if n == 1, do: "stop", else: "stops"
 
       [
-        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 6},
-        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 3},
-        {Content.Utilities.width_padded_string(headsign, "away", 18), 3}
+        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 4},
+        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 4},
+        {Content.Utilities.width_padded_string(headsign, "away", 18), 4}
       ]
     end
   end

--- a/test/content/messages/alert/no_service_use_shuttle_test.exs
+++ b/test/content/messages/alert/no_service_use_shuttle_test.exs
@@ -6,8 +6,8 @@ defmodule Content.Message.Alert.NoServiceUseShuttleTest do
       msg = %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
 
       assert Content.Message.to_string(msg) == [
-               {"Medfd/Tufts   no service", 3},
-               {"Medfd/Tufts  use shuttle", 3}
+               {"Medfd/Tufts   no service", 4},
+               {"Medfd/Tufts  use shuttle", 4}
              ]
     end
   end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -7,8 +7,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: :heath_street,
                range: {5, 7}
              }) == [
-               {"Heath St    trains every", 3},
-               {"Heath St      5 to 7 min", 3}
+               {"Heath St    trains every", 4},
+               {"Heath St      5 to 7 min", 4}
              ]
     end
 
@@ -17,8 +17,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: nil,
                range: {5, 7}
              }) == [
-               {"Trains every", 3},
-               {"5 to 7 min", 3}
+               {"Trains every", 4},
+               {"5 to 7 min", 4}
              ]
     end
   end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -401,8 +401,8 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == [
-               {"Oak Grove    2 min", 3},
-               {"Oak Grove    Trk 2", 3}
+               {"Oak Grove    2 min", 4},
+               {"Oak Grove    Trk 2", 4}
              ]
     end
 

--- a/test/content/messages/stopped_train_test.exs
+++ b/test/content/messages/stopped_train_test.exs
@@ -7,9 +7,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 6},
-                 {"Braintree  2 stops", 3},
-                 {"Braintree     away", 3}
+                 {"Braintree  Stopped", 4},
+                 {"Braintree  2 stops", 4},
+                 {"Braintree     away", 4}
                ]
     end
 
@@ -18,9 +18,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 6},
-                 {"Braintree   1 stop", 3},
-                 {"Braintree     away", 3}
+                 {"Braintree  Stopped", 4},
+                 {"Braintree   1 stop", 4},
+                 {"Braintree     away", 4}
                ]
     end
   end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -316,7 +316,7 @@ defmodule PaEss.HttpUpdaterTest do
       msg = %Content.Message.StoppedTrain{destination: :ashmont, stops_away: 3}
 
       assert PaEss.HttpUpdater.to_command(msg, 55, :now, "n", 1) ==
-               "e55~n1-\"Ashmont       away\".2-\"Ashmont    Stopped\".5-\"Ashmont    3 stops\".2"
+               "e55~n1-\"Ashmont       away\".3-\"Ashmont    Stopped\".3-\"Ashmont    3 stops\".3"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Stabilize paging frequency to address memory issues](https://app.asana.com/0/1201753694073608/1204168984928043/f)

This PR updates the few paging messages that we have to show each page for 4 seconds each (with the exception of JFK/UMass which we have set to page every 6 seconds) instead of 3 seconds. For background context: the "stops away" messages were set to show the first page for 6 seconds to convey that the primary piece of info is that the train is stopped. We decided internally to change this behavior so that each page shows for an equal duration.

The countdown clocks have been known to have their internal memory buffers overflow which causes crashes of unpredictable lengths.  Each page is sent by the SCU to the sign as an individual message at a frequency based on the page duration. By lengthening the page durations and making them more consistent, we hope to mitigate the potential for these memory-related crashes.
