### PR TITLE
unify handling of multiple audios

### DIFF
--- a/lib/content/audio/closure.ex
+++ b/lib/content/audio/closure.ex
@@ -12,18 +12,18 @@ defmodule Content.Audio.Closure do
           alert: :shuttles_closed_station | :suspension_closed_station
         }
 
-  @spec from_messages(Content.Message.t(), Content.Message.t()) :: t() | nil
+  @spec from_messages(Content.Message.t(), Content.Message.t()) :: [t()]
   def from_messages(%Content.Message.Alert.NoService{}, %Content.Message.Alert.UseShuttleBus{}) do
-    %Content.Audio.Closure{alert: :shuttles_closed_station}
+    [%Content.Audio.Closure{alert: :shuttles_closed_station}]
   end
 
   def from_messages(%Content.Message.Alert.NoService{}, %Content.Message.Empty{}) do
-    %Content.Audio.Closure{alert: :suspension_closed_station}
+    [%Content.Audio.Closure{alert: :suspension_closed_station}]
   end
 
   def from_messages(top, bottom) do
     Logger.error("message_to_audio_error Audio.Closure #{inspect(top)} #{inspect(bottom)}")
-    nil
+    []
   end
 
   defimpl Content.Audio do

--- a/lib/content/audio/custom.ex
+++ b/lib/content/audio/custom.ex
@@ -12,31 +12,25 @@ defmodule Content.Audio.Custom do
           message: String.t()
         }
 
-  @spec from_messages(Content.Message.Custom.t(), Content.Message.t()) :: t() | nil
+  @spec from_messages(Content.Message.Custom.t(), Content.Message.t()) :: [t()]
   def from_messages(%Content.Message.Custom{line: :top, message: top}, %Content.Message.Custom{
         line: :bottom,
         message: bottom
       }) do
     audio = "#{top} #{bottom}"
 
-    %__MODULE__{
-      message: audio
-    }
+    [%__MODULE__{message: audio}]
   end
 
   def from_messages(%Content.Message.Custom{line: :top, message: audio}, %Content.Message.Empty{}) do
-    %__MODULE__{
-      message: audio
-    }
+    [%__MODULE__{message: audio}]
   end
 
   def from_messages(%Content.Message.Empty{}, %Content.Message.Custom{
         line: :bottom,
         message: audio
       }) do
-    %__MODULE__{
-      message: audio
-    }
+    [%__MODULE__{message: audio}]
   end
 
   defimpl Content.Audio do

--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -21,7 +21,7 @@ defmodule Content.Audio.FollowingTrain do
   @spec from_predictions_message({
           Signs.Utilities.SourceConfig.source(),
           Content.Message.Predictions.t()
-        }) :: Content.Audio.FollowingTrain.t() | nil
+        }) :: [Content.Audio.FollowingTrain.t()]
   def from_predictions_message({
         %{
           terminal?: terminal
@@ -34,17 +34,19 @@ defmodule Content.Audio.FollowingTrain do
         }
       })
       when is_integer(n) do
-    %__MODULE__{
-      destination: destination,
-      route_id: route_id,
-      minutes: n,
-      verb: arrives_or_departs(terminal),
-      station_code: station_code
-    }
+    [
+      %__MODULE__{
+        destination: destination,
+        route_id: route_id,
+        minutes: n,
+        verb: arrives_or_departs(terminal),
+        station_code: station_code
+      }
+    ]
   end
 
   def from_predictions_message({_src, _msg}) do
-    nil
+    []
   end
 
   @spec arrives_or_departs(boolean) :: :arrives | :departs

--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -19,16 +19,14 @@ defmodule Content.Audio.NoServiceToDestination do
       {:ok, destination} ->
         audio = "No service to #{destination}"
 
-        %__MODULE__{
-          message: audio
-        }
+        [%__MODULE__{message: audio}]
 
       {:error, :unknown} ->
         Logger.error(
           "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
         )
 
-        nil
+        []
     end
   end
 
@@ -37,16 +35,14 @@ defmodule Content.Audio.NoServiceToDestination do
       {:ok, destination} ->
         audio = "No service to #{destination} use shuttle"
 
-        %__MODULE__{
-          message: audio
-        }
+        [%__MODULE__{message: audio}]
 
       {:error, :unknown} ->
         Logger.error(
           "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
         )
 
-        nil
+        []
     end
   end
 

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -19,7 +19,7 @@ defmodule Content.Audio.Predictions do
           {Signs.Utilities.SourceConfig.source(), Content.Message.Predictions.t()},
           Content.line_location(),
           boolean()
-        ) :: nil | Content.Audio.t()
+        ) :: [Content.Audio.t()]
   def from_sign_content(
         {%Signs.Utilities.SourceConfig{} = src, %Content.Message.Predictions{} = predictions},
         line,
@@ -27,73 +27,90 @@ defmodule Content.Audio.Predictions do
       ) do
     cond do
       TrackChange.park_track_change?(predictions) and predictions.minutes == :boarding ->
-        %TrackChange{
-          destination: predictions.destination,
-          route_id: predictions.route_id,
-          berth: predictions.stop_id
-        }
+        [
+          %TrackChange{
+            destination: predictions.destination,
+            route_id: predictions.route_id,
+            berth: predictions.stop_id
+          }
+        ]
 
       predictions.minutes == :boarding ->
-        %TrainIsBoarding{
-          destination: predictions.destination,
-          trip_id: predictions.trip_id,
-          route_id: predictions.route_id,
-          track_number: Content.Utilities.stop_track_number(predictions.stop_id)
-        }
+        [
+          %TrainIsBoarding{
+            destination: predictions.destination,
+            trip_id: predictions.trip_id,
+            route_id: predictions.route_id,
+            track_number: Content.Utilities.stop_track_number(predictions.stop_id)
+          }
+        ]
 
       predictions.minutes == :arriving ->
