### PR TITLE
refactor headway code

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -201,7 +201,8 @@ defmodule PaEss.Utilities do
   @doc """
   Used for parsing headway_direction_name from the source config to a PaEss.destination
   """
-  @spec headsign_to_destination(String.t()) :: {:ok, PaEss.destination()} | {:error, :unknown}
+  @spec headsign_to_destination(String.t()) ::
+          {:ok, PaEss.destination() | nil} | {:error, :unknown}
   def headsign_to_destination("Alewife"), do: {:ok, :alewife}
   def headsign_to_destination("Ashmont"), do: {:ok, :ashmont}
   def headsign_to_destination("Braintree"), do: {:ok, :braintree}
@@ -230,6 +231,7 @@ defmodule PaEss.Utilities do
   def headsign_to_destination("Inbound"), do: {:ok, :inbound}
   def headsign_to_destination("Outbound"), do: {:ok, :outbound}
   def headsign_to_destination("Medford/Tufts"), do: {:ok, :medford_tufts}
+  def headsign_to_destination(nil), do: {:ok, nil}
   def headsign_to_destination(_unknown), do: {:error, :unknown}
 
   @doc """

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -104,7 +104,7 @@ defmodule Signs.Utilities.Audio do
 
   @spec from_sign(Signs.Realtime.t()) :: {[Content.Audio.t()], Signs.Realtime.t()}
   def from_sign(sign) do
-    multi_source? = Signs.Utilities.SourceConfig.multi_source?(sign.source_config)
+    multi_source? = SourceConfig.multi_source?(sign.source_config)
 
     audios = get_audio(sign.current_content_top, sign.current_content_bottom, multi_source?)
 
@@ -143,7 +143,7 @@ defmodule Signs.Utilities.Audio do
     }
 
     new_audios =
-      if Signs.Utilities.SourceConfig.multi_source?(sign.source_config) do
+      if SourceConfig.multi_source?(sign.source_config) do
         sort_audio(new_audios)
       else
         new_audios

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -6,124 +6,53 @@ defmodule Signs.Utilities.Headways do
   alias Signs.Utilities.SourceConfig
   require Logger
 
-  @spec get_messages(Signs.Realtime.t(), DateTime.t()) :: Signs.Utilities.Messages.sign_messages()
+  @spec get_messages(Signs.Realtime.t(), DateTime.t()) :: Signs.Realtime.sign_messages()
   def get_messages(sign, current_time) do
-    config = single_source_config(sign) || config_by_headway_id(sign)
+    {sources, group, destination} =
+      case sign.source_config do
+        {top, bottom} -> {top.sources ++ bottom.sources, top.headway_group, nil}
+        single -> {single.sources, single.headway_group, single.headway_destination}
+      end
 
-    headways =
-      SourceConfig.sign_headway_group(sign)
-      |> sign.config_engine.headway_config(current_time)
-
-    stop_ids = get_stop_ids(sign, config)
-
-    if display_headways?(sign, stop_ids, current_time, headways) do
-      destination = get_destination(config)
-      get_headway_messages(config, destination, headways)
-    else
-      get_empty_messages(config)
-    end
-  end
-
-  @spec get_paging_message(
-          Signs.Realtime.t(),
-          list(SourceConfig.source()),
-          String.t(),
-          DateTime.t()
-        ) :: Content.Message.Headways.Paging.t()
-  def get_paging_message(sign, config, headway_group, current_time) do
-    case sign.config_engine.headway_config(headway_group, current_time) do
+    case fetch_headways(sign, group, sources, current_time) do
       nil ->
-        %Content.Message.Empty{}
+        {{nil, %Content.Message.Empty{}}, {nil, %Content.Message.Empty{}}}
 
       headways ->
-        if display_headways?(sign, Enum.map(config, & &1.stop_id), current_time, headways) do
-          config |> source_list_destination() |> get_paging_headway_message(headways)
-        else
-          %Content.Message.Empty{}
-        end
+        {{nil, %Content.Message.Headways.Top{destination: destination, vehicle_type: :train}},
+         {nil,
+          %Content.Message.Headways.Bottom{
+            range: {headways.range_low, headways.range_high},
+            prev_departure_mins: nil
+          }}}
     end
   end
 
-  @spec display_headways?(
-          Signs.Realtime.t(),
-          [String.t()],
-          DateTime.t(),
-          Engine.Config.Headway.t() | nil
-        ) :: boolean()
-  defp display_headways?(_sign, _stop_ids, _current_time, nil), do: false
+  @spec get_paging_message(Signs.Realtime.t(), SourceConfig.config(), DateTime.t()) ::
+          Signs.Realtime.line_content()
+  def get_paging_message(sign, config, current_time) do
+    case fetch_headways(sign, config.headway_group, config.sources, current_time) do
+      nil ->
+        {nil, %Content.Message.Empty{}}
 
-  defp display_headways?(sign, stop_ids, current_time, headways) do
-    sign.headway_engine.display_headways?(stop_ids, current_time, headways.range_high)
-  end
-
-  @spec get_stop_ids(Signs.Realtime.t(), SourceConfig.source() | nil) :: [String.t()]
-  defp get_stop_ids(sign, nil), do: Signs.Utilities.SourceConfig.sign_stop_ids(sign.source_config)
-  defp get_stop_ids(sign, config), do: [sign.headway_stop_id || config.stop_id]
-
-  @spec source_list_destination(list(SourceConfig.source())) :: PaEss.destination() | nil
-  def source_list_destination(config) do
-    config
-    |> Enum.map(& &1.headway_destination)
-    |> Enum.uniq()
-    |> case do
-      [destination] -> destination
-      _ -> nil
+      headways ->
+        {nil,
+         %Content.Message.Headways.Paging{
+           destination: config.headway_destination,
+           range: {headways.range_low, headways.range_high}
+         }}
     end
   end
 
-  @spec get_destination(SourceConfig.source() | nil) ::
-          PaEss.destination() | nil
-  defp get_destination(nil), do: nil
+  defp fetch_headways(sign, headway_group, sources, current_time) do
+    stop_ids = Enum.map(sources, & &1.stop_id)
 
-  defp get_destination(config), do: config.headway_destination
-
-  @spec get_headway_messages(
-          SourceConfig.source() | nil,
-          PaEss.destination() | nil,
-          Engine.Config.Headway.t()
-        ) :: Signs.Utilities.Messages.sign_messages()
-  defp get_headway_messages(config, destination, headways) do
-    {{config,
-      %Content.Message.Headways.Top{
-        destination: destination,
-        vehicle_type: :train
-      }},
-     {config,
-      %Content.Message.Headways.Bottom{
-        range: {headways.range_low, headways.range_high},
-        prev_departure_mins: nil
-      }}}
-  end
-
-  @spec get_paging_headway_message(
-          PaEss.destination() | nil,
-          Engine.Config.Headway.t()
-        ) :: Content.Message.Headways.Paging.t()
-  defp get_paging_headway_message(destination, headways) do
-    %Content.Message.Headways.Paging{
-      destination: destination,
-      range: {headways.range_low, headways.range_high}
-    }
-  end
-
-  @spec get_empty_messages(SourceConfig.source() | nil) ::
-          Signs.Utilities.Messages.sign_messages()
-  defp get_empty_messages(config) do
-    {{config, %Content.Message.Empty{}}, {config, %Content.Message.Empty{}}}
-  end
-
-  @spec config_by_headway_id(Signs.Realtime.t()) :: SourceConfig.source() | nil
-  defp config_by_headway_id(sign) do
-    sign.source_config
-    |> Tuple.to_list()
-    |> List.flatten()
-    |> Enum.find(& &1.source_for_headway?)
-  end
-
-  @spec single_source_config(Signs.Realtime.t()) :: SourceConfig.source() | nil
-  defp single_source_config(sign) do
-    case sign.source_config do
-      {[one]} -> one
+    with headways when not is_nil(headways) <-
+           sign.config_engine.headway_config(headway_group, current_time),
+         true <-
+           sign.headway_engine.display_headways?(stop_ids, current_time, headways.range_high) do
+      headways
+    else
       _ -> nil
     end
   end

--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -20,12 +20,12 @@ defmodule Signs.Utilities.SignsConfig do
   @doc "Extracts every train stop_id from the signs.json configuration"
   @spec all_train_stop_ids() :: [String.t()]
   def all_train_stop_ids do
-    children_config()
-    |> Enum.filter(&match?(%{"type" => "realtime"}, &1))
-    |> Enum.map(&get_stop_ids_for_sign(&1))
-    |> List.flatten()
-    |> Enum.reject(fn x -> x == nil end)
-    |> Enum.uniq()
+    for %{"type" => "realtime"} = sign <- children_config(),
+        %{"sources" => sources} <- List.wrap(sign["source_config"]),
+        %{"stop_id" => stop_id} <- sources,
+        uniq: true do
+      stop_id
+    end
   end
 
   @spec all_bus_stop_ids() :: [String.t()]

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -45,7 +45,10 @@ defmodule Signs.Utilities.SourceConfig do
   object as defined below. For mezzanine signs, this will be a list of two of these objects,
   which will cause each line to display separately using the corresponding config.
 
-  * headway_group: This references the signs-ui values that the PIOs set for headways.
+  * headway_group: This determines which headway group to look up when getting headyway time
+    ranges, and must match the values set by signs-ui. Most mezzanine signs show both directions
+    of the same headway group, and so will have the same value for both configs. A notable
+    exception is Ashmont, which handles both the Ashmont and Mattapan headway groups.
   * headway_direction_name: The headsign used to generate the "trains every X minutes" message in
     headway mode. Must be a value recognized by `PaEss.Utilities.headsign_to_destination/1`.
   * sources: A list of source objects (see below for details). The sources determine which

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1,7 +1,6 @@
 [
   {
     "id": "cedar_grove_outbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MCED",
     "read_loop_offset": 60,
@@ -9,26 +8,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
         {
           "stop_id": "70263",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Mattapan",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "cedar_grove_inbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MCED",
     "read_loop_offset": 0,
@@ -36,26 +35,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70264",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "butler_center",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MBUT",
     "read_loop_offset": 150,
@@ -64,39 +63,44 @@
       "c"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70266",
-          "routes": [
-            "Mattapan"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Ashmont",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70265",
-          "routes": [
-            "Mattapan"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Mattapan",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70266",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Mattapan",
+        "sources": [
+          {
+            "stop_id": "70265",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "milton_outbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MMIL",
     "read_loop_offset": 60,
@@ -104,26 +108,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
         {
           "stop_id": "70267",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Mattapan",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "milton_inbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MMIL",
     "read_loop_offset": 0,
@@ -131,26 +135,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70268",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "central_avenue_outbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MCEN",
     "read_loop_offset": 60,
@@ -158,26 +162,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
         {
           "stop_id": "70269",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Mattapan",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "central_avenue_inbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MCEN",
     "read_loop_offset": 0,
@@ -185,26 +189,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70270",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "valley_road_outbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MVAL",
     "read_loop_offset": 60,
@@ -212,26 +216,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
         {
           "stop_id": "70271",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Mattapan",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "valley_road_inbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MVAL",
     "read_loop_offset": 0,
@@ -239,26 +243,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70272",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "capen_street_inbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "MCAP",
     "read_loop_offset": 0,
@@ -266,26 +270,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70274",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wonderland_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BWON",
     "read_loop_offset": 90,
@@ -293,26 +297,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70059",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "wonderland_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BWON",
     "read_loop_offset": 120,
@@ -320,26 +324,26 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70059",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "revere_beach_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BREV",
     "read_loop_offset": 30,
@@ -347,26 +351,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70058",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "revere_beach_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BREV",
     "read_loop_offset": 120,
@@ -375,39 +379,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70058",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70057",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70058",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70057",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "revere_beach_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BREV",
     "read_loop_offset": 90,
@@ -415,26 +424,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70057",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "beachmont_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BBEA",
     "read_loop_offset": 30,
@@ -442,26 +451,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70056",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "beachmont_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BBEA",
     "read_loop_offset": 90,
@@ -469,26 +478,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70055",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "suffolk_downs_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BSUF",
     "read_loop_offset": 30,
@@ -496,26 +505,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70054",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "suffolk_downs_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BSUF",
     "read_loop_offset": 90,
@@ -523,26 +532,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70053",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orient_heights_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BORH",
     "read_loop_offset": 30,
@@ -550,26 +559,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70052",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orient_heights_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BORH",
     "read_loop_offset": 120,
@@ -578,39 +587,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70052",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70051",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70052",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70051",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "orient_heights_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BORH",
     "read_loop_offset": 90,
@@ -618,26 +632,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70051",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wood_island_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 30,
@@ -645,26 +659,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70050",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wood_island_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 120,
@@ -673,39 +687,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70050",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70049",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70050",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70049",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "wood_island_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BWOO",
     "read_loop_offset": 90,
@@ -713,26 +732,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70049",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "airport_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BAIR",
     "read_loop_offset": 30,
@@ -740,26 +759,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70048",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "airport_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BAIR",
     "read_loop_offset": 90,
@@ -767,26 +786,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70047",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "maverick_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BMAV",
     "read_loop_offset": 30,
@@ -794,26 +813,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70046",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "maverick_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BMAV",
     "read_loop_offset": 90,
@@ -821,26 +840,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70045",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "aquarium_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 30,
@@ -848,26 +867,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70044",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "aquarium_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 120,
@@ -876,39 +895,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70044",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70043",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70044",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70043",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "aquarium_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BAQU",
     "read_loop_offset": 90,
@@ -916,26 +940,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70043",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "state_blue_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 30,
@@ -943,26 +967,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70042",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "state_blue_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 120,
@@ -971,39 +995,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70042",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70041",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70042",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70041",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "state_blue_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
     "read_loop_offset": 90,
@@ -1011,26 +1040,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70041",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "government_center_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 30,
@@ -1038,26 +1067,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70040",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "government_center_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 120,
@@ -1066,39 +1095,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70040",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Wonderland",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70039",
-          "routes": [
-            "Blue"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Wonderland",
+        "sources": [
+          {
+            "stop_id": "70040",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "blue_trunk",
+        "headway_direction_name": "Bowdoin",
+        "sources": [
+          {
+            "stop_id": "70039",
+            "routes": [
+              "Blue"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "government_center_westbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BGOV",
     "read_loop_offset": 90,
@@ -1106,26 +1140,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Bowdoin",
+      "sources": [
         {
           "stop_id": "70039",
           "routes": [
             "Blue"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Bowdoin",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "bowdoin_eastbound",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BBOW",
     "read_loop_offset": 30,
@@ -1133,26 +1167,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70038",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "bowdoin_drop_off",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BBOW",
     "read_loop_offset": 60,
@@ -1160,26 +1194,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70038",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "bowdoin_mezzanine",
-    "headway_group": "blue_trunk",
     "type": "realtime",
     "pa_ess_loc": "BBOW",
     "read_loop_offset": 120,
@@ -1187,26 +1221,26 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
         {
           "stop_id": "70038",
           "routes": [
             "Blue"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Wonderland",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "oak_grove_mezzanine_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 120,
@@ -1214,20 +1248,20 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70036",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Oak Grove-01",
@@ -1235,7 +1269,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -1247,18 +1280,16 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "oak_grove_east_busway",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 30,
@@ -1266,20 +1297,20 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70036",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Oak Grove-01",
@@ -1287,7 +1318,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -1299,18 +1329,16 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "oak_grove_platform",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OOAK",
     "read_loop_offset": 60,
@@ -1318,20 +1346,20 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70036",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Oak Grove-01",
@@ -1339,7 +1367,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -1351,18 +1378,16 @@
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "malden_lobby",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OMAL",
     "read_loop_offset": 120,
@@ -1371,39 +1396,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70035",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70034",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70035",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70034",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "malden_center_platform",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OMAL",
     "read_loop_offset": 0,
@@ -1412,39 +1442,44 @@
       "n"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70035",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70034",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70035",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70034",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "wellington_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 120,
@@ -1453,39 +1488,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70033",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70032",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70033",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70032",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "wellington_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 0,
@@ -1493,26 +1533,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70033",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wellington_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OWEL",
     "read_loop_offset": 60,
@@ -1520,15 +1560,16 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": null,
+      "sources": [
         {
           "stop_id": "70032",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
@@ -1540,18 +1581,16 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "assembly_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 120,
@@ -1560,39 +1599,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70279",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70278",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70279",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70278",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "assembly_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 0,
@@ -1600,26 +1644,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70279",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "assembly_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OASQ",
     "read_loop_offset": 60,
@@ -1627,26 +1671,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70278",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "sullivan_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 120,
@@ -1655,39 +1699,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70031",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70030",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70031",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70030",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "sullivan_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 0,
@@ -1695,26 +1744,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70031",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "sullivan_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSUL",
     "read_loop_offset": 60,
@@ -1722,26 +1771,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70030",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "community_college_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 120,
@@ -1750,39 +1799,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70029",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70028",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70029",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70028",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "community_college_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 0,
@@ -1790,26 +1844,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70029",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "community_college_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCOM",
     "read_loop_offset": 60,
@@ -1817,26 +1871,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70028",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_north_station_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONST",
     "read_loop_offset": 0,
@@ -1844,26 +1898,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70027",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_north_station_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONST",
     "read_loop_offset": 60,
@@ -1871,26 +1925,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70026",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_north_station_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONST",
     "read_loop_offset": 150,
@@ -1899,39 +1953,44 @@
       "c"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70027",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70026",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70027",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70026",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "orange_north_station_commuter_rail_exit",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONST",
     "read_loop_offset": 120,
@@ -1940,39 +1999,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70027",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70026",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70027",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70026",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "orange_haymarket_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 120,
@@ -1981,39 +2045,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70025",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70024",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70025",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70024",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "orange_haymarket_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 0,
@@ -2021,26 +2090,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70025",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_haymarket_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OHAY",
     "read_loop_offset": 60,
@@ -2048,26 +2117,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70024",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_state_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTN",
     "read_loop_offset": 120,
@@ -2076,39 +2145,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70023",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70022",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70023",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70022",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "orange_state_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTN",
     "read_loop_offset": 0,
@@ -2116,26 +2190,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70023",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_state_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTS",
     "read_loop_offset": 60,
@@ -2143,26 +2217,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70022",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_downtown_crossing_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ODTN",
     "read_loop_offset": 0,
@@ -2170,26 +2244,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70021",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "orange_downtown_crossing_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ODTS",
     "read_loop_offset": 60,
@@ -2197,26 +2271,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70020",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chinatown_northbound_lobby",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCHN",
     "read_loop_offset": 120,
@@ -2224,26 +2298,26 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70019",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chinatown_southbound_lobby",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCHS",
     "read_loop_offset": 120,
@@ -2251,26 +2325,26 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70018",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chinatown_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCHN",
     "read_loop_offset": 0,
@@ -2278,26 +2352,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70019",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chinatown_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OCHS",
     "read_loop_offset": 60,
@@ -2305,26 +2379,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70018",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "tufts_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 120,
@@ -2333,39 +2407,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70017",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70016",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70017",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70016",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "tufts_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 0,
@@ -2373,26 +2452,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70017",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "tufts_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ONEM",
     "read_loop_offset": 60,
@@ -2400,26 +2479,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70016",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "back_bay_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 120,
@@ -2428,39 +2507,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70015",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70014",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70015",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70014",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "back_bay_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 0,
@@ -2468,26 +2552,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70015",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "back_bay_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OBAC",
     "read_loop_offset": 60,
@@ -2495,26 +2579,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70014",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "mass_ave_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 120,
@@ -2523,39 +2607,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70013",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70012",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70013",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70012",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "mass_ave_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 0,
@@ -2563,26 +2652,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70013",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "mass_ave_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OMAS",
     "read_loop_offset": 60,
@@ -2590,26 +2679,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70012",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ruggles_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 0,
@@ -2617,26 +2706,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70011",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ruggles_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 60,
@@ -2644,26 +2733,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70010",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ruggles_center",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 150,
@@ -2672,39 +2761,44 @@
       "c"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70011",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70010",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "ruggles_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "ORUG",
     "read_loop_offset": 120,
@@ -2713,39 +2807,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70011",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70010",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "roxbury_crossing_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OROX",
     "read_loop_offset": 120,
@@ -2754,39 +2853,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70009",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70008",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70009",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70008",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "roxbury_crossing_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OROX",
     "read_loop_offset": 0,
@@ -2794,26 +2898,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70009",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "roxbury_crossing_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OROX",
     "read_loop_offset": 60,
@@ -2821,26 +2925,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70008",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jackson_square_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 120,
@@ -2849,39 +2953,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70007",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70006",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70007",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70006",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "jackson_square_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 0,
@@ -2889,26 +2998,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70007",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jackson_square_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OJAC",
     "read_loop_offset": 60,
@@ -2916,26 +3025,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70006",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "stony_brook_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 120,
@@ -2944,39 +3053,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70005",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70004",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70005",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70004",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "stony_brook_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 0,
@@ -2984,26 +3098,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70005",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "stony_brook_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OSTO",
     "read_loop_offset": 60,
@@ -3011,26 +3125,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70004",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_street_mezzanine",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 120,
@@ -3039,39 +3153,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70003",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70002",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70003",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70002",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "green_street_northbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 0,
@@ -3079,26 +3198,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70003",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_street_southbound",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OGRE",
     "read_loop_offset": 60,
@@ -3106,26 +3225,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Forest Hills",
+      "sources": [
         {
           "stop_id": "70002",
           "routes": [
             "Orange"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Forest Hills",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "forest_hills_main_lobby",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OFOR",
     "read_loop_offset": 120,
@@ -3133,20 +3252,20 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70001",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Forest Hills-01",
@@ -3154,7 +3273,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -3166,18 +3284,16 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "forest_hills_platform",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "OFOR",
     "read_loop_offset": 0,
@@ -3185,20 +3301,20 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70001",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Forest Hills-01",
@@ -3206,7 +3322,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -3218,18 +3333,16 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "forest_hills_entrances_from_busways",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "SFOR",
     "read_loop_offset": 120,
@@ -3237,20 +3350,20 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "orange_trunk",
+      "headway_direction_name": "Oak Grove",
+      "sources": [
         {
           "stop_id": "70001",
           "routes": [
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Forest Hills-01",
@@ -3258,7 +3371,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -3270,18 +3382,16 @@
             "Orange"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Oak Grove",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "ruggles_upper_busway",
-    "headway_group": "orange_trunk",
     "type": "realtime",
     "pa_ess_loc": "SRUG",
     "read_loop_offset": 120,
@@ -3290,39 +3400,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70011",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Forest Hills",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70010",
-          "routes": [
-            "Orange"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Oak Grove",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Forest Hills",
+        "sources": [
+          {
+            "stop_id": "70011",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "orange_trunk",
+        "headway_direction_name": "Oak Grove",
+        "sources": [
+          {
+            "stop_id": "70010",
+            "routes": [
+              "Orange"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "alewife_center_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RALE",
     "read_loop_offset": 150,
@@ -3330,20 +3445,20 @@
     "audio_zones": [
       "c"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70061",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Alewife-01",
@@ -3351,7 +3466,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -3363,18 +3477,16 @@
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "alewife_mezzanine_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RALE",
     "read_loop_offset": 120,
@@ -3382,20 +3494,20 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70061",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Alewife-01",
@@ -3403,7 +3515,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -3415,18 +3526,16 @@
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "davis_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 120,
@@ -3435,39 +3544,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70064",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70063",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70064",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70063",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "davis_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 0,
@@ -3475,26 +3589,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70064",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "davis_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RDAV",
     "read_loop_offset": 60,
@@ -3502,26 +3616,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70063",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "porter_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 120,
@@ -3530,39 +3644,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70066",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70065",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70066",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70065",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "porter_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 0,
@@ -3570,26 +3689,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70066",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "porter_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPOR",
     "read_loop_offset": 60,
@@ -3597,26 +3716,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70065",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "harvard_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 120,
@@ -3625,39 +3744,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70068",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70067",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70068",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70067",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "harvard_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 0,
@@ -3665,26 +3789,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70068",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "harvard_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RHAR",
     "read_loop_offset": 60,
@@ -3692,26 +3816,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70067",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "central_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RCEN",
     "read_loop_offset": 0,
@@ -3719,26 +3843,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70070",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "central_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RCEN",
     "read_loop_offset": 60,
@@ -3746,26 +3870,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70069",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kendall_mit_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RKEN",
     "read_loop_offset": 0,
@@ -3773,26 +3897,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70072",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kendall_mit_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RKEN",
     "read_loop_offset": 60,
@@ -3800,26 +3924,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70071",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "charles_mgh_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RMGH",
     "read_loop_offset": 0,
@@ -3827,26 +3951,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70074",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "charles_mgh_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RMGH",
     "read_loop_offset": 60,
@@ -3854,26 +3978,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70073",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_park_st_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPRK",
     "read_loop_offset": 0,
@@ -3882,26 +4006,26 @@
       "n",
       "c"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70076",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_park_st_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPRK",
     "read_loop_offset": 60,
@@ -3910,65 +4034,70 @@
       "s",
       "c"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70075",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_park_st_center",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RPRK",
     "read_loop_offset": 150,
     "text_zone": "c",
     "audio_zones": [],
     "source_config": [
-      [
-        {
-          "stop_id": "70076",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70075",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70076",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70075",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "red_downtown_crossing_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RDTC",
     "read_loop_offset": 0,
@@ -3976,26 +4105,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70078",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_downtown_crossing_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RDTC",
     "read_loop_offset": 60,
@@ -4003,26 +4132,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70077",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_south_station_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 120,
@@ -4031,39 +4160,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70080",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70079",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70080",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70079",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "red_south_station_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 0,
@@ -4071,26 +4205,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70080",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_south_station_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RSOU",
     "read_loop_offset": 60,
@@ -4098,26 +4232,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70079",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "south_station_silver_line_arrival_platform",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "SSOU",
     "read_loop_offset": 90,
@@ -4126,39 +4260,44 @@
       "w"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70080",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70079",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70080",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70079",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "broadway_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 120,
@@ -4167,39 +4306,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70082",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70081",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70082",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70081",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "broadway_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 0,
@@ -4207,26 +4351,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70082",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "broadway_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RBRO",
     "read_loop_offset": 60,
@@ -4234,26 +4378,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70081",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "andrew_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RAND",
     "read_loop_offset": 120,
@@ -4262,39 +4406,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70084",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70083",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70084",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70083",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "andrew_northbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RAND",
     "read_loop_offset": 0,
@@ -4302,26 +4451,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70084",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "andrew_southbound",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RAND",
     "read_loop_offset": 60,
@@ -4329,26 +4478,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_trunk",
+      "headway_direction_name": "Southbound",
+      "sources": [
         {
           "stop_id": "70083",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Southbound",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "savin_hill_mezzanine",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 120,
@@ -4357,39 +4506,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70088",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70087",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Ashmont",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70088",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70087",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "savin_hill_northbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 0,
@@ -4397,26 +4551,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70088",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "savin_hill_southbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSAV",
     "read_loop_offset": 60,
@@ -4424,26 +4578,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70087",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "fields_corner_mezzanine",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 120,
@@ -4452,39 +4606,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70090",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70089",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Ashmont",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70090",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70089",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "fields_corner_northbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 0,
@@ -4492,26 +4651,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70090",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "fields_corner_southbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RFIE",
     "read_loop_offset": 60,
@@ -4519,26 +4678,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70089",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "shawmut_mezzanine",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 120,
@@ -4547,39 +4706,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70092",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70091",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Ashmont",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70092",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Ashmont",
+        "sources": [
+          {
+            "stop_id": "70091",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "shawmut_northbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 0,
@@ -4587,26 +4751,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70092",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "shawmut_southbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RSHA",
     "read_loop_offset": 60,
@@ -4614,26 +4778,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70091",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ashmont_mezzanine",
-    "headway_group": ["red_ashmont", "mattapan_trunk"],
     "type": "realtime",
     "pa_ess_loc": "RASH",
     "read_loop_offset": 120,
@@ -4642,39 +4806,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70094",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": true,
-          "announce_arriving": false,
-          "announce_boarding": true
-        }
-      ],
-      [
-        {
-          "stop_id": "70261",
-          "routes": [
-            "Mattapan"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Mattapan",
-          "platform": null,
-          "terminal": true,
-          "announce_arriving": true,
-          "announce_boarding": true
-        }
-      ]
+      {
+        "headway_group": "red_ashmont",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70094",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": true,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      },
+      {
+        "headway_group": "mattapan_trunk",
+        "headway_direction_name": "Mattapan",
+        "sources": [
+          {
+            "stop_id": "70261",
+            "routes": [
+              "Mattapan"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": true,
+            "announce_arriving": true,
+            "announce_boarding": true
+          }
+        ]
+      }
     ]
   },
   {
     "id": "red_ashmont_northbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RASH",
     "read_loop_offset": 0,
@@ -4682,26 +4851,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70094",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "red_ashmont_southbound",
-    "headway_group": "mattapan_trunk",
     "type": "realtime",
     "pa_ess_loc": "RASH",
     "read_loop_offset": 60,
@@ -4709,26 +4878,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "mattapan_trunk",
+      "headway_direction_name": "Mattapan",
+      "sources": [
         {
           "stop_id": "70261",
           "routes": [
             "Mattapan"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Mattapan",
           "platform": null,
           "terminal": true,
           "announce_arriving": true,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "north_quincy_mezzanine",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 120,
@@ -4737,39 +4906,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70098",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70097",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Braintree",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70098",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70097",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "north_quincy_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 0,
@@ -4777,26 +4951,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70098",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "north_quincy_southbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RNQU",
     "read_loop_offset": 60,
@@ -4804,26 +4978,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
         {
           "stop_id": "70097",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Braintree",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wollaston_mezzanine",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 120,
@@ -4832,39 +5006,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70100",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70099",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Braintree",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70100",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70099",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "wollaston_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 0,
@@ -4872,26 +5051,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70100",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "wollaston_southbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RWOL",
     "read_loop_offset": 60,
@@ -4899,26 +5078,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
         {
           "stop_id": "70099",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Braintree",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "quincy_center_mezzanine",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 120,
@@ -4927,39 +5106,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70102",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70101",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Braintree",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70102",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70101",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "quincy_center_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 0,
@@ -4967,26 +5151,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70102",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "quincy_center_southbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUC",
     "read_loop_offset": 60,
@@ -4994,26 +5178,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
         {
           "stop_id": "70101",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Braintree",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "quincy_adams_mezzanine",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 120,
@@ -5022,39 +5206,44 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70104",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70103",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 0,
-          "headway_direction_name": "Braintree",
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70104",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_braintree",
+        "headway_direction_name": "Braintree",
+        "sources": [
+          {
+            "stop_id": "70103",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "quincy_adams_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 0,
@@ -5062,26 +5251,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70104",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "quincy_adams_southbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RQUA",
     "read_loop_offset": 60,
@@ -5089,26 +5278,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
         {
           "stop_id": "70103",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Braintree",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "braintree_center_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RBRA",
     "read_loop_offset": 150,
@@ -5116,20 +5305,20 @@
     "audio_zones": [
       "c"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70105",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Braintree-01",
@@ -5137,7 +5326,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -5149,18 +5337,16 @@
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "braintree_mezzanine_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RBRA",
     "read_loop_offset": 120,
@@ -5168,20 +5354,20 @@
     "audio_zones": [
       "m"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70105",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": true,
-          "source_for_headway": true
+          "announce_boarding": true
         },
         {
           "stop_id": "Braintree-01",
@@ -5189,7 +5375,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
@@ -5201,18 +5386,16 @@
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "jfk_umass_ashmont_platform_southbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 90,
@@ -5220,26 +5403,26 @@
     "audio_zones": [
       "w"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Ashmont",
+      "sources": [
         {
           "stop_id": "70085",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Ashmont",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jfk_umass_braintree_platform_southbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 60,
@@ -5247,26 +5430,26 @@
     "audio_zones": [
       "s"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Braintree",
+      "sources": [
         {
           "stop_id": "70095",
           "routes": [
             "Red"
           ],
           "direction_id": 0,
-          "headway_direction_name": "Braintree",
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jfk_umass_ashmont_platform_northbound",
-    "headway_group": "red_ashmont",
     "type": "realtime",
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 30,
@@ -5274,26 +5457,26 @@
     "audio_zones": [
       "e"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_ashmont",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70086",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": "ashmont",
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jfk_umass_braintree_platform_northbound",
-    "headway_group": "red_braintree",
     "type": "realtime",
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 0,
@@ -5301,26 +5484,26 @@
     "audio_zones": [
       "n"
     ],
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "red_braintree",
+      "headway_direction_name": "Alewife",
+      "sources": [
         {
           "stop_id": "70096",
           "routes": [
             "Red"
           ],
           "direction_id": 1,
-          "headway_direction_name": "Alewife",
           "platform": "braintree",
           "terminal": false,
           "announce_arriving": true,
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "jfk_umass_mezzanine",
-    "headway_group": "red_trunk",
     "type": "realtime",
     "pa_ess_loc": "RJFK",
     "read_loop_offset": 120,
@@ -5329,63 +5512,66 @@
       "m"
     ],
     "source_config": [
-      [
-        {
-          "stop_id": "70085",
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "routes": [
-            "Red"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
-          "stop_id": "70095",
-          "direction_id": 0,
-          "headway_direction_name": "Southbound",
-          "platform": null,
-          "terminal": false,
-          "routes": [
-            "Red"
-          ],
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70086",
-          "routes": [
-            "Red"
-          ],
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "platform": "ashmont",
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
-          "stop_id": "70096",
-          "direction_id": 1,
-          "headway_direction_name": "Alewife",
-          "routes": [
-            "Red"
-          ],
-          "platform": "braintree",
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Southbound",
+        "sources": [
+          {
+            "stop_id": "70085",
+            "direction_id": 0,
+            "routes": [
+              "Red"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "70095",
+            "direction_id": 0,
+            "platform": null,
+            "terminal": false,
+            "routes": [
+              "Red"
+            ],
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "red_trunk",
+        "headway_direction_name": "Alewife",
+        "sources": [
+          {
+            "stop_id": "70086",
+            "routes": [
+              "Red"
+            ],
+            "direction_id": 1,
+            "platform": "ashmont",
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "70096",
+            "direction_id": 1,
+            "routes": [
+              "Red"
+            ],
+            "platform": "braintree",
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "riverside_entire_station",
-    "headway_group": "green_d",
     "pa_ess_loc": "GRIV",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5393,12 +5579,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70160",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5408,11 +5595,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "woodland_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GWOO",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5420,12 +5606,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70162",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5435,11 +5622,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "woodland_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GWOO",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5447,12 +5633,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70163",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5462,11 +5649,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "waban_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GWAB",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5474,12 +5660,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70164",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5489,11 +5676,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "waban_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GWAB",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5501,12 +5687,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70165",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5516,11 +5703,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "eliot_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GELI",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5528,12 +5714,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70166",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5543,11 +5730,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "eliot_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GELI",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5555,12 +5741,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70167",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5570,11 +5757,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "newton_highlands_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GNEH",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5582,12 +5768,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70168",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5597,11 +5784,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "newton_highlands_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GNEH",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5609,12 +5795,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70169",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5624,11 +5811,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "newton_centre_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GNEC",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5636,12 +5822,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70170",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5651,11 +5838,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "newton_centre_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GNEC",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5663,12 +5849,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70171",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5678,11 +5865,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chestnut_hill_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GCHE",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5690,12 +5876,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70172",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5705,11 +5892,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "chestnut_hill_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GCHE",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5717,12 +5903,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70173",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5732,11 +5919,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "reservoir_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GRES",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5744,12 +5930,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70174",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5759,11 +5946,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "reservoir_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GRES",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5771,12 +5957,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70175",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5786,11 +5973,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "beaconsfield_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBEA",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5799,12 +5985,13 @@
     ],
     "type": "realtime",
     "uses_shuttles": false,
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70176",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5814,11 +6001,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "beaconsfield_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBEA",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5827,12 +6013,13 @@
     ],
     "type": "realtime",
     "uses_shuttles": false,
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70177",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5842,11 +6029,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "brookline_hills_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBRH",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5854,12 +6040,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70178",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5869,11 +6056,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "brookline_hills_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBRH",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5881,12 +6067,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70179",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5896,11 +6083,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "brookline_village_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBRV",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5908,12 +6094,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "North Station",
+      "sources": [
         {
           "stop_id": "70180",
           "direction_id": 1,
-          "headway_direction_name": "North Station",
           "routes": [
             "Green-D"
           ],
@@ -5923,11 +6110,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "brookline_village_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GBRV",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5935,12 +6121,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70181",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -5950,11 +6137,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "longwood_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GLON",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -5962,12 +6148,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70182",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -5977,11 +6164,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "longwood_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GLON",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -5989,12 +6175,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70183",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -6004,11 +6191,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "fenway_eastbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GFEN",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6016,12 +6202,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Union Square",
+      "sources": [
         {
           "stop_id": "70186",
           "direction_id": 1,
-          "headway_direction_name": "Union Square",
           "routes": [
             "Green-D"
           ],
@@ -6031,11 +6218,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "fenway_westbound",
-    "headway_group": "green_d",
     "pa_ess_loc": "GFEN",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6043,12 +6229,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_d",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70187",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -6058,11 +6245,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "babcock_st_eastbound",
-    "headway_group": "green_b",
     "pa_ess_loc": "GBAB",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6070,12 +6256,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Government Center",
+      "sources": [
         {
           "stop_id": "170136",
           "direction_id": 1,
-          "headway_direction_name": "Government Center",
           "routes": [
             "Green-B"
           ],
@@ -6085,11 +6272,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "babcock_st_westbound",
-    "headway_group": "green_b",
     "pa_ess_loc": "GBAB",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6097,12 +6283,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Boston College",
+      "sources": [
         {
           "stop_id": "170137",
           "direction_id": 0,
-          "headway_direction_name": "Boston College",
           "routes": [
             "Green-B"
           ],
@@ -6112,11 +6299,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "amory_st_eastbound",
-    "headway_group": "green_b",
     "pa_ess_loc": "GAMO",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6124,12 +6310,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Government Center",
+      "sources": [
         {
           "stop_id": "170140",
           "direction_id": 1,
-          "headway_direction_name": "Government Center",
           "routes": [
             "Green-B"
           ],
@@ -6139,11 +6326,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "amory_st_westbound",
-    "headway_group": "green_b",
     "pa_ess_loc": "GAMO",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6151,12 +6337,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_b",
+      "headway_direction_name": "Boston College",
+      "sources": [
         {
           "stop_id": "170141",
           "direction_id": 0,
-          "headway_direction_name": "Boston College",
           "routes": [
             "Green-B"
           ],
@@ -6166,11 +6353,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kenmore_b_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6178,12 +6364,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "71150",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6195,11 +6382,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kenmore_b_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6207,12 +6393,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "71151",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6224,11 +6411,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kenmore_c_d_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 0,
     "text_zone": "n",
@@ -6236,12 +6422,13 @@
       "n"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70150",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6253,11 +6440,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kenmore_c_d_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 60,
     "text_zone": "s",
@@ -6265,12 +6451,13 @@
       "s"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70151",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6282,11 +6469,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "kenmore_mezzanine",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GKEN",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -6295,75 +6481,78 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70150",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
-          "stop_id": "71150",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70151",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
-          "stop_id": "71151",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70150",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "71150",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70151",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          },
+          {
+            "stop_id": "71151",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "hynes_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6371,12 +6560,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70152",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6388,11 +6578,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "hynes_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6400,12 +6589,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70153",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6417,11 +6607,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "hynes_mezzanine",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GAUD",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -6430,43 +6619,48 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70152",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70153",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70152",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70153",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "copley_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GCOP",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6474,12 +6668,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70154",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6492,11 +6687,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "copley_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GCOP",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6504,12 +6698,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70155",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6522,11 +6717,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "arlington_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GARL",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6534,12 +6728,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70156",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6552,11 +6747,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "arlington_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GARL",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6564,12 +6758,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70157",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6582,11 +6777,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "arlington_mezzanine",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GARL",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -6595,45 +6789,50 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70156",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70157",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70156",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70157",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "boylston_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GBOY",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6641,12 +6840,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70158",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6659,11 +6859,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "boylston_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GBOY",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6671,12 +6870,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70159",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6689,11 +6889,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "symphony_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GSYM",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6701,12 +6900,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70242",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -6716,11 +6916,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "symphony_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GSYM",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6728,12 +6927,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70241",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -6743,11 +6943,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "prudential_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6755,12 +6954,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70240",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -6770,11 +6970,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "prudential_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6782,12 +6981,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70239",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -6797,11 +6997,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "prudential_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GPRU",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -6810,39 +7009,44 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70240",
-          "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70239",
-          "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70240",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70239",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "park_st_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GPRKE",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -6850,12 +7054,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "71199",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6865,13 +7070,11 @@
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
-          "announce_boarding": false,
-          "source_for_headway": true
+          "announce_boarding": false
         },
         {
           "stop_id": "70200",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6884,11 +7087,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "park_st_winter_st_concourse",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GPRKE",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -6896,12 +7098,13 @@
       "m"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "71199",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6911,13 +7114,11 @@
           "platform": null,
           "terminal": false,
           "announce_arriving": true,
-          "announce_boarding": false,
-          "source_for_headway": true
+          "announce_boarding": false
         },
         {
           "stop_id": "70200",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -6930,11 +7131,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "park_st_westbound_wall_track",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GPRKW",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -6942,12 +7142,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70198",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "platform": null,
           "routes": [
             "Green-B",
@@ -6963,7 +7164,6 @@
         {
           "stop_id": "70199",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "platform": null,
           "routes": [
             "Green-B",
@@ -6977,11 +7177,10 @@
           "multi_berth": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "park_st_westbound_fence_track",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GPRKW",
     "read_loop_offset": 0,
     "text_zone": "n",
@@ -6989,12 +7188,13 @@
       "n"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70196",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7005,13 +7205,11 @@
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true,
-          "multi_berth": true,
-          "source_for_headway": true
+          "multi_berth": true
         },
         {
           "stop_id": "70197",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7022,15 +7220,13 @@
           "terminal": false,
           "announce_arriving": false,
           "announce_boarding": true,
-          "multi_berth": true,
-          "source_for_headway": true
+          "multi_berth": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_government_center_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7038,12 +7234,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70201",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7056,11 +7253,10 @@
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_government_center_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7068,12 +7264,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70202",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7086,11 +7283,10 @@
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_government_center_mezzanine",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GGOV",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7099,45 +7295,50 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70201",
-          "direction_id": 1,
-          "headway_direction_name": "Eastbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70202",
-          "direction_id": 0,
-          "headway_direction_name": "Westbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Eastbound",
+        "sources": [
+          {
+            "stop_id": "70201",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Westbound",
+        "sources": [
+          {
+            "stop_id": "70202",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "green_haymarket_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GHAY",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7145,12 +7346,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Eastbound",
+      "sources": [
         {
           "stop_id": "70203",
           "direction_id": 1,
-          "headway_direction_name": "Eastbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7163,11 +7365,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_haymarket_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GHAY",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7175,12 +7376,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Westbound",
+      "sources": [
         {
           "stop_id": "70204",
           "direction_id": 0,
-          "headway_direction_name": "Westbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7193,11 +7395,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_north_station_eastbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GNST",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7205,12 +7406,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Outbound",
+      "sources": [
         {
           "stop_id": "70205",
           "direction_id": 1,
-          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7223,11 +7425,10 @@
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_north_station_westbound",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GNST",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7235,12 +7436,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Inbound",
+      "sources": [
         {
           "stop_id": "70206",
           "direction_id": 0,
-          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7253,11 +7455,10 @@
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "green_north_station_commuter_rail_exit",
-    "headway_group": "green_trunk",
     "pa_ess_loc": "GNST",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7265,12 +7466,13 @@
       "m"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_trunk",
+      "headway_direction_name": "Inbound",
+      "sources": [
         {
           "stop_id": "70206",
           "direction_id": 0,
-          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7283,11 +7485,10 @@
           "announce_boarding": true
         }
       ]
-    ]
+    }
   },
   {
     "id": "science_park_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7295,12 +7496,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Outbound",
+      "sources": [
         {
           "stop_id": "70207",
           "direction_id": 1,
-          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7313,11 +7515,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "science_park_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7325,12 +7526,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Inbound",
+      "sources": [
         {
           "stop_id": "70208",
           "direction_id": 0,
-          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7343,11 +7545,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "science_park_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GSCI",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7356,45 +7557,50 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70207",
-          "direction_id": 1,
-          "headway_direction_name": "Outbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70208",
-          "direction_id": 0,
-          "headway_direction_name": "Inbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70207",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70208",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "lechmere_green_line_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7402,12 +7608,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Outbound",
+      "sources": [
         {
           "stop_id": "70501",
           "direction_id": 1,
-          "headway_direction_name": "Outbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7420,11 +7627,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "lechmere_green_line_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7432,12 +7638,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Inbound",
+      "sources": [
         {
           "stop_id": "70502",
           "direction_id": 0,
-          "headway_direction_name": "Inbound",
           "routes": [
             "Green-B",
             "Green-C",
@@ -7450,11 +7657,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "lechmere_green_line_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GLEC",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7463,56 +7669,62 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70501",
-          "direction_id": 1,
-          "headway_direction_name": "Outbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70502",
-          "direction_id": 0,
-          "headway_direction_name": "Inbound",
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70501",
+            "direction_id": 1,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70502",
+            "direction_id": 0,
+            "routes": [
+              "Green-B",
+              "Green-C",
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "union_sq_track_one",
-    "headway_group": "green_e",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 30,
     "text_zone": "e",
     "audio_zones": [],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -7522,22 +7734,22 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "union_sq_track_two",
-    "headway_group": "green_e",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 90,
     "text_zone": "w",
     "audio_zones": [],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -7547,11 +7759,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "union_sq_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GUNS",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7561,12 +7772,13 @@
       "m"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Riverside",
+      "sources": [
         {
           "stop_id": "70504",
           "direction_id": 0,
-          "headway_direction_name": "Riverside",
           "routes": [
             "Green-D"
           ],
@@ -7576,11 +7788,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "east_somerville_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GESS",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7588,12 +7799,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70513",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -7603,11 +7815,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "east_somerville_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GESS",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7615,12 +7826,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70514",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -7630,50 +7842,54 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "east_somerville_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GESS",
     "read_loop_offset": 120,
     "text_zone": "m",
     "audio_zones": [],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70513",
-          "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70514",
-          "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70513",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70514",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "gilman_square_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GGSS",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7681,12 +7897,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70505",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -7696,11 +7913,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "gilman_square_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GGSS",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7708,12 +7924,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70506",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -7723,11 +7940,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "gilman_square_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GGSS",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7736,39 +7952,44 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70505",
-          "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70506",
-          "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70505",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70506",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "magoun_square_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GMSS",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7776,12 +7997,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70507",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -7791,11 +8013,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "magoun_square_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GMSS",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7803,12 +8024,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70508",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -7818,11 +8040,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "magoun_square_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GMSS",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7831,39 +8052,44 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70507",
-          "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70508",
-          "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70507",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70508",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "ball_square_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GBSS",
     "read_loop_offset": 30,
     "text_zone": "e",
@@ -7871,12 +8097,13 @@
       "e"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Medford/Tufts",
+      "sources": [
         {
           "stop_id": "70509",
           "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
           "routes": [
             "Green-E"
           ],
@@ -7886,11 +8113,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ball_square_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GBSS",
     "read_loop_offset": 90,
     "text_zone": "w",
@@ -7898,12 +8124,13 @@
       "w"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70510",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -7913,11 +8140,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "ball_square_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GBSS",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -7926,50 +8152,56 @@
     ],
     "type": "realtime",
     "source_config": [
-      [
-        {
-          "stop_id": "70509",
-          "direction_id": 1,
-          "headway_direction_name": "Medford/Tufts",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ],
-      [
-        {
-          "stop_id": "70510",
-          "direction_id": 0,
-          "headway_direction_name": "Heath Street",
-          "routes": [
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": true,
-          "announce_boarding": false
-        }
-      ]
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Medford/Tufts",
+        "sources": [
+          {
+            "stop_id": "70509",
+            "direction_id": 1,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      },
+      {
+        "headway_group": "green_e",
+        "headway_direction_name": "Heath Street",
+        "sources": [
+          {
+            "stop_id": "70510",
+            "direction_id": 0,
+            "routes": [
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": true,
+            "announce_boarding": false
+          }
+        ]
+      }
     ]
   },
   {
     "id": "college_ave_eastbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GCOS",
     "read_loop_offset": 30,
     "text_zone": "e",
     "audio_zones": [],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70512",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -7979,22 +8211,22 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "college_ave_westbound",
-    "headway_group": "green_e",
     "pa_ess_loc": "GCOS",
     "read_loop_offset": 90,
     "text_zone": "w",
     "audio_zones": [],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70512",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -8004,11 +8236,10 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   },
   {
     "id": "college_ave_mezzanine",
-    "headway_group": "green_e",
     "pa_ess_loc": "GCOS",
     "read_loop_offset": 120,
     "text_zone": "m",
@@ -8018,12 +8249,13 @@
       "m"
     ],
     "type": "realtime",
-    "source_config": [
-      [
+    "source_config": {
+      "headway_group": "green_e",
+      "headway_direction_name": "Heath Street",
+      "sources": [
         {
           "stop_id": "70512",
           "direction_id": 0,
-          "headway_direction_name": "Heath Street",
           "routes": [
             "Green-E"
           ],
@@ -8033,6 +8265,6 @@
           "announce_boarding": false
         }
       ]
-    ]
+    }
   }
 ]

--- a/scripts/one_off/transform_signs.exs
+++ b/scripts/one_off/transform_signs.exs
@@ -1,0 +1,37 @@
+Mix.install([{:jason, "~> 1.4.0"}])
+
+signs =
+  File.read!("priv/signs.json")
+  |> Jason.decode!(objects: :ordered_objects)
+
+signs_json = Enum.map(signs, fn sign ->
+  {headway_group, sign} = pop_in(sign["headway_group"])
+  headway_groups = case headway_group do
+    [one, two] -> [one, two]
+    one -> [one, one]
+  end
+  make_config = fn {list, headway_group} ->
+    Jason.OrderedObject.new([
+      headway_group: headway_group,
+      headway_direction_name:
+        case Enum.map(list, fn s -> s["headway_direction_name"] end) |> Enum.uniq() do
+          [name] -> name
+          _ -> nil
+        end,
+      sources: Enum.map(list, fn source ->
+        {_, source} = pop_in(source["headway_direction_name"])
+        {_, source} = pop_in(source["source_for_headway"])
+        source
+      end)
+    ])
+  end
+  update_in(sign["source_config"], fn source_config ->
+    case source_config do
+      [one] -> make_config.({one, hd(headway_groups)})
+      [one, two] -> Enum.zip([one, two], headway_groups) |> Enum.map(make_config)
+    end
+  end)
+end)
+|> Jason.encode!(pretty: true)
+
+File.write!("priv/signs.json", signs_json)

--- a/test/content/audio/predictions_test.exs
+++ b/test/content/audio/predictions_test.exs
@@ -10,7 +10,6 @@ defmodule Content.Audio.PredictionsTest do
   @src %SourceConfig{
     stop_id: "70196",
     direction_id: 0,
-    headway_destination: :heath_street,
     platform: nil,
     terminal?: false,
     announce_arriving?: false,
@@ -19,7 +18,7 @@ defmodule Content.Audio.PredictionsTest do
 
   describe "from_sign_content/3" do
     test "returns a TrackChange audio when Green-B boarding at C berth at Park St" do
-      src = %{@src | stop_id: "70197", direction_id: 0, headway_destination: :boston_college}
+      src = %{@src | stop_id: "70197", direction_id: 0}
 
       predictions = %Message.Predictions{
         destination: :boston_college,
@@ -38,7 +37,7 @@ defmodule Content.Audio.PredictionsTest do
     end
 
     test "returns a TrackChange audio when Green-E boarding at D berth at Park St" do
-      src = %{@src | stop_id: "70198", direction_id: 0, headway_destination: :heath_street}
+      src = %{@src | stop_id: "70198", direction_id: 0}
 
       predictions = %Message.Predictions{
         destination: :heath_street,
@@ -57,7 +56,7 @@ defmodule Content.Audio.PredictionsTest do
     end
 
     test "returns a NextTrainCountdown if it's the wrong track but somehow not boarding" do
-      src = %{@src | stop_id: "70196", direction_id: 0, headway_destination: :heath_street}
+      src = %{@src | stop_id: "70196", direction_id: 0}
 
       predictions = %Message.Predictions{
         destination: :heath_street,
@@ -80,7 +79,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70085",
           direction_id: 0,
-          headway_destination: :southbound,
           platform: :ashmont
       }
 
@@ -109,7 +107,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70085",
           direction_id: 0,
-          headway_destination: :southbound,
           platform: :ashmont
       }
 
@@ -137,8 +134,7 @@ defmodule Content.Audio.PredictionsTest do
       src = %{
         @src
         | stop_id: "70155",
-          direction_id: 0,
-          headway_destination: :westbound
+          direction_id: 0
       }
 
       predictions = %Message.Predictions{
@@ -154,7 +150,7 @@ defmodule Content.Audio.PredictionsTest do
     end
 
     test "returns a NextTrainCountdown audio if predictions say it's approaching on the bottom line" do
-      src = %{@src | stop_id: "70065", direction_id: 0, headway_destination: :southbound}
+      src = %{@src | stop_id: "70065", direction_id: 0}
 
       predictions = %Message.Predictions{
         destination: :ashmont,
@@ -175,7 +171,7 @@ defmodule Content.Audio.PredictionsTest do
     end
 
     test "returns a TrainIsBoarding audio if predictions say it's boarding" do
-      src = %{@src | stop_id: "70065", direction_id: 0, headway_destination: :southbound}
+      src = %{@src | stop_id: "70065", direction_id: 0}
 
       predictions = %Message.Predictions{
         destination: :ashmont,
@@ -200,7 +196,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70085",
           direction_id: 0,
-          headway_destination: :southbound,
           platform: :ashmont
       }
 
@@ -227,7 +222,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70065",
           direction_id: 0,
-          headway_destination: :southbound,
           terminal?: false
       }
 
@@ -247,7 +241,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70061",
           direction_id: 0,
-          headway_destination: :southbound,
           terminal?: true
       }
 
@@ -267,7 +260,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70096",
           direction_id: 1,
-          headway_destination: :alewife,
           platform: :ashmont
       }
 
@@ -293,7 +285,6 @@ defmodule Content.Audio.PredictionsTest do
         @src
         | stop_id: "70065",
           direction_id: 0,
-          headway_destination: :southbound,
           terminal?: false
       }
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -81,7 +81,6 @@ defmodule Signs.RealtimeTest do
 
   @src %Signs.Utilities.SourceConfig{
     stop_id: "1",
-    headway_destination: :southbound,
     direction_id: 0,
     platform: nil,
     terminal?: false,
@@ -91,10 +90,13 @@ defmodule Signs.RealtimeTest do
 
   @sign %Signs.Realtime{
     id: "sign_id",
-    headway_group: "headway_group",
     text_id: {"TEST", "x"},
     audio_id: {"TEST", ["x"]},
-    source_config: {[@src]},
+    source_config: %{
+      sources: [@src],
+      headway_group: "headway_group",
+      headway_destination: :southbound
+    },
     current_content_top: {@src, %HT{destination: :southbound, vehicle_type: :train}},
     current_content_bottom: {@src, %HB{range: {1, 5}, prev_departure_mins: nil}},
     prediction_engine: FakePredictions,

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -87,7 +87,6 @@ defmodule Signs.Utilities.MessagesTest do
   @src %Signs.Utilities.SourceConfig{
     stop_id: "1",
     direction_id: 0,
-    headway_destination: :mattapan,
     platform: nil,
     terminal?: false,
     announce_arriving?: false,
@@ -96,10 +95,9 @@ defmodule Signs.Utilities.MessagesTest do
 
   @sign %Signs.Realtime{
     id: "sign_id",
-    headway_group: "headway_group",
     text_id: {"TEST", "x"},
     audio_id: {"TEST", ["x"]},
-    source_config: {[@src]},
+    source_config: %{sources: [@src]},
     current_content_top: {@src, %Content.Message.Predictions{destination: :alewife, minutes: 4}},
     current_content_bottom:
       {@src, %Content.Message.Predictions{destination: :ashmont, minutes: 3}},
@@ -142,7 +140,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -159,7 +157,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -176,7 +174,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -194,17 +192,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :shuttles_transfer_station
 
       assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+               {{@src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 2,
@@ -214,17 +202,7 @@ defmodule Signs.Utilities.MessagesTest do
                    station_code: "TEST",
                    zone: "x"
                  }},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+                {@src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 4,
@@ -241,7 +219,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -259,7 +237,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()},
           uses_shuttles: false
@@ -277,7 +255,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -286,17 +264,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :shuttles_closed_station
 
       assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+               {{src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 2,
@@ -306,17 +274,7 @@ defmodule Signs.Utilities.MessagesTest do
                    station_code: "TEST",
                    zone: "x"
                  }},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+                {src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 4,
@@ -333,7 +291,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -350,7 +308,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -367,7 +325,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       sign = %{
         @sign
-        | source_config: {[src]},
+        | source_config: %{sources: [src]},
           current_content_top: {src, Content.Message.Empty.new()},
           current_content_bottom: {src, Content.Message.Empty.new()}
       }
@@ -376,17 +334,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
 
       assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+               {{src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 2,
@@ -396,17 +344,7 @@ defmodule Signs.Utilities.MessagesTest do
                    station_code: "TEST",
                    zone: "x"
                  }},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+                {src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 4,
@@ -424,17 +362,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :none
 
       assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+               {{@src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 2,
@@ -444,17 +372,7 @@ defmodule Signs.Utilities.MessagesTest do
                    station_code: "TEST",
                    zone: "x"
                  }},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "1",
-                   terminal?: false
-                 },
+                {@src,
                  %Content.Message.Predictions{
                    destination: :ashmont,
                    minutes: 4,
@@ -469,9 +387,12 @@ defmodule Signs.Utilities.MessagesTest do
     test "when there are no predictions and only one source config, puts headways on the sign" do
       sign = %{
         @sign
-        | source_config: {[%{@src | stop_id: "no_preds"}]},
-          config_engine: FakeConfigEngine,
-          headway_group: "8-11"
+        | source_config: %{
+            headway_group: "8-11",
+            headway_destination: :mattapan,
+            sources: [%{@src | stop_id: "no_preds"}]
+          },
+          config_engine: FakeConfigEngine
       }
 
       sign_config = :auto
@@ -480,32 +401,12 @@ defmodule Signs.Utilities.MessagesTest do
       current_time = Timex.shift(FakeDepartures.test_departure_time(), minutes: 5)
 
       assert Messages.get_messages(sign, sign_config, current_time, alert_status) ==
-               {{%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "no_preds",
-                   terminal?: false
-                 },
+               {{nil,
                  %Content.Message.Headways.Top{
                    destination: :mattapan,
                    vehicle_type: :train
                  }},
-                {%Signs.Utilities.SourceConfig{
-                   announce_arriving?: false,
-                   announce_boarding?: false,
-                   direction_id: 0,
-                   headway_destination: :mattapan,
-                   multi_berth?: false,
-                   platform: nil,
-                   routes: nil,
-                   stop_id: "no_preds",
-                   terminal?: false
-                 },
+                {nil,
                  %Content.Message.Headways.Bottom{
                    range: {8, 11},
                    prev_departure_mins: nil
@@ -515,7 +416,11 @@ defmodule Signs.Utilities.MessagesTest do
     test "when there are no predictions and more than one source config, puts nothing on the sign" do
       sign = %{
         @sign
-        | source_config: {[%{@src | stop_id: "no_preds"}, %{@src | stop_id: "no_preds"}]}
+        | source_config: %{
+            headway_group: "headway_group",
+            headway_destination: :mattapan,
+            sources: [%{@src | stop_id: "no_preds"}, %{@src | stop_id: "no_preds"}]
+          }
       }
 
       sign_config = :auto
@@ -526,7 +431,12 @@ defmodule Signs.Utilities.MessagesTest do
     end
 
     test "when sign is forced into headway mode but no alerts are present, displays headways" do
-      sign = %{@sign | config_engine: FakeConfigEngine, headway_group: "8-11"}
+      sign = %{
+        @sign
+        | config_engine: FakeConfigEngine,
+          source_config: %{sources: [], headway_group: "8-11", headway_destination: :mattapan}
+      }
+
       sign_config = :headway
       alert_status = :none
 

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -614,10 +614,9 @@ defmodule Signs.Utilities.PredictionsTest do
 
   @sign %Signs.Realtime{
     id: "sign_id",
-    headway_group: "headway_group",
     text_id: {"TEST", "x"},
     audio_id: {"TEST", ["x"]},
-    source_config: {[], []},
+    source_config: {%{sources: []}, %{sources: []}},
     current_content_top: {nil, Content.Message.Empty.new()},
     current_content_bottom: {nil, Content.Message.Empty.new()},
     prediction_engine: FakePredictions,
@@ -638,7 +637,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "when given two source lists, returns earliest result from each" do
       s1 = %SourceConfig{
         stop_id: "1",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -648,7 +646,6 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %SourceConfig{
         stop_id: "2",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -656,7 +653,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s1], [s2]}
+      config = {%{sources: [s1]}, %{sources: [s2]}}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -668,7 +665,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "when given one source list, returns earliest two results" do
       s1 = %SourceConfig{
         stop_id: "3",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -678,7 +674,6 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %SourceConfig{
         stop_id: "4",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -686,7 +681,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s1, s2]}
+      config = %{sources: [s1, s2]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -698,7 +693,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "sorts by arrival or departure depending on which is present" do
       src = %SourceConfig{
         stop_id: "arrival_vs_departure_time",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -706,7 +700,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[src]}
+      config = %{sources: [src]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -718,7 +712,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "When the train is stopped a long time away, but not quite max time, shows stopped" do
       src = %SourceConfig{
         stop_id: "stopped_not_too_long_away",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -726,7 +719,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[src]}
+      config = %{sources: [src]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -738,7 +731,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "When the train is stopped a long time away from a terminal, shows max time instead of stopped" do
       src = %SourceConfig{
         stop_id: "stopped_a_long_time_away_terminal",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: true,
         platform: nil,
@@ -746,7 +738,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[src]}
+      config = %{sources: [src]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -758,7 +750,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "When the train is stopped a long time away, shows max time instead of stopped" do
       src = %SourceConfig{
         stop_id: "stopped_a_long_time_away",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -766,7 +757,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[src]}
+      config = %{sources: [src]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -778,7 +769,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "pads out results if only one prediction" do
       s = %SourceConfig{
         stop_id: "7",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -786,7 +776,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -798,7 +788,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "pads out results if no predictions" do
       s = %SourceConfig{
         stop_id: "n/a",
-        headway_destination: :mattapan,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -806,7 +795,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -818,7 +807,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "only the first prediction in a source list can be BRD" do
       s = %SourceConfig{
         stop_id: "8",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -826,7 +814,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -838,7 +826,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Returns stopped train message" do
       s = %SourceConfig{
         stop_id: "9",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -846,7 +833,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -858,7 +845,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Only includes predictions if a departure prediction is present" do
       s = %SourceConfig{
         stop_id: "stop_with_nil_departure_prediction",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -866,7 +852,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -878,7 +864,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Filters by route if present" do
       s1 = %SourceConfig{
         stop_id: "filterable_by_route",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -889,8 +874,8 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %{s1 | routes: ["Green-D"]}
 
-      config1 = {[s1]}
-      config2 = {[s2]}
+      config1 = %{sources: [s1]}
+      config2 = %{sources: [s2]}
 
       sign1 = %{@sign | source_config: config1}
       sign2 = %{@sign | source_config: config2}
@@ -909,7 +894,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Sorts boarding status to the top" do
       s = %SourceConfig{
         stop_id: "both_brd",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -918,7 +902,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -929,7 +913,7 @@ defmodule Signs.Utilities.PredictionsTest do
              } = Signs.Utilities.Predictions.get_messages(sign)
 
       s = %{s | stop_id: "second_brd"}
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{sign | source_config: config}
 
       assert {
@@ -939,7 +923,7 @@ defmodule Signs.Utilities.PredictionsTest do
              } = Signs.Utilities.Predictions.get_messages(sign)
 
       s = %{s | stop_id: "first_brd"}
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{sign | source_config: config}
 
       assert {
@@ -952,7 +936,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Does not allow ARR on second line unless platform has multiple berths" do
       s1 = %SourceConfig{
         stop_id: "arr_multi_berth1",
-        headway_destination: :mattapan,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -964,7 +947,7 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %{s1 | stop_id: "arr_multi_berth2"}
 
-      config = {[s1, s2]}
+      config = %{sources: [s1, s2]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -975,7 +958,7 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s1 = %{s1 | multi_berth?: false}
       s2 = %{s2 | multi_berth?: false}
-      config = {[s1, s2]}
+      config = %{sources: [s1, s2]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -988,7 +971,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "Correctly orders BRD predictions between trains mid-trip and those starting their trip" do
       s1 = %SourceConfig{
         stop_id: "multiple_brd_some_first_stop_1",
-        headway_destination: :westbound,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -1000,7 +982,7 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %{s1 | stop_id: "multiple_brd_some_first_stop_2"}
 
-      config = {[s1, s2]}
+      config = %{sources: [s1, s2]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -1013,7 +995,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "doesn't sort 0 stops away to first for terminals when another departure is sooner" do
       s = %SourceConfig{
         stop_id: "terminal_dont_sort_0_stops_first",
-        headway_destination: :southbound,
         direction_id: 0,
         terminal?: true,
         platform: nil,
@@ -1022,7 +1003,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: true
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert {
@@ -1034,7 +1015,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "properly handles case where destination can't be determined" do
       s = %SourceConfig{
         stop_id: "indeterminate_destination",
-        headway_destination: :southbound,
         direction_id: 0,
         terminal?: true,
         platform: nil,
@@ -1043,7 +1023,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: true
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_messages(sign) ==
@@ -1055,7 +1035,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "returns appropriate audio structs for multi-source sign" do
       s1 = %SourceConfig{
         stop_id: "passthrough_trains",
-        headway_destination: :southbound,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -1066,7 +1045,6 @@ defmodule Signs.Utilities.PredictionsTest do
 
       s2 = %SourceConfig{
         stop_id: "passthrough_trains",
-        headway_destination: :alewife,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -1075,7 +1053,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s1], [s2]}
+      config = {%{sources: [s1]}, %{sources: [s2]}}
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) == [
@@ -1090,7 +1068,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "returns appropriate audio structs for single-source sign" do
       s = %SourceConfig{
         stop_id: "passthrough_trains",
-        headway_destination: :southbound,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -1099,7 +1076,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) ==
@@ -1115,7 +1092,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "handles \"Southbound\" headsign" do
       s = %SourceConfig{
         stop_id: "passthrough_trains_southbound_red_line_destination",
-        headway_destination: :alewife,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -1124,7 +1100,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       assert Signs.Utilities.Predictions.get_passthrough_train_audio(sign) ==
@@ -1140,7 +1116,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "handles case where headsign can't be determined" do
       s = %SourceConfig{
         stop_id: "passthrough_trains_bad_destination",
-        headway_destination: :alewife,
         direction_id: 1,
         terminal?: false,
         platform: nil,
@@ -1149,7 +1124,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      config = {[s]}
+      config = %{sources: [s]}
       sign = %{@sign | source_config: config}
 
       log =
@@ -1163,7 +1138,6 @@ defmodule Signs.Utilities.PredictionsTest do
     test "prefers showing distinct destinations when present" do
       s = %SourceConfig{
         stop_id: "multiple_destinations",
-        headway_destination: :southbound,
         direction_id: 0,
         terminal?: false,
         platform: nil,
@@ -1172,7 +1146,7 @@ defmodule Signs.Utilities.PredictionsTest do
         announce_boarding?: false
       }
 
-      sign = %{@sign | source_config: {[s]}}
+      sign = %{@sign | source_config: %{sources: [s]}}
 
       assert {
                {^s, %Content.Message.Predictions{destination: :ashmont}},

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -21,7 +21,6 @@ defmodule Signs.Utilities.ReaderTest do
   @src %Signs.Utilities.SourceConfig{
     stop_id: "1",
     direction_id: 0,
-    headway_destination: :southbound,
     platform: nil,
     terminal?: false,
     announce_arriving?: false,
@@ -30,10 +29,9 @@ defmodule Signs.Utilities.ReaderTest do
 
   @sign %Signs.Realtime{
     id: "sign_id",
-    headway_group: "headway_group",
     text_id: {"TEST", "x"},
     audio_id: {"TEST", ["x"]},
-    source_config: {[@src]},
+    source_config: %{sources: [@src]},
     current_content_top: {@src, %Predictions{destination: :alewife, minutes: 4}},
     current_content_bottom: {@src, %Predictions{destination: :ashmont, minutes: 3}},
     prediction_engine: FakePredictions,

--- a/test/signs/utilities/updater_test.exs
+++ b/test/signs/utilities/updater_test.exs
@@ -26,7 +26,6 @@ defmodule Signs.Utilities.UpdaterTest do
 
   @src %Signs.Utilities.SourceConfig{
     stop_id: "1",
-    headway_destination: :southbound,
     direction_id: 0,
     platform: nil,
     terminal?: false,
@@ -36,10 +35,9 @@ defmodule Signs.Utilities.UpdaterTest do
 
   @sign %Signs.Realtime{
     id: "sign_id",
-    headway_group: "headway_group",
     text_id: {"TEST", "x"},
     audio_id: {"TEST", ["x"]},
-    source_config: {[]},
+    source_config: %{sources: []},
     current_content_top: {@src, %P{destination: :alewife, minutes: 4}},
     current_content_bottom: {@src, %P{destination: :ashmont, minutes: 3}},
     prediction_engine: FakePredictions,


### PR DESCRIPTION
#### Summary of changes

This aims to simplify the code that calculates headway messages. It does this by changing the structure of the signs JSON, and adding an explicit object under `source_config`, which holds the headway information alongside the prediction sources. Similar to before, platform signs have one config object, while mezzanine signs have a list of two. This allows for natural encodings of all existing cases, including the multiple headway groups at Ashmont. This results in simpler downstream logic for reading and interpreting the data.

Notes:
* The changes to `signs.json` were done entirely with the `transform_signs.exs` script, which is included here for review (but we can delete it afterward)
* This removes `source_for_headway`, since the headway configuration is now explicit and centralized. Currently that means the special multi-track stops (e.g. `Forest Hills-01`) will be included in the time-range calculation when deciding whether to show headways. I think this is ok, but if not, we can add logic to filter them out.
* There is one expected behavior change, the `park_st_westbound_wall_track` sign will now start showing the headway destination in its headway message. The fact that it wasn't already was likely a misconfiguration.
* The `wellington_southbound` sign will continue NOT showing a headway destination, but that fact is now encoded explicitly as a `null` in the new config object, rather than implicitly in the logic.
* Most of the headway messages now just include a `nil` as their associated source. This should not cause any behavior changes, because we only examine the source for prediction messages, but some of the tests needed to be adjusted.