### PR TITLE
fix passthrough train audio

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -162,7 +162,7 @@ defmodule Signs.Realtime do
     |> Utilities.Predictions.get_passthrough_train_audio()
     |> Enum.reduce(sign, fn audio, sign ->
       if audio.trip_id not in sign.announced_passthroughs do
-        sign.sign_updater.send_audio(sign.audio_id, audio, 5, 60)
+        sign.sign_updater.send_audio(sign.audio_id, [audio], 5, 60)
 
         update_in(sign.announced_passthroughs, fn list ->
           Enum.take([audio.trip_id | list], @announced_history_length)

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -211,7 +211,7 @@ defmodule Signs.RealtimeTest do
 
       assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, sign)
       assert sign.announced_passthroughs == ["123"]
-      assert_received({:send_audio, _, %Content.Audio.Passthrough{}, _, _})
+      assert_received({:send_audio, _, [%Content.Audio.Passthrough{}], _, _})
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

This fixes a bug that came out of the audio refactor. Passthrough train messages are sent via a separate code path, which wasn't updated to the new call spec.