### PR TITLE
improve handling of bus prediction data

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -17,7 +17,7 @@ defmodule Content.Utilities do
     for message <- [top, bottom] do
       case Content.Message.to_string(message) do
         pages when is_list(pages) -> Enum.map(pages, fn {_, n} -> n end) |> Enum.sum()
-        str when is_binary(str) -> 0
+        str when is_binary(str) -> 6
       end
     end
     |> Enum.max()

--- a/lib/engine/bus_predictions.ex
+++ b/lib/engine/bus_predictions.ex
@@ -12,94 +12,100 @@ defmodule Engine.BusPredictions do
 
   def init(_) do
     schedule_update(self())
-    {:ok, %{predictions: %{}}}
+    {:ok, %{predictions: %{}, last_modified: nil}}
   end
 
   def handle_info(:update, state) do
+    %{last_modified: last_modified} = state
     schedule_update(self())
     api_url = Application.get_env(:realtime_signs, :api_v3_url)
     api_key = Application.get_env(:realtime_signs, :api_v3_key)
     http_client = Application.get_env(:realtime_signs, :http_client)
 
-    with {:ok, %{status_code: 200, body: body}} <-
-           http_client.get(
-             api_url <> "/predictions",
-             if api_key do
-               [{"x-api-key", api_key}]
-             else
-               []
-             end,
-             timeout: 2000,
-             recv_timeout: 2000,
-             params: %{
-               "include" => "trip,vehicle",
-               "fields[prediction]" => "departure_time,direction_id",
-               "fields[trip]" => "headsign",
-               "fields[vehicle]" => "updated_at",
-               "filter[stop]" => Enum.join(Signs.Utilities.SignsConfig.all_bus_stop_ids(), ",")
-             }
+    case http_client.get(
+           api_url <> "/predictions",
+           Enum.concat(
+             if(last_modified, do: [{"if-modified-since", last_modified}], else: []),
+             if(api_key, do: [{"x-api-key", api_key}], else: [])
            ),
-         {:ok, %{"data" => data, "included" => included}} <- Jason.decode(body) do
-      vehicles_lookup =
-        for %{
-              "type" => "vehicle",
-              "id" => id,
-              "attributes" => %{"updated_at" => updated_at}
-            } <- included,
-            into: %{} do
-          {id, %{id: id, updated_at: updated_at}}
-        end
+           timeout: 2000,
+           recv_timeout: 2000,
+           params: %{
+             "include" => "trip,vehicle",
+             "fields[prediction]" => "departure_time,direction_id",
+             "fields[trip]" => "headsign",
+             "fields[vehicle]" => "updated_at",
+             "filter[stop]" => Enum.join(Signs.Utilities.SignsConfig.all_bus_stop_ids(), ",")
+           }
+         ) do
+      {:ok, %{status_code: 200, body: body, headers: headers}} ->
+        %{"data" => data, "included" => included} = Jason.decode!(body)
 
-      trips_lookup =
-        for %{
-              "type" => "trip",
-              "id" => id,
-              "attributes" => %{"headsign" => headsign},
-              "relationships" => %{
-                "route" => %{"data" => %{"id" => route_id}}
-              }
-            } <- included,
-            into: %{} do
-          {id, %{id: id, headsign: headsign, route_id: route_id}}
-        end
+        vehicles_lookup =
+          for %{
+                "type" => "vehicle",
+                "id" => id,
+                "attributes" => %{"updated_at" => updated_at}
+              } <- included,
+              into: %{} do
+            {id, %{id: id, updated_at: updated_at}}
+          end
 
-      new_predictions =
-        for %{
-              "attributes" => %{
-                "direction_id" => direction_id,
-                "departure_time" => departure_time
-              },
-              "relationships" => %{
-                "route" => %{"data" => %{"id" => route_id}},
-                "stop" => %{"data" => %{"id" => stop_id}},
-                "trip" => %{"data" => %{"id" => trip_id}},
-                "vehicle" => %{"data" => vehicle_data}
-              }
-            } <- data,
-            # Multi-route trips will have duplicate predictions for each route.
-            # To filter them out, we only keep the one whose route_id matches the trip's.
-            route_id == trips_lookup[trip_id].route_id do
-          vehicle_id =
-            case vehicle_data do
-              %{"id" => vehicle_id} -> vehicle_id
-              _ -> nil
-            end
+        trips_lookup =
+          for %{
+                "type" => "trip",
+                "id" => id,
+                "attributes" => %{"headsign" => headsign},
+                "relationships" => %{
+                  "route" => %{"data" => %{"id" => route_id}}
+                }
+              } <- included,
+              into: %{} do
+            {id, %{id: id, headsign: headsign, route_id: route_id}}
+          end
 
-          %Predictions.BusPrediction{
-            direction_id: direction_id,
-            departure_time:
-              if(departure_time, do: Timex.parse!(departure_time, "{ISO:Extended}")),
-            route_id: route_id,
-            stop_id: stop_id,
-            headsign: trips_lookup[trip_id].headsign,
-            vehicle_id: vehicle_id,
-            updated_at: if(vehicle_id, do: vehicles_lookup[vehicle_id].updated_at)
-          }
-        end
-        |> Enum.group_by(& &1.stop_id)
+        new_predictions =
+          for %{
+                "attributes" => %{
+                  "direction_id" => direction_id,
+                  "departure_time" => departure_time
+                },
+                "relationships" => %{
+                  "route" => %{"data" => %{"id" => route_id}},
+                  "stop" => %{"data" => %{"id" => stop_id}},
+                  "trip" => %{"data" => %{"id" => trip_id}},
+                  "vehicle" => %{"data" => vehicle_data}
+                }
+              } <- data,
+              # Multi-route trips will have duplicate predictions for each route.
+              # To filter them out, we only keep the one whose route_id matches the trip's.
+              route_id == trips_lookup[trip_id].route_id do
+            vehicle_id =
+              case vehicle_data do
+                %{"id" => vehicle_id} -> vehicle_id
+                _ -> nil
+              end
 
-      {:noreply, %{state | predictions: new_predictions}}
-    else
+            %Predictions.BusPrediction{
+              direction_id: direction_id,
+              departure_time:
+                if(departure_time, do: Timex.parse!(departure_time, "{ISO:Extended}")),
+              route_id: route_id,
+              stop_id: stop_id,
+              headsign: trips_lookup[trip_id].headsign,
+              vehicle_id: vehicle_id,
+              trip_id: trip_id,
+              updated_at: if(vehicle_id, do: vehicles_lookup[vehicle_id].updated_at)
+            }
+          end
+          |> Enum.group_by(& &1.stop_id)
+
+        {:noreply,
+         %{state | predictions: new_predictions, last_modified: Map.new(headers)["last-modified"]}}
+
+      {:ok, %{status_code: 304}} ->
+        {:noreply, state}
+
       err ->
         Logger.error("Error getting bus predictions: #{inspect(err)}")
         {:noreply, state}

--- a/lib/engine/bus_predictions.ex
+++ b/lib/engine/bus_predictions.ex
@@ -15,8 +15,7 @@ defmodule Engine.BusPredictions do
     {:ok, %{predictions: %{}, last_modified: nil}}
   end
 
-  def handle_info(:update, state) do
-    %{last_modified: last_modified} = state
+  def handle_info(:update, %{last_modified: last_modified} = state) do
     schedule_update(self())
     api_url = Application.get_env(:realtime_signs, :api_v3_url)
     api_key = Application.get_env(:realtime_signs, :api_v3_key)

--- a/lib/predictions/bus_prediction.ex
+++ b/lib/predictions/bus_prediction.ex
@@ -6,6 +6,7 @@ defmodule Predictions.BusPrediction do
     :stop_id,
     :headsign,
     :vehicle_id,
+    :trip_id,
     :updated_at
   ]
   defstruct @enforce_keys
