### PR TITLE
allow pointing at local sign config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here's a general overview of the realtime_signs application which should be help
 
 First, ensure you have a basic working environment as described above, and in the signs_ui README.
 1. Start signs_ui and tell it what API key to accept: `MESSAGES_API_KEYS=realtime_signs:a6975e41192b888c NODE_ENV=development mix run --no-halt`. The key is arbitrary but it must match what you provide in the next step.
-2. Start realtime_signs, and provide the local URL and API key: `SIGN_UI_URL=localhost:5000 SIGN_UI_API_KEY=a6975e41192b888c mix run --no-halt`
+2. Start realtime_signs, and provide the local URL and API key, as well as the location of the config file: `SIGN_UI_URL=localhost:5000 SIGN_UI_API_KEY=a6975e41192b888c SIGN_CONFIG_FILE=../signs_ui/priv/config.json mix run --no-halt`
 3. Open up http://localhost:5000 and you should see the signs data being populated by your local app.
 
 ### Running locally in a docker container

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,7 +15,6 @@ if config_env() != :test do
     s3_path: System.get_env("SIGNS_S3_PATH"),
     api_v3_url: System.get_env("API_V3_URL", "https://api-dev-green.mbtace.com"),
     api_v3_key: System.get_env("API_V3_KEY"),
-    sign_config_file: System.get_env("SIGN_CONFIG_FILE"),
     chelsea_bridge_url: System.get_env("CHELSEA_BRIDGE_URL"),
     chelsea_bridge_auth: System.get_env("CHELSEA_BRIDGE_AUTH"),
     filter_uncertain_predictions?: System.get_env("FILTER_UNCERTAIN_PREDICTIONS", "false") == "true",
@@ -25,6 +24,11 @@ if config_env() != :test do
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
     message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
     monitoring_api_key: System.get_env("MONITORING_API_KEY")
+end
+
+if config_env() == :dev do
+  config :realtime_signs,
+    sign_config_file: System.get_env("SIGN_CONFIG_FILE")
 end
 
 message_log_job =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,6 +15,7 @@ if config_env() != :test do
     s3_path: System.get_env("SIGNS_S3_PATH"),
     api_v3_url: System.get_env("API_V3_URL", "https://api-dev-green.mbtace.com"),
     api_v3_key: System.get_env("API_V3_KEY"),
+    sign_config_file: System.get_env("SIGN_CONFIG_FILE"),
     chelsea_bridge_url: System.get_env("CHELSEA_BRIDGE_URL"),
     chelsea_bridge_auth: System.get_env("CHELSEA_BRIDGE_AUTH"),
     filter_uncertain_predictions?: System.get_env("FILTER_UNCERTAIN_PREDICTIONS", "false") == "true",

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,5 +10,6 @@ config :realtime_signs,
   scheduled_headway_requester: Fake.Headway.Request,
   headway_calculator: Fake.Headway.HeadwayDisplay,
   external_config_getter: Fake.ExternalConfig.Local,
+  sign_config_file: "priv/config.json",
   aws_client: Fake.ExAws,
   s3_client: Fake.ExAws

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -92,13 +92,9 @@ defmodule Engine.Config do
     latest_version =
       case updater.get(state.current_version) do
         {version, config} ->
-          # To handle two formats of signs config:
-          # old: %{ "sign_id" => %{ sign config}, "sign_id2" => ...}
-          # new: %{ "signs" => %{ "sign_id" => %{ sign_config }, ...}}
-          config_signs = Map.get(config, "signs", config)
-
           config_signs =
-            Enum.map(config_signs, fn {sign_id, config_json} ->
+            Map.get(config, "signs", %{})
+            |> Enum.map(fn {sign_id, config_json} ->
               {sign_id, transform_sign_config(state, config_json)}
             end)
 

--- a/lib/external_config/local.ex
+++ b/lib/external_config/local.ex
@@ -3,7 +3,13 @@ defmodule ExternalConfig.Local do
 
   @impl ExternalConfig.Interface
   def get(current_version) do
-    {:ok, file} = File.read("priv/config.json")
+    file =
+      with path when not is_nil(path) <- Application.get_env(:realtime_signs, :sign_config_file),
+           {:ok, file} <- File.read(path) do
+        file
+      else
+        _ -> "{}"
+      end
 
     etag =
       file

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -35,17 +35,19 @@ defmodule Fake.ExternalConfig.Local do
   def get(_current_version) do
     {nil,
      %{
-       "chelsea_inbound" => %{"mode" => "auto"},
-       "chelsea_outbound" => %{"mode" => "off"},
-       "custom_text_test" => %{
-         "line1" => "Test message",
-         "line2" => "Please ignore",
-         "expires" => "2017-07-04T12:00:00Z"
-       },
-       "off_test" => %{"mode" => "off"},
-       "auto_test" => %{"mode" => "auto"},
-       "headway_test" => %{"mode" => "headway"},
-       "MVAL0" => %{"mode" => "auto"}
+       "signs" => %{
+         "chelsea_inbound" => %{"mode" => "auto"},
+         "chelsea_outbound" => %{"mode" => "off"},
+         "custom_text_test" => %{
+           "line1" => "Test message",
+           "line2" => "Please ignore",
+           "expires" => "2017-07-04T12:00:00Z"
+         },
+         "off_test" => %{"mode" => "off"},
+         "auto_test" => %{"mode" => "auto"},
+         "headway_test" => %{"mode" => "headway"},
+         "MVAL0" => %{"mode" => "auto"}
+       }
      }}
   end
 

--- a/priv/config.json
+++ b/priv/config.json
@@ -1,11 +1,13 @@
 {
-  "chelsea_inbound": {
-    "mode": "headway"
-  },
-  "chelsea_outbound": {
-    "mode": "off"
-  },
-  "MVAL0": {
-    "mode": "auto"
+  "signs": {
+    "chelsea_inbound": {
+      "mode": "headway"
+    },
+    "chelsea_outbound": {
+      "mode": "off"
+    },
+    "MVAL0": {
+      "mode": "auto"
+    }
   }
 }

--- a/test/external_config/local_test.exs
+++ b/test/external_config/local_test.exs
@@ -4,26 +4,18 @@ defmodule ExternalConfig.LocalTest do
   describe "get/1" do
     test "loads config from a local json file" do
       assert ExternalConfig.Local.get("version") ==
-               {"47052743",
+               {"29027168",
                 %{
-                  "chelsea_inbound" => %{"mode" => "headway"},
-                  "chelsea_outbound" => %{"mode" => "off"},
-                  "MVAL0" => %{"mode" => "auto"}
-                }}
-    end
-
-    test "uses a hash of the file as a version id" do
-      assert ExternalConfig.Local.get(nil) ==
-               {"47052743",
-                %{
-                  "chelsea_inbound" => %{"mode" => "headway"},
-                  "chelsea_outbound" => %{"mode" => "off"},
-                  "MVAL0" => %{"mode" => "auto"}
+                  "signs" => %{
+                    "chelsea_inbound" => %{"mode" => "headway"},
+                    "chelsea_outbound" => %{"mode" => "off"},
+                    "MVAL0" => %{"mode" => "auto"}
+                  }
                 }}
     end
 
     test "if the file is unchanged, returns :unchanged" do
-      assert ExternalConfig.Local.get("47052743") == :unchanged
+      assert ExternalConfig.Local.get("29027168") == :unchanged
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

This leverages the recent signs-ui work to allow pointing at the config file of a local signs-ui. This enables a fully interactive local setup, where config changes in signs-ui are picked up and reflected in the sign output in real time, mirroring how the production system works.

Also removes support for the config file's "old format", which is no longer used.