### PR TITLE
Increase message queue size to 400

### DIFF
--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -18,7 +18,7 @@ defmodule MessageQueue do
           length: integer()
         }
 
-  @max_size 300
+  @max_size 400
   @too_full_drop 30
 
   use GenServer
@@ -62,6 +62,8 @@ defmodule MessageQueue do
 
   @impl GenServer
   def handle_call({:queue_update, msg}, _from, state) do
+    IO.inspect(state.length)
+
     {queue, length} =
       if state.length >= @max_size do
         Logger.warn(["Message queue too full; dropping ", inspect(@too_full_drop)])

--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -62,8 +62,6 @@ defmodule MessageQueue do
 
   @impl GenServer
   def handle_call({:queue_update, msg}, _from, state) do
-    IO.inspect(state.length)
-
     {queue, length} =
       if state.length >= @max_size do
         Logger.warn(["Message queue too full; dropping ", inspect(@too_full_drop)])

--- a/test/message_queue_test.exs
+++ b/test/message_queue_test.exs
@@ -15,14 +15,14 @@ defmodule MessageQueueTest do
 
     test "bumps 15 old messages when more than max size" do
       q = 1..300 |> Enum.to_list() |> :queue.from_list()
-      state = %{queue: q, length: 300}
+      state = %{queue: q, length: 400}
       msg = 201
 
       {:reply, {:ok, :sent}, state} =
         MessageQueue.handle_call({:queue_update, msg}, self(), state)
 
       assert {{:value, 31}, _queue} = :queue.out(state.queue)
-      assert state.length == 271
+      assert state.length == 371
     end
 
     test "logs if message size is multiple of 30" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate increasing message queue size](https://app.asana.com/0/1201753694073608/1204331493928462/f)

Increase the message queue size to 400 to prevent a bit of overflow on startup and to leave some extra buffer room + room for the new bus signs that are to be added.