-        %TrainIsArriving{
-          destination: predictions.destination,
-          trip_id: predictions.trip_id,
-          platform: src.platform,
-          route_id: predictions.route_id
-        }
+        [
+          %TrainIsArriving{
+            destination: predictions.destination,
+            trip_id: predictions.trip_id,
+            platform: src.platform,
+            route_id: predictions.route_id
+          }
+        ]
 
       predictions.minutes == :approaching and (line == :top or multi_source?) and
           predictions.route_id in @heavy_rail_routes ->
-        %Approaching{
-          destination: predictions.destination,
-          trip_id: predictions.trip_id,
-          platform: src.platform,
-          route_id: predictions.route_id,
-          new_cars?: predictions.new_cars?
-        }
+        [
+          %Approaching{
+            destination: predictions.destination,
+            trip_id: predictions.trip_id,
+            platform: src.platform,
+            route_id: predictions.route_id,
+            new_cars?: predictions.new_cars?
+          }
+        ]
 
       predictions.minutes == :approaching ->
-        %NextTrainCountdown{
-          destination: predictions.destination,
-          route_id: predictions.route_id,
-          minutes: 1,
-          verb: if(src.terminal?, do: :departs, else: :arrives),
-          track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform,
-          station_code: predictions.station_code,
-          zone: predictions.zone
-        }
+        [
+          %NextTrainCountdown{
+            destination: predictions.destination,
+            route_id: predictions.route_id,
+            minutes: 1,
+            verb: if(src.terminal?, do: :departs, else: :arrives),
+            track_number: Content.Utilities.stop_track_number(predictions.stop_id),
+            platform: src.platform,
+            station_code: predictions.station_code,
+            zone: predictions.zone
+          }
+        ]
 
       predictions.minutes == :max_time ->
-        %NextTrainCountdown{
-          destination: predictions.destination,
-          route_id: predictions.route_id,
-          minutes: div(Content.Utilities.max_time_seconds(), 60),
-          verb: if(src.terminal?, do: :departs, else: :arrives),
-          track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform,
-          station_code: predictions.station_code,
-          zone: predictions.zone
-        }
+        [
+          %NextTrainCountdown{
+            destination: predictions.destination,
+            route_id: predictions.route_id,
+            minutes: div(Content.Utilities.max_time_seconds(), 60),
+            verb: if(src.terminal?, do: :departs, else: :arrives),
+            track_number: Content.Utilities.stop_track_number(predictions.stop_id),
+            platform: src.platform,
+            station_code: predictions.station_code,
+            zone: predictions.zone
+          }
+        ]
 
       is_integer(predictions.minutes) ->
-        %NextTrainCountdown{
-          destination: predictions.destination,
-          route_id: predictions.route_id,
-          minutes: predictions.minutes,
-          verb: if(src.terminal?, do: :departs, else: :arrives),
-          track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-          platform: src.platform,
-          station_code: predictions.station_code,
-          zone: predictions.zone
-        }
+        [
+          %NextTrainCountdown{
+            destination: predictions.destination,
+            route_id: predictions.route_id,
+            minutes: predictions.minutes,
+            verb: if(src.terminal?, do: :departs, else: :arrives),
+            track_number: Content.Utilities.stop_track_number(predictions.stop_id),
+            platform: src.platform,
+            station_code: predictions.station_code,
+            zone: predictions.zone
+          }
+        ]
+
+      true ->
+        []
     end
   end
 end

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -14,19 +14,19 @@ defmodule Content.Audio.StoppedTrain do
           stops_away: non_neg_integer()
         }
 
-  @spec from_message(Content.Message.t()) :: t() | nil
+  @spec from_message(Content.Message.t()) :: [t()]
   def from_message(%Content.Message.StoppedTrain{destination: destination, stops_away: stops_away})
       when stops_away > 0 do
-    %__MODULE__{destination: destination, stops_away: stops_away}
+    [%__MODULE__{destination: destination, stops_away: stops_away}]
   end
 
   def from_message(%Content.Message.StoppedTrain{stops_away: 0}) do
-    nil
+    []
   end
 
   def from_message(message) do
     Logger.error("message_to_audio_error Audio.StoppedTrain #{inspect(message)}")
-    nil
+    []
   end
 
   defimpl Content.Audio do

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -16,17 +16,13 @@ defmodule Content.Audio.VehiclesToDestination do
           previous_departure_mins: integer() | nil
         }
 
-  @spec from_headway_message(Content.Message.t(), Content.Message.t()) :: t() | {t(), t()} | nil
+  @spec from_headway_message(Content.Message.t(), Content.Message.t()) :: [t()]
   def from_headway_message(
         %Content.Message.Headways.Top{destination: destination},
         %Content.Message.Headways.Bottom{range: range} = msg
       ) do
-    case {create(:english, destination, range, msg.prev_departure_mins),
-          create(:spanish, destination, range, msg.prev_departure_mins)} do
-      {%__MODULE__{} = a1, %__MODULE__{} = a2} -> {a1, a2}
-      {%__MODULE__{} = a, nil} -> a
-      _ -> nil
-    end
+    create(:english, destination, range, msg.prev_departure_mins) ++
+      create(:spanish, destination, range, msg.prev_departure_mins)
   end
 
   def from_headway_message(top, bottom) do
@@ -34,7 +30,7 @@ defmodule Content.Audio.VehiclesToDestination do
       "message_to_audio_error Audio.VehiclesToDestination: #{inspect(top)}, #{inspect(bottom)}"
     )
 
-    nil
+    []
   end
 
   def from_paging_headway_message(%Content.Message.Headways.Paging{
@@ -49,30 +45,36 @@ defmodule Content.Audio.VehiclesToDestination do
           PaEss.destination() | nil,
           Headway.HeadwayDisplay.headway_range(),
           integer() | nil
-        ) :: t() | nil
+        ) :: [t()]
 
   defp create(:english, nil, range, nil) do
-    %__MODULE__{
-      language: :english,
-      destination: nil,
-      headway_range: range,
-      previous_departure_mins: nil
-    }
+    [
+      %__MODULE__{
+        language: :english,
+        destination: nil,
+        headway_range: range,
+        previous_departure_mins: nil
+      }
+    ]
   end
 
   defp create(:spanish, nil, _range, nil) do
