### PR TITLE
fix prediction collapsing with headsign variations

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -487,6 +487,13 @@ defmodule PaEss.Utilities do
     end)
   end
 
+  @spec headsign_key(String.t()) :: String.t()
+  def headsign_key(headsign) do
+    Enum.find_value(@headsign_abbreviation_mappings, headsign, fn {prefix, _} ->
+      if String.starts_with?(headsign, prefix), do: prefix
+    end)
+  end
+
   @spec prediction_route_name(Predictions.BusPrediction.t()) :: String.t() | nil
   # Don't display route names for SL1, SL2, SL3, or SLW. This also has the effect of combining
   # inbound predictions along the waterfront, where all routes follow the same path.

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -481,7 +481,8 @@ defmodule Signs.Bus do
   end
 
   defp route_key(prediction) do
-    {PaEss.Utilities.prediction_route_name(prediction), prediction.headsign}
+    {PaEss.Utilities.prediction_route_name(prediction),
+     PaEss.Utilities.headsign_key(prediction.headsign)}
   end
 
   defp format_prediction(nil, _, _), do: ""


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Ensure bus predictions collapse when headsign variations are present](https://app.asana.com/0/1201753694073608/1204383490284793/f)

This fixes the de-duplication logic for bus predictions to correctly collapse multiple variations of the same headsign.