@@ -17,6 +18,7 @@ defmodule Predictions.BusPrediction do
           stop_id: String.t(),
           headsign: String.t(),
           vehicle_id: String.t() | nil,
+          trip_id: String.t(),
           updated_at: String.t() | nil
         }
 end

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -422,7 +422,7 @@ defmodule Signs.Bus do
   end
 
   defp prediction_key(prediction) do
-    Map.take(prediction, [:stop_id, :route_id, :vehicle_id, :direction_id])
+    Map.take(prediction, [:stop_id, :route_id, :vehicle_id, :direction_id, :trip_id])
   end
 
   defp bridge_status_minutes(bridge_status, current_time) do

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -12,6 +12,7 @@ defmodule Signs.BusTest do
           stop_id: "stop1",
           headsign: "Wakefield Ave",
           vehicle_id: "a",
+          trip_id: "a",
           updated_at: ""
         },
         %Predictions.BusPrediction{
@@ -21,6 +22,7 @@ defmodule Signs.BusTest do
           stop_id: "stop1",
           headsign: "Wakefield Ave",
           vehicle_id: "b",
+          trip_id: "b",
           updated_at: ""
         },
         %Predictions.BusPrediction{
@@ -30,6 +32,7 @@ defmodule Signs.BusTest do
           stop_id: "stop1",
           headsign: "Clarendon Hill",
           vehicle_id: "c",
+          trip_id: "c",
           updated_at: ""
         },
         %Predictions.BusPrediction{
@@ -39,6 +42,7 @@ defmodule Signs.BusTest do
           stop_id: "stop1",
           headsign: "Chelsea",
           vehicle_id: "d",
+          trip_id: "d",
           updated_at: ""
         }
       ]
@@ -53,6 +57,7 @@ defmodule Signs.BusTest do
           stop_id: "stop2",
           headsign: "Nubian",
           vehicle_id: "e",
+          trip_id: "e",
           updated_at: ""
         }
       ]


### PR DESCRIPTION
#### Summary of changes

* Uses API-provided headers to filter out responses that contain older data than we've gotten in previous responses. This fixes some instability in the prediction numbers over time.
* Includes trip id when identifying previous predictions. This accounts for the fact that we sometimes get predictions for future trips before the bus has passed on the current trip.
* Treats single-page messages as having a 6-second duration, for the purpose of delaying further updates. This will slow down sign updates in case we do encounter rapid changes in the predictions.