-    nil
+    []
   end
 
   defp create(language, destination, headway_range, previous_departure_mins) do
     if Utilities.valid_destination?(destination, language) and
          not (language == :spanish and !is_nil(previous_departure_mins)) do
-      %__MODULE__{
-        language: language,
-        destination: destination,
-        headway_range: headway_range,
-        previous_departure_mins: previous_departure_mins
-      }
+      [
+        %__MODULE__{
+          language: language,
+          destination: destination,
+          headway_range: headway_range,
+          previous_departure_mins: previous_departure_mins
+        }
+      ]
+    else
+      []
     end
   end
 

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -163,19 +163,10 @@ defmodule PaEss.HttpUpdater do
   end
 
   def process({:send_audio, [{station, zones}, audios, priority, timeout]}, state) do
-    case audios do
-      list when is_list(list) ->
-        for audio <- list do
-          process_send_audio(station, zones, audio, priority, timeout, state)
-        end
-
-      {a1, a2} ->
-        process_send_audio(station, zones, a1, priority, timeout, state)
-        process_send_audio(station, zones, a2, priority, timeout, state)
-
-      a ->
-        process_send_audio(station, zones, a, priority, timeout, state)
+    for audio <- audios do
+      process_send_audio(station, zones, audio, priority, timeout, state)
     end
+    |> List.last()
   end
 
   @spec process_send_audio(String.t(), [String.t()], Content.Audio.t(), integer(), integer(), t()) ::

--- a/lib/pa_ess/logger.ex
+++ b/lib/pa_ess/logger.ex
@@ -50,11 +50,7 @@ defmodule PaEss.Logger do
 
   @impl true
   def send_audio(audio_id, audios, priority, timeout) do
-    audio_text =
-      case audios do
-        {a1, a2} -> inspect([Content.Audio.to_params(a1), Content.Audio.to_params(a2)])
-        a -> inspect(Content.Audio.to_params(a))
-      end
+    audio_text = Enum.map(audios, &Content.Audio.to_params(&1)) |> inspect()
 
     line = [
       now(),

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -14,8 +14,5 @@ defmodule PaEss.Updater do
               {:ok, :sent} | {:error, any()}
             when priority: integer(),
                  timeout: integer(),
-                 audios:
-                   Content.Audio.t()
-                   | {Content.Audio.t(), Content.Audio.t()}
-                   | [Content.Audio.t()]
+                 audios: [Content.Audio.t()]
 end

--- a/lib/signs/utilities/reader.ex
+++ b/lib/signs/utilities/reader.ex
@@ -38,20 +38,12 @@ defmodule Signs.Utilities.Reader do
   @spec send_audio_update(Signs.Realtime.t()) :: {boolean(), Signs.Realtime.t()}
   defp send_audio_update(sign) do
     case Signs.Utilities.Audio.from_sign(sign) do
-      {nil, sign} ->
+      {[], sign} ->
         {false, sign}
 
       {audios, sign} ->
-        send_audios(sign, audios)
+        sign.sign_updater.send_audio(sign.audio_id, audios, 5, 60)
         {true, sign}
     end
-  end
-
-  @spec send_audios(
-          Signs.Realtime.t(),
-          Content.Audio.t() | {Content.Audio.t(), Content.Audio.t()}
-        ) :: {:ok, :sent} | {:error, any()}
-  defp send_audios(sign, audio) do
-    sign.sign_updater.send_audio(sign.audio_id, audio, 5, 60)
   end
 end

--- a/test/content/audio/closure_test.exs
+++ b/test/content/audio/closure_test.exs
@@ -5,21 +5,21 @@ defmodule Content.Audio.ClosureTest do
 
   describe "from_messages/2" do
     test "Non-suspension messages" do
-      assert from_messages(%Content.Message.Empty{}, %Content.Message.Empty{}) == nil
+      assert from_messages(%Content.Message.Empty{}, %Content.Message.Empty{}) == []
     end
 
     test "Station closed due to shuttle" do
       assert from_messages(
                %Content.Message.Alert.NoService{},
                %Content.Message.Alert.UseShuttleBus{}
-             ) == %Content.Audio.Closure{alert: :shuttles_closed_station}
+             ) == [%Content.Audio.Closure{alert: :shuttles_closed_station}]
     end
 
     test "Station closed due to suspension" do
       assert from_messages(
                %Content.Message.Alert.NoService{},
                %Content.Message.Empty{}
-             ) == %Content.Audio.Closure{alert: :suspension_closed_station}
+             ) == [%Content.Audio.Closure{alert: :suspension_closed_station}]
     end
   end
 

--- a/test/content/audio/custom_test.exs
+++ b/test/content/audio/custom_test.exs
@@ -12,9 +12,8 @@ defmodule Content.Audio.CustomTest do
       message: "Bottom Message"
     }
 
-    assert Content.Audio.Custom.from_messages(top, bottom) == %Content.Audio.Custom{
-             message: "Top Message Bottom Message"
-           }
+    assert Content.Audio.Custom.from_messages(top, bottom) ==
+             [%Content.Audio.Custom{message: "Top Message Bottom Message"}]
   end
 
   test "Makes an audio message when the top is empty" do
@@ -25,9 +24,8 @@ defmodule Content.Audio.CustomTest do
       message: "Bottom Message"
     }
 
-    assert Content.Audio.Custom.from_messages(top, bottom) == %Content.Audio.Custom{
-             message: "Bottom Message"
-           }
+    assert Content.Audio.Custom.from_messages(top, bottom) ==
+             [%Content.Audio.Custom{message: "Bottom Message"}]
   end
 
   test "Makes an audio message when the bottom is empty" do
@@ -38,8 +36,7 @@ defmodule Content.Audio.CustomTest do
 
     bottom = %Content.Message.Empty{}
 
-    assert Content.Audio.Custom.from_messages(top, bottom) == %Content.Audio.Custom{
-             message: "Top Message"
-           }
+    assert Content.Audio.Custom.from_messages(top, bottom) ==
+             [%Content.Audio.Custom{message: "Top Message"}]
   end
 end

