### PR TITLE
enable bus sign engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Environment variables are stored in AWS Secrets Manager. If a new env variable n
 * `SIGN_UI_API_KEY`: API key used when making requests to `signs_ui`. Not set by default.
 * `TRIP_UPDATE_URL` and `VEHICLE_POSITIONS_URL`: URLs of the enhanced trip-update and vehicle-position feeds. Default to the real feed URLs.
 * `API_V3_KEY` and `API_V3_URL`: Access key and URL for V3 API. Default respectively to a blank string and the URL of the dev-green API instance.
+* `CHELSEA_BRIDGE_URL` and `CHELSEA_BRIDGE_AUTH`: URL and auth key for the Chelsea bridge API. These values can be found in the shared 1Password vault, in the "Chelsea Street Bridge Application" entry, in fields `url` and `auth`.
 * `NUMBER_OF_HTTP_UPDATERS`: Number of `PaEss.HttpUpdater` processes that should run. These are responsible for posting updates to the PA/ESS head-end server, so this number is also the number of concurrent HTTP requests to that server.
 
 ## Deploying

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,8 +2,3 @@ import Config
 
 config :logger,
   backends: [:console]
-
-config :realtime_signs,
-  # This flag enables testing of the in-progress bus work. It should be removed when the work
-  # is finished
-  test_bus_mode: System.get_env("TEST_BUS_MODE") == "true"

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -586,5 +586,9 @@ defmodule Fake.HTTPoison do
     {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(response)}}
   end
 
+  def mock_response("https://api-dev-green.mbtace.com/predictions" <> _) do
+    {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{data: [], included: []})}}
+  end
+
   def mock_response(_), do: {:ok, %HTTPoison.Response{status_code: 200, body: ""}}
 end

--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -21,11 +21,12 @@ defmodule RealtimeSigns do
         Engine.Departures,
         Engine.Static,
         Engine.Alerts,
+        Engine.BusPredictions,
+        Engine.ChelseaBridge,
         MessageQueue,
         RealtimeSigns.Scheduler,
         RealtimeSignsWeb.Endpoint
       ] ++
-        bus_children() ++
         http_updater_children() ++
         [
           Signs.Supervisor
@@ -64,16 +65,6 @@ defmodule RealtimeSigns do
 
     for i <- 1..num_children do
       {PaEss.HttpUpdater, i}
-    end
-  end
-
-  # These modules are specific to the in-progress bus work, and are disabled by default.
-  # They should be enabled and inlined once the work is complete.
-  def bus_children do
-    if Application.get_env(:realtime_signs, :test_bus_mode) do
-      [Engine.BusPredictions, Engine.ChelseaBridge]
-    else
-      []
     end
   end
 end

--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -6,13 +6,9 @@ defmodule Signs.Utilities.SignsConfig do
   @doc "Pulls the entire signs.json configuration"
   @spec children_config() :: [map()]
   def children_config() do
-    # This override allows testing the in-progress bus work, and is off by default.
-    # It should be removed once the work is complete.
-    test_bus_mode = Application.get_env(:realtime_signs, :test_bus_mode)
-
     :realtime_signs
     |> :code.priv_dir()
-    |> Path.join(if test_bus_mode, do: "bus-signs.json", else: "signs.json")
+    |> Path.join("signs.json")
     |> File.read!()
     |> Jason.decode!()
   end

--- a/test/signs/utilities/signs_config_test.exs
+++ b/test/signs/utilities/signs_config_test.exs
@@ -12,10 +12,4 @@ defmodule Signs.Utilities.SignsConfigTest do
       assert Enum.member?(Signs.Utilities.SignsConfig.all_train_stop_ids(), "70056")
     end
   end
-
-  describe "all_bus_stop_ids" do
-    test "empty for now" do
-      assert Signs.Utilities.SignsConfig.all_bus_stop_ids() == []
-    end
-  end
 end


### PR DESCRIPTION
#### Summary of changes

This removes the `TEST_BUS_MODE` flag and enables the bus predictions and Chelsea bridge engines. These will fetch the relevant data in the background even though there are no enabled signs using them yet. After this, bus signs can be enabled one-by-one by adding entries to `signs.json`.

Also changes some code paths to behave correctly with empty data, and caches the list of bus stop ids on startup.