### PR TITLE
Stop filtering Red Line predictions based on certainty

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -149,7 +149,7 @@ defmodule Predictions.Predictions do
   end
 
   @spec sufficient_certainty?(map(), String.t()) :: boolean()
-  defp sufficient_certainty?(stop_time_event, route_id) when route_id in ["Red", "Blue"] do
+  defp sufficient_certainty?(stop_time_event, route_id) when route_id in ["Blue"] do
     is_nil(stop_time_event["uncertainty"]) or stop_time_event["uncertainty"] < 120
   end
 

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -882,7 +882,7 @@ defmodule Predictions.PredictionsTest do
               "timestamp" => nil,
               "trip" => %{
                 "direction_id" => 0,
-                "route_id" => "Red",
+                "route_id" => "Blue",
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,


### PR DESCRIPTION
#### Summary of changes
Restore reverse and terminal predictions for Red Line. Deploy pending on result of analysis. [Context in Slack ](https://mbta.slack.com/archives/C03K6NLKKD1/p1681224044867379)