--- a/test/content/audio/following_train_test.exs
+++ b/test/content/audio/following_train_test.exs
@@ -29,12 +29,14 @@ defmodule Content.Audio.FollowingTrainTest do
            }, message}
         )
 
-      assert audio == %Content.Audio.FollowingTrain{
-               destination: :ashmont,
-               route_id: "Mattapan",
-               minutes: 5,
-               verb: :arrives
-             }
+      assert audio == [
+               %Content.Audio.FollowingTrain{
+                 destination: :ashmont,
+                 route_id: "Mattapan",
+                 minutes: 5,
+                 verb: :arrives
+               }
+             ]
     end
 
     test "when its a terminal it uses departs" do
@@ -52,12 +54,14 @@ defmodule Content.Audio.FollowingTrainTest do
            }, message}
         )
 
-      assert audio == %Content.Audio.FollowingTrain{
-               destination: :ashmont,
-               route_id: "Mattapan",
-               minutes: 5,
-               verb: :departs
-             }
+      assert audio == [
+               %Content.Audio.FollowingTrain{
+                 destination: :ashmont,
+                 route_id: "Mattapan",
+                 minutes: 5,
+                 verb: :departs
+               }
+             ]
     end
 
     test "when its 1 minute, uses the right singular announcement" do

--- a/test/content/audio/no_service_to_destination_test.exs
+++ b/test/content/audio/no_service_to_destination_test.exs
@@ -7,9 +7,7 @@ defmodule Content.Audio.NoServiceToDestinationTest do
     }
 
     assert Content.Audio.NoServiceToDestination.from_message(message) ==
-             %Content.Audio.NoServiceToDestination{
-               message: "No service to Medford/Tufts"
-             }
+             [%Content.Audio.NoServiceToDestination{message: "No service to Medford/Tufts"}]
   end
 
   test "Inserts destination into audio for paging shuttle alert" do
@@ -18,8 +16,10 @@ defmodule Content.Audio.NoServiceToDestinationTest do
     }
 
     assert Content.Audio.NoServiceToDestination.from_message(message) ==
-             %Content.Audio.NoServiceToDestination{
-               message: "No service to Medford/Tufts use shuttle"
-             }
+             [
+               %Content.Audio.NoServiceToDestination{
+                 message: "No service to Medford/Tufts use shuttle"
+               }
+             ]
   end
 end

--- a/test/content/audio/predictions_test.exs
+++ b/test/content/audio/predictions_test.exs
@@ -28,11 +28,13 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70197"
       }
 
