### PR TITLE
fix prediction sorting issue

### DIFF
--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -231,7 +231,7 @@ defmodule Signs.Bus do
 
       %{prediction | departure_time: departure_time}
     end
-    |> Enum.sort_by(& &1.departure_time)
+    |> Enum.sort_by(& &1.departure_time, DateTime)
   end
 
   defp filter_predictions(predictions, current_time, state) do

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -143,8 +143,8 @@ defmodule Signs.BusTest do
 
     test "platform mode, multiple pages" do
       expect_messages([
-        [{"14 WakefldAv 2 min", 6}, {"Chelsea      4 min", 6}],
-        [{"34 Clarendon 7 min", 6}, {"", 6}]
+        [{"14 WakefldAv 2 min", 6}, {"34 Clarendon 7 min", 6}],
+        [{"Chelsea      4 min", 6}, {"", 6}]
       ])
 
       expect_audios([
@@ -158,13 +158,13 @@ defmodule Signs.BusTest do
             "5502",
             "505",
             "21012",
+            "860",
+            "5504",
+            "505",
+            "21012",
             "678",
             "605",
             "5507",
-            "505",
-            "21012",
-            "860",
-            "5504",
             "505"
           ], :audio}}
       ])


### PR DESCRIPTION
#### Summary of changes

This fixes a bug in the predictions sorting, where prediction timestamps were being sorted structurally instead of by-value. This only seemed to impact test code, which generates `DateTime` structs dynamically, whereas the parsed values from the API seemed to sort correctly despite the bug. Additionally, there was a bug in the test code that was asserting the wrong value, which masked the issue.