### PR TITLE
fix audio zones for bus mezzanines

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -8345,7 +8345,9 @@
     "read_loop_interval": 360,
     "read_loop_offset": 60,
     "text_zone": "m",
-    "audio_zones": [],
+    "audio_zones": [
+      "m"
+    ],
     "type": "bus",
     "sources": [
       {

--- a/scripts/transitway_engine/parse_config.exs
+++ b/scripts/transitway_engine/parse_config.exs
@@ -161,7 +161,7 @@ signs_json =
             []
           else
             for {c, i} <- Enum.with_index(["m", "c", "n", "s", "e", "w"]),
-                String.at(audio_zones, i) == "1" do
+                String.at(if(audio_zones == "", do: "100000", else: audio_zones), i) == "1" do
               c
             end
           end,


### PR DESCRIPTION
#### Summary of changes

This fixes the missing audio zones for mezzanine bus signs. Transitway engine includes an empty audio zone bitmap for mezzanine signs, so we need to compensate for that in the translation script. This also fixes the already-generated courthouse sign.