-      assert %Audio.TrackChange{
-               destination: :boston_college,
-               route_id: "Green-B",
-               berth: "70197"
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.TrackChange{
+                 destination: :boston_college,
+                 route_id: "Green-B",
+                 berth: "70197"
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a TrackChange audio when Green-E boarding at D berth at Park St" do
@@ -45,11 +47,13 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70198"
       }
 
-      assert %Audio.TrackChange{
-               destination: :heath_street,
-               route_id: "Green-E",
-               berth: "70198"
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.TrackChange{
+                 destination: :heath_street,
+                 route_id: "Green-E",
+                 berth: "70198"
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a NextTrainCountdown if it's the wrong track but somehow not boarding" do
@@ -62,11 +66,13 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70196"
       }
 
-      assert %Audio.NextTrainCountdown{
-               destination: :heath_street,
-               verb: :arrives,
-               minutes: 2
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.NextTrainCountdown{
+                 destination: :heath_street,
+                 verb: :arrives,
+                 minutes: 2
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns an Approaching audio if predictions say it's approaching on the top line" do
@@ -87,13 +93,15 @@ defmodule Content.Audio.PredictionsTest do
         new_cars?: false
       }
 
-      assert %Audio.Approaching{
-               destination: :ashmont,
-               trip_id: "trip1",
-               platform: :ashmont,
-               route_id: "Red",
-               new_cars?: false
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.Approaching{
+                 destination: :ashmont,
+                 trip_id: "trip1",
+                 platform: :ashmont,
+                 route_id: "Red",
+                 new_cars?: false
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns an Approaching audio with new cars flag set" do
@@ -114,13 +122,15 @@ defmodule Content.Audio.PredictionsTest do
         new_cars?: true
       }
 
-      assert %Audio.Approaching{
-               destination: :ashmont,
-               trip_id: "trip1",
-               platform: :ashmont,
-               route_id: "Red",
-               new_cars?: true
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.Approaching{
+                 destination: :ashmont,
+                 trip_id: "trip1",
+                 platform: :ashmont,
+                 route_id: "Red",
+                 new_cars?: true
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a NextTrainCountdown audio for 'minutes: :approaching' and top line, but light rail" do
@@ -139,10 +149,8 @@ defmodule Content.Audio.PredictionsTest do
         trip_id: "trip1"
       }
 
-      assert %Audio.NextTrainCountdown{
-               destination: :riverside,
-               minutes: 1
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [%Audio.NextTrainCountdown{destination: :riverside, minutes: 1}] =
+               from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a NextTrainCountdown audio if predictions say it's approaching on the bottom line" do
@@ -155,13 +163,15 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70065"
       }
 
-      assert %Audio.NextTrainCountdown{
-               destination: :ashmont,
-               minutes: 1,
-               verb: :arrives,
-               track_number: nil,
-               platform: nil
-             } = from_sign_content({src, predictions}, :bottom, false)
+      assert [
+               %Audio.NextTrainCountdown{
+                 destination: :ashmont,
+                 minutes: 1,
+                 verb: :arrives,
+                 track_number: nil,
+                 platform: nil
+               }
+             ] = from_sign_content({src, predictions}, :bottom, false)
     end
 
     test "returns a TrainIsBoarding audio if predictions say it's boarding" do
@@ -175,12 +185,14 @@ defmodule Content.Audio.PredictionsTest do
         trip_id: "trip1"
       }
 
-      assert %Audio.TrainIsBoarding{
-               destination: :ashmont,
-               trip_id: "trip1",
-               route_id: "Red",
-               track_number: nil
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.TrainIsBoarding{
+                 destination: :ashmont,
+                 trip_id: "trip1",
+                 route_id: "Red",
+                 track_number: nil
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a TrainIsArriving audio if predictions say it's arriving" do
@@ -200,12 +212,14 @@ defmodule Content.Audio.PredictionsTest do
         trip_id: "trip1"
       }
 
-      assert %Audio.TrainIsArriving{
-               destination: :ashmont,
-               trip_id: "trip1",
-               platform: :ashmont,
-               route_id: "Red"
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.TrainIsArriving{
+                 destination: :ashmont,
+                 trip_id: "trip1",
+                 platform: :ashmont,
+                 route_id: "Red"
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a NextTrainCountdown arriving audio if prediction is minutes away and non-terminal source" do
@@ -224,7 +238,7 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70065"
       }
 
-      assert %Audio.NextTrainCountdown{destination: :ashmont, verb: :arrives, minutes: 1} =
+      assert [%Audio.NextTrainCountdown{destination: :ashmont, verb: :arrives, minutes: 1}] =
                from_sign_content({src, predictions}, :top, false)
     end
 
@@ -244,7 +258,7 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70061"
       }
 
-      assert %Audio.NextTrainCountdown{destination: :ashmont, verb: :departs, minutes: 1} =
+      assert [%Audio.NextTrainCountdown{destination: :ashmont, verb: :departs, minutes: 1}] =
                from_sign_content({src, predictions}, :top, false)
     end
 
@@ -264,12 +278,14 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70096"
       }
 
-      assert %Audio.NextTrainCountdown{
-               destination: :alewife,
-               verb: :arrives,
-               minutes: 2,
-               platform: :ashmont
-             } = from_sign_content({src, predictions}, :top, false)
+      assert [
+               %Audio.NextTrainCountdown{
+                 destination: :alewife,
+                 verb: :arrives,
+                 minutes: 2,
+                 platform: :ashmont
+               }
+             ] = from_sign_content({src, predictions}, :top, false)
     end
 
     test "returns a NextTrainCountdown with 30 mins if predictions is :max_time" do
@@ -288,7 +304,7 @@ defmodule Content.Audio.PredictionsTest do
         stop_id: "70065"
       }
 
-      assert %Audio.NextTrainCountdown{destination: :ashmont, verb: :arrives, minutes: 20} =
+      assert [%Audio.NextTrainCountdown{destination: :ashmont, verb: :arrives, minutes: 20}] =
                from_sign_content({src, predictions}, :top, false)
     end
   end

--- a/test/content/audio/stopped_train_test.exs
+++ b/test/content/audio/stopped_train_test.exs
@@ -83,18 +83,18 @@ defmodule Content.Audio.StoppedTrainTest do
       msg = %Content.Message.StoppedTrain{destination: :forest_hills, stops_away: 1}
 
       assert Content.Audio.StoppedTrain.from_message(msg) ==
-               %Content.Audio.StoppedTrain{destination: :forest_hills, stops_away: 1}
+               [%Content.Audio.StoppedTrain{destination: :forest_hills, stops_away: 1}]
     end
 
     test "Returns nil for irrelevant message" do
       msg = %Content.Message.Empty{}
-      assert Content.Audio.StoppedTrain.from_message(msg) == nil
+      assert Content.Audio.StoppedTrain.from_message(msg) == []
     end
 
     test "when the trian is stopped 0 stops away, does not announce that it is stopped 0 stops away" do
       msg = %Content.Message.StoppedTrain{destination: :forest_hills, stops_away: 0}
 
-      assert Content.Audio.StoppedTrain.from_message(msg) == nil
+      assert Content.Audio.StoppedTrain.from_message(msg) == []
     end
   end
 end

--- a/test/content/audio/vehicles_to_destination_test.exs
+++ b/test/content/audio/vehicles_to_destination_test.exs
@@ -166,116 +166,149 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     @msg %Content.Message.Headways.Bottom{range: {5, 7}}
 
     test "returns an audio message from a headway message to chelsea" do
-      assert {
+      assert [
                %Content.Audio.VehiclesToDestination{language: :english, destination: :chelsea},
                %Content.Audio.VehiclesToDestination{language: :spanish, destination: :chelsea}
-             } = from_headway_message(%Content.Message.Headways.Top{destination: :chelsea}, @msg)
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :chelsea}, @msg)
     end
 
     test "returns an audio message from a headway message to red/orange/blue/green line terminals" do
       # green line
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :lechmere
-             } = from_headway_message(%Content.Message.Headways.Top{destination: :lechmere}, @msg)
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :lechmere
+               }
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :lechmere}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :union_sq
-             } = from_headway_message(%Content.Message.Headways.Top{destination: :union_sq}, @msg)
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :union_sq
+               }
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :union_sq}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :government_center
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :government_center
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :government_center},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :north_station
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :north_station
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :north_station},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :park_street} =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :park_street
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :park_street},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :heath_street
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :heath_street
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :heath_street},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :riverside
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :riverside
+               }
+             ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :riverside}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :boston_college
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :boston_college
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :boston_college},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :cleveland_circle
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :cleveland_circle
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :cleveland_circle},
                  @msg
                )
 
       # blue line
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :bowdoin
-             } = from_headway_message(%Content.Message.Headways.Top{destination: :bowdoin}, @msg)
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :bowdoin
+               }
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :bowdoin}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :wonderland} =
+      assert [
+               %Content.Audio.VehiclesToDestination{language: :english, destination: :wonderland}
+             ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :wonderland}, @msg)
 
       # orange line
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: :forest_hills
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: :forest_hills
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :forest_hills},
                  @msg
                )
 
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :oak_grove} =
+      assert [
+               %Content.Audio.VehiclesToDestination{language: :english, destination: :oak_grove}
+             ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :oak_grove}, @msg)
 
       # red line
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :alewife} =
-               from_headway_message(%Content.Message.Headways.Top{destination: :alewife}, @msg)
+      assert [
+               %Content.Audio.VehiclesToDestination{language: :english, destination: :alewife}
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :alewife}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :ashmont} =
-               from_headway_message(%Content.Message.Headways.Top{destination: :ashmont}, @msg)
+      assert [
+               %Content.Audio.VehiclesToDestination{language: :english, destination: :ashmont}
+             ] = from_headway_message(%Content.Message.Headways.Top{destination: :ashmont}, @msg)
 
