### PR TITLE
Remove single line logic

### DIFF
--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -9,7 +9,7 @@ defmodule MessageQueue do
   @behaviour PaEss.Updater
 
   @type message :: {
-          :update_single_line | :update_sign | :send_audio,
+          :update_sign | :send_audio,
           [term()]
         }
 
@@ -32,14 +32,6 @@ defmodule MessageQueue do
   @spec init(any()) :: {:ok, t()}
   def init(_) do
     {:ok, %{queue: :queue.new(), length: 0}}
-  end
-
-  @impl PaEss.Updater
-  def update_single_line(pid \\ __MODULE__, text_id, line_no, msg, duration, start) do
-    GenServer.call(
-      pid,
-      {:queue_update, {:update_single_line, [text_id, line_no, msg, duration, start]}}
-    )
   end
 
   @impl PaEss.Updater

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -77,43 +77,6 @@ defmodule PaEss.HttpUpdater do
     end
   end
 
-  @spec process({atom, [any]}, __MODULE__.t()) :: post_result
-  def process({:update_single_line, [{station, zone}, line_no, msg, duration, start_secs]}, state) do
-    cmd = to_command(msg, duration, start_secs, zone, line_no)
-    uid = get_uid(state)
-    encoded = URI.encode_query(MsgType: "SignContent", uid: uid, sta: station, c: cmd)
-
-    {arinc_time, result} = :timer.tc(fn -> send_post(state.http_poster, encoded) end)
-
-    case result do
-      {:ok, _} ->
-        {ui_time, _} = :timer.tc(fn -> update_ui(state.http_poster, encoded) end)
-
-        Logger.info([
-          "update_single_line: ",
-          encoded,
-          " pid=",
-          inspect(self()),
-          " arinc_ms=",
-          inspect(div(arinc_time, 1000)),
-          " signs_ui_ms=",
-          inspect(div(ui_time, 1000))
-        ])
-
-      {:error, _} ->
-        Logger.info([
-          "update_single_line: ",
-          encoded,
-          " pid=",
-          inspect(self()),
-          " arinc_ms=",
-          inspect(div(arinc_time, 1000))
-        ])
-    end
-
-    result
-  end
-
   def process(
         {:update_sign, [{station, zone}, top_line, bottom_line, duration, start_secs]},
         state

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -1,8 +1,4 @@
 defmodule PaEss.Updater do
-  @callback update_single_line(PaEss.text_id(), line_no, Content.Message.t(), duration, start) ::
-              {:ok, :sent} | {:error, :bad_status} | {:error, :post_error}
-            when line_no: String.t(), duration: integer(), start: integer() | :now
-
   @callback update_sign(PaEss.text_id(), top_line, bottom_line, duration, start) ::
               {:ok, :sent} | {:error, :bad_status} | {:error, :post_error}
             when top_line: Content.Message.t(),

--- a/test/message_queue_test.exs
+++ b/test/message_queue_test.exs
@@ -51,11 +51,9 @@ defmodule MessageQueueTest do
 
   describe "works through public interfaces" do
     {:ok, pid} = GenServer.start_link(MessageQueue, [])
-    {:ok, :sent} = MessageQueue.update_single_line(pid, 1, 2, 3, 4, 5)
     {:ok, :sent} = MessageQueue.update_sign(pid, 1, 2, 3, 4, 5)
     {:ok, :sent} = MessageQueue.send_audio(pid, 1, 2, 3, 4)
 
-    assert MessageQueue.get_message(pid) == {:update_single_line, [1, 2, 3, 4, 5]}
     assert MessageQueue.get_message(pid) == {:update_sign, [1, 2, 3, 4, 5]}
     assert MessageQueue.get_message(pid) == {:send_audio, [1, 2, 3, 4]}
     assert MessageQueue.get_message(pid) == nil

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -57,10 +57,6 @@ defmodule Signs.RealtimeTest do
   end
 
   defmodule FakeUpdater do
-    def update_single_line(id, line_no, msg, duration, start) do
-      send(self(), {:update_single_line, id, line_no, msg, duration, start})
-    end
-
     def update_sign(id, top_msg, bottom_msg, duration, start) do
       send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start})
     end