-      assert %Content.Audio.VehiclesToDestination{language: :english, destination: :braintree} =
+      assert [
+               %Content.Audio.VehiclesToDestination{language: :english, destination: :braintree}
+             ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :braintree}, @msg)
     end
 
     test "returns an audio message from a headway message to south station" do
-      assert {
+      assert [
                %Content.Audio.VehiclesToDestination{
                  language: :english,
                  destination: :south_station
@@ -284,7 +317,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                  language: :spanish,
                  destination: :south_station
                }
-             } =
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :south_station},
                  @msg
@@ -292,12 +325,14 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     end
 
     test "handles a nil destination in English" do
-      assert %Content.Audio.VehiclesToDestination{
-               language: :english,
-               destination: nil,
-               headway_range: {8, 10},
-               previous_departure_mins: nil
-             } =
+      assert [
+               %Content.Audio.VehiclesToDestination{
+                 language: :english,
+                 destination: nil,
+                 headway_range: {8, 10},
+                 previous_departure_mins: nil
+               }
+             ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: nil, vehicle_type: :train},
                  %Content.Message.Headways.Bottom{range: {8, 10}, prev_departure_mins: nil}
@@ -307,7 +342,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     test "returns nils for an unknown destination" do
       log =
         capture_log([level: :warn], fn ->
-          assert from_headway_message(:foo, :bar) == nil
+          assert from_headway_message(:foo, :bar) == []
         end)
 
       assert log =~ "message_to_audio_error"

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -123,7 +123,7 @@ defmodule PaEss.HttpUpdaterTest do
       audio = %Fake.UnknownAudio{}
 
       assert {:ok, :no_audio} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"GKEN", ["m"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"GKEN", ["m"]}, [audio], 5, 60]}, state)
     end
   end
 
@@ -141,7 +141,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} ==
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"SBOX", ["c"]}, audio, 5, 60]},
+                     {:send_audio, [{"SBOX", ["c"]}, [audio], 5, 60]},
                      state
                    )
         end)
@@ -159,7 +159,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBSQ", ["m"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"SBSQ", ["m"]}, [audio], 5, 60]}, state)
     end
 
     test "Buses to Chelsea, in Spanish" do
@@ -172,7 +172,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBOX", ["e"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"SBOX", ["e"]}, [audio], 5, 60]}, state)
     end
 
     test "Next train to Ashmont arrives in 4 minutes" do
@@ -187,7 +187,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["n"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["n"]}, [audio], 5, 60]}, state)
     end
 
     test "Train to Mattapan arriving" do
@@ -198,7 +198,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["s"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["s"]}, [audio], 5, 60]}, state)
     end
 
     test "Train to Ashmont arriving" do
@@ -210,7 +210,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCAP", ["n"]}, audio, 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]}, state)
     end
 
     test "sends custom audio messages" do
@@ -224,7 +224,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} ==
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"MCAP", ["n"]}, audio, 5, 60]},
+                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]},
                      state
                    )
         end)
@@ -244,7 +244,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} =
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"MCAP", ["n"]}, audio, 5, 60]},
+                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]},
                      state
                    )
         end)
@@ -272,7 +272,7 @@ defmodule PaEss.HttpUpdaterTest do
         minutes: 7
       }
 
-      PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["s"]}, {audio1, audio2}, 5, 60]}, state)
+      PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["s"]}, [audio1, audio2], 5, 60]}, state)
 
       assert_received {:post, q1}
       assert_received {:post, q2}
@@ -292,7 +292,7 @@ defmodule PaEss.HttpUpdaterTest do
       minutes: 2
     }
 
-    PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["m", "s", "c"]}, audio, 5, 60]}, state)
+    PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["m", "s", "c"]}, [audio], 5, 60]}, state)
     assert_received {:post, q}
     assert q =~ "sta=RPRK110100"
   end

--- a/test/pa_ess/logger_test.exs
+++ b/test/pa_ess/logger_test.exs
@@ -22,7 +22,7 @@ defmodule PaEss.LoggerTest do
     assert {:ok, :sent} =
              PaEss.Logger.send_audio(
                {"a", "b"},
-               %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5},
+               [%Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5}],
                5,
                60
              )
@@ -32,8 +32,10 @@ defmodule PaEss.LoggerTest do
     assert {:ok, :sent} =
              PaEss.Logger.send_audio(
                {"a", "b"},
-               {%Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5},
-                %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5}},
+               [
+                 %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5},
+                 %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 5}
+               ],
                5,
                60
              )

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -198,7 +198,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.Closure{alert: :shuttles_closed_station},
+               [%Audio.Closure{alert: :shuttles_closed_station}],
                ^sign
              } = from_sign(sign)
     end
@@ -211,7 +211,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.Custom{message: "Custom Top Custom Bottom"},
+               [%Audio.Custom{message: "Custom Top Custom Bottom"}],
                ^sign
              } = from_sign(sign)
     end
@@ -224,7 +224,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.Custom{message: "Custom Bottom"},
+               [%Audio.Custom{message: "Custom Bottom"}],
                ^sign
              } = from_sign(sign)
     end
@@ -237,11 +237,13 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :alewife,
-                 headway_range: {1, 3}
-               },
+               [
+                 %Audio.VehiclesToDestination{
+                   language: :english,
+                   destination: :alewife,
+                   headway_range: {1, 3}
+                 }
+               ],
                ^sign
              } = from_sign(sign)
     end
@@ -253,10 +255,10 @@ defmodule Signs.Utilities.AudioTest do
           current_content_bottom: {@src, %Message.Headways.Bottom{range: {1, 3}}}
       }
 
-      assert {{
+      assert {[
                 %Audio.VehiclesToDestination{language: :english},
                 %Audio.VehiclesToDestination{language: :spanish}
-              }, ^sign} = from_sign(sign)
+              ], ^sign} = from_sign(sign)
     end
 
     test "Countdowns say 'following train' if second line is same headsign" do
@@ -266,8 +268,10 @@ defmodule Signs.Utilities.AudioTest do
           current_content_bottom: {@src, %Message.Predictions{destination: :ashmont, minutes: 4}}
       }
 
-      assert {{%Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
-               %Audio.FollowingTrain{destination: :ashmont, minutes: 4}}, ^sign} = from_sign(sign)
+      assert {[
+                %Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
+                %Audio.FollowingTrain{destination: :ashmont, minutes: 4}
+              ], ^sign} = from_sign(sign)
     end
 
     test "If top line prediction and bottom line paging headways, announce both" do
@@ -283,9 +287,10 @@ defmodule Signs.Utilities.AudioTest do
              }}
       }
 
-      assert {{%Audio.NextTrainCountdown{destination: :medford_tufts, minutes: 3},
-               %Audio.VehiclesToDestination{destination: :heath_street, headway_range: {5, 7}}},
-              ^sign} = from_sign(sign)
+      assert {[
+                %Audio.NextTrainCountdown{destination: :medford_tufts, minutes: 3},
+                %Audio.VehiclesToDestination{destination: :heath_street, headway_range: {5, 7}}
+              ], ^sign} = from_sign(sign)
     end
 
     test "Ignores 'following train' if same headsign but it's arriving (we don't have audio)" do
@@ -297,7 +302,7 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.Predictions{destination: :ashmont, minutes: :arriving}}
       }
 
-      assert {%Audio.TrainIsBoarding{destination: :ashmont}, ^sign} = from_sign(sign)
+      assert {[%Audio.TrainIsBoarding{destination: :ashmont}], ^sign} = from_sign(sign)
     end
 
     test "reads the approaching and bottom line when top line is approaching" do
@@ -311,8 +316,10 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               {%Audio.Approaching{destination: :alewife},
-                %Audio.FollowingTrain{destination: :alewife, minutes: 5, verb: :arrives}},
+               [
+                 %Audio.Approaching{destination: :alewife},
+                 %Audio.FollowingTrain{destination: :alewife, minutes: 5, verb: :arrives}
+               ],
                ^sign
              } = from_sign(sign)
     end
@@ -327,7 +334,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.TrainIsArriving{destination: :alewife},
+               [%Audio.TrainIsArriving{destination: :alewife}],
                ^sign
              } = from_sign(sign)
     end
@@ -342,14 +349,16 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               {%Audio.TrainIsBoarding{destination: :ashmont},
-                %Audio.NextTrainCountdown{
-                  destination: :braintree,
-                  verb: :arrives,
-                  minutes: 1,
-                  track_number: nil,
-                  platform: nil
-                }},
+               [
+                 %Audio.TrainIsBoarding{destination: :ashmont},
+                 %Audio.NextTrainCountdown{
+                   destination: :braintree,
+                   verb: :arrives,
+                   minutes: 1,
+                   track_number: nil,
+                   platform: nil
+                 }
+               ],
                ^sign
              } = from_sign(sign)
     end
@@ -364,7 +373,7 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.Predictions{destination: :alewife, minutes: 5, route_id: "Red"}}
       }
 
-      assert {%Audio.TrainIsArriving{destination: :alewife}, ^sign} = from_sign(sign)
+      assert {[%Audio.TrainIsArriving{destination: :alewife}], ^sign} = from_sign(sign)
     end
 
     test "reads both lines when the top line is arriving and light rail" do
@@ -377,8 +386,10 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.Predictions{destination: :ashmont, minutes: 5, route_id: "Mattapan"}}
       }
 
-      assert {{%Audio.TrainIsArriving{destination: :ashmont, route_id: "Mattapan"},
-               %Audio.FollowingTrain{destination: :ashmont, minutes: 5}}, ^sign} = from_sign(sign)
+      assert {[
+                %Audio.TrainIsArriving{destination: :ashmont, route_id: "Mattapan"},
+                %Audio.FollowingTrain{destination: :ashmont, minutes: 5}
+              ], ^sign} = from_sign(sign)
     end
 
     test "only reads the bottom line when the bottom line is arriving on a multi_source sign for heavy rail" do
@@ -392,7 +403,7 @@ defmodule Signs.Utilities.AudioTest do
           source_config: {[@src], [@src]}
       }
 
-      assert {%Audio.TrainIsArriving{destination: :braintree}, ^sign} = from_sign(sign)
+      assert {[%Audio.TrainIsArriving{destination: :braintree}], ^sign} = from_sign(sign)
     end
 
     test "reads both lines in order when the bottom line is arriving on a multi_source sign for light rail" do
@@ -410,9 +421,10 @@ defmodule Signs.Utilities.AudioTest do
           source_config: {[@src], [@src]}
       }
 
-      assert {{%Audio.TrainIsArriving{destination: :riverside},
-               %Audio.NextTrainCountdown{destination: :lechmere, minutes: 3}},
-              ^sign} = from_sign(sign)
+      assert {[
+                %Audio.TrainIsArriving{destination: :riverside},
+                %Audio.NextTrainCountdown{destination: :lechmere, minutes: 3}
+              ], ^sign} = from_sign(sign)
     end
 
     test "Two stopped train messages only plays once if both same headsign" do
@@ -425,7 +437,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.StoppedTrain{destination: :alewife, stops_away: 2},
+               [%Audio.StoppedTrain{destination: :alewife, stops_away: 2}],
                ^sign
              } = from_sign(sign)
     end
@@ -439,7 +451,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.StoppedTrain{destination: :alewife, stops_away: 2},
+               [%Audio.StoppedTrain{destination: :alewife, stops_away: 2}],
                ^sign
              } = from_sign(sign)
     end
@@ -453,7 +465,7 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               %Audio.NextTrainCountdown{destination: :alewife, minutes: 4},
+               [%Audio.NextTrainCountdown{destination: :alewife, minutes: 4}],
                ^sign
              } = from_sign(sign)
     end