@@ -134,7 +130,6 @@ defmodule Signs.RealtimeTest do
 
       assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, sign)
       refute_received({:send_audio, _, _, _, _})
-      refute_received({:update_single_line, _, _, _, _, _})
       refute_received({:update_sign, _, _, _, _, _})
       assert sign.tick_content == 0
       assert sign.tick_read == 0

--- a/test/signs/utilities/updater_test.exs
+++ b/test/signs/utilities/updater_test.exs
@@ -11,10 +11,6 @@ defmodule Signs.Utilities.UpdaterTest do
   end
 
   defmodule FakeUpdater do
-    def update_single_line(id, line_no, msg, duration, start) do
-      send(self(), {:update_single_line, id, line_no, msg, duration, start})
-    end
-
     def update_sign(id, top_msg, bottom_msg, duration, start) do
       send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start})
     end
@@ -61,57 +57,8 @@ defmodule Signs.Utilities.UpdaterTest do
       sign = Updater.update_sign(@sign, same_top, same_bottom)
 
       refute_received({:send_audio, _, _, _, _})
-      refute_received({:update_single_line, _, _, _, _, _})
       refute_received({:update_sign, _, _, _, _, _})
       assert sign.tick_content == 1
-    end
-
-    test "does not change top line if it would be a count up from ARR to approaching" do
-      sign = %{@sign | current_content_top: {@src, %P{destination: :alewife, minutes: :arriving}}}
-      diff_top = {@src, %P{destination: :alewife, minutes: :approaching}}
-      same_bottom = {@src, %P{destination: :ashmont, minutes: 3}}
-
-      Updater.update_sign(sign, diff_top, same_bottom)
-
-      refute_received({:update_single_line, _id, "1", %P{minutes: :approaching}, _dur, _start})
-    end
-
-    test "does not change the top line if it would be a count up from approaching to 1 min" do
-      sign = %{
-        @sign
-        | current_content_top: {@src, %P{destination: :alewife, minutes: :approaching}}
-      }
-
-      diff_top = {@src, %P{destination: :alewife, minutes: 1}}
-      same_bottom = {@src, %P{destination: :ashmont, minutes: 3}}
-
-      Updater.update_sign(sign, diff_top, same_bottom)
-
-      refute_received({:update_single_line, _id, "1", %P{minutes: 1}, _dur, _start})
-    end
-
-    test "does not change top line if it would be a count up from 3 min to 4 min" do
-      sign = %{@sign | current_content_top: {@src, %P{destination: :alewife, minutes: 3}}}
-      diff_top = {@src, %P{destination: :alewife, minutes: 4}}
-      same_bottom = {@src, %P{destination: :ashmont, minutes: 3}}
-
-      Updater.update_sign(sign, diff_top, same_bottom)
-
-      refute_received({:update_single_line, _id, "1", %P{minutes: 4}, _dur, _start})
-    end
-
-    test "does not change bottom line if it would be a count up from ARR to approaching" do
-      sign = %{
-        @sign
-        | current_content_bottom: {@src, %P{destination: :ashmont, minutes: :arriving}}
-      }
-
-      same_top = {@src, %P{destination: :alewife, minutes: 4}}
-      diff_bottom = {@src, %P{destination: :ashmont, minutes: :approaching}}
-
-      Updater.update_sign(sign, same_top, diff_bottom)
-
-      refute_received({:update_single_line, _id, "2", %P{minutes: :approaching}, _dur, _start})
     end
 
     test "changes both lines if necessary" do
@@ -120,7 +67,6 @@ defmodule Signs.Utilities.UpdaterTest do
 
       sign = Updater.update_sign(@sign, diff_top, diff_bottom)
 
-      refute_received({:update_single_line, _, _, _, _, _})
       assert_received({:update_sign, _id, %P{minutes: 3}, %P{minutes: 2}, _dur, _start})
       assert sign.tick_content == 100
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Remove logic related to updating single lines for rail](https://app.asana.com/0/1201753694073608/1204460989217745/f)

Since we made messages always update both lines at the same time with #628 , we can remove all of the single line update logic.