@@ -466,10 +478,10 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.Predictions{destination: :braintree, minutes: 4}}
       }
 
-      assert {{
+      assert {[
                 %Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
                 %Audio.NextTrainCountdown{destination: :braintree, minutes: 4}
-              }, ^sign} = from_sign(sign)
+              ], ^sign} = from_sign(sign)
     end
 
     test "One countdown and one stopped train, with different headsigns, both are read" do
@@ -480,10 +492,10 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.StoppedTrain{destination: :braintree, stops_away: 4}}
       }
 
-      assert {{
+      assert {[
                 %Audio.NextTrainCountdown{destination: :ashmont, minutes: 3},
                 %Audio.StoppedTrain{destination: :braintree, stops_away: 4}
-              }, ^sign} = from_sign(sign)
+              ], ^sign} = from_sign(sign)
     end
 
     test "When bottom line is empty, reads top" do
@@ -493,7 +505,7 @@ defmodule Signs.Utilities.AudioTest do
           current_content_bottom: {nil, %Message.Empty{}}
       }
 
-      assert {%Audio.NextTrainCountdown{destination: :ashmont, minutes: 3}, ^sign} =
+      assert {[%Audio.NextTrainCountdown{destination: :ashmont, minutes: 3}], ^sign} =
                from_sign(sign)
     end
 
@@ -504,7 +516,7 @@ defmodule Signs.Utilities.AudioTest do
           current_content_bottom: {@src, %Message.Predictions{destination: :ashmont, minutes: 3}}
       }
 
-      assert {%Audio.NextTrainCountdown{destination: :ashmont, minutes: 3}, ^sign} =
+      assert {[%Audio.NextTrainCountdown{destination: :ashmont, minutes: 3}], ^sign} =
                from_sign(sign)
     end
 
@@ -515,7 +527,7 @@ defmodule Signs.Utilities.AudioTest do
           current_content_bottom: {nil, %Message.Empty{}}
       }
 
-      assert {nil, ^sign} = from_sign(sign)
+      assert {[], ^sign} = from_sign(sign)
     end
 
     test "When one train is boarding and another is a countdown, audio is ordered correctly" do
@@ -527,10 +539,10 @@ defmodule Signs.Utilities.AudioTest do
             {@src, %Message.Predictions{destination: :riverside, minutes: 4}}
       }
 
-      assert {{
+      assert {[
                 %Audio.TrainIsBoarding{destination: :boston_college},
                 %Audio.NextTrainCountdown{destination: :riverside}
-              }, _sign} = from_sign(sign)
+              ], _sign} = from_sign(sign)
     end
 
     test "Reads ARR on sign even if announce_arriving? is false" do
@@ -542,7 +554,7 @@ defmodule Signs.Utilities.AudioTest do
             {src, %Message.Predictions{destination: :alewife, minutes: :arriving}}
       }
 
-      assert {%Audio.TrainIsArriving{destination: :alewife}, _sign} = from_sign(sign)
+      assert {[%Audio.TrainIsArriving{destination: :alewife}], _sign} = from_sign(sign)
     end
 
     test "Reads BRD on sign even if announce_boarding? is false" do
@@ -554,7 +566,7 @@ defmodule Signs.Utilities.AudioTest do
             {src, %Message.Predictions{destination: :alewife, minutes: :boarding}}
       }
 
-      assert {%Audio.TrainIsBoarding{destination: :alewife}, _sign} = from_sign(sign)
+      assert {[%Audio.TrainIsBoarding{destination: :alewife}], _sign} = from_sign(sign)
     end
 
     test "Logs error and returns nil if unknown message type" do
@@ -568,7 +580,7 @@ defmodule Signs.Utilities.AudioTest do
       log =
         capture_log([level: :error], fn ->
           assert {
-                   %Audio.StoppedTrain{destination: :alewife, stops_away: 2},
+                   [%Audio.StoppedTrain{destination: :alewife, stops_away: 2}],
                    ^sign
                  } = from_sign(sign)
         end)
@@ -587,10 +599,10 @@ defmodule Signs.Utilities.AudioTest do
 
       {audio, new_sign} = from_sign(sign)
 
-      assert %Content.Audio.TrainIsArriving{} = audio
+      assert [%Content.Audio.TrainIsArriving{}] = audio
       assert new_sign.announced_arrivals == ["trip1"]
 
-      assert {nil, ^new_sign} = from_sign(new_sign)
+      assert {[], ^new_sign} = from_sign(new_sign)
     end
 
     test "announces approaching, then skips approaching for the same trip" do
@@ -609,10 +621,10 @@ defmodule Signs.Utilities.AudioTest do
 
       {audio, new_sign} = from_sign(sign)
 
-      assert %Content.Audio.Approaching{} = audio
+      assert [%Content.Audio.Approaching{}] = audio
       assert new_sign.announced_approachings == ["trip1"]
 
-      assert {nil, ^new_sign} = from_sign(new_sign)
+      assert {[], ^new_sign} = from_sign(new_sign)
     end
 
     test "Announces higher priority message first even on bottom of multi-source sign" do
@@ -627,10 +639,10 @@ defmodule Signs.Utilities.AudioTest do
       }
 
       assert {
-               {
+               [
                  %Content.Audio.Approaching{destination: :ashmont},
                  %Content.Audio.NextTrainCountdown{minutes: 5, destination: :alewife}
-               },
+               ],
                ^sign
              } = from_sign(sign)
     end

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -78,7 +78,7 @@ defmodule Signs.Utilities.ReaderTest do
 
       Reader.read_sign(sign)
 
-      assert_received({:send_audio, _id, %Content.Audio.Custom{}, _priority, _timeout})
+      assert_received({:send_audio, _id, [%Content.Audio.Custom{}], _priority, _timeout})
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

This standardizes the internal handling of audio message so that everything deals with lists of audio messages. This simplifies function signatures and eliminates the packing/unpacking of tuples in various places. Absence of audio is represented as `[]` instead of `nil`.