### PR TITLE
use direnv for local environment management

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,0 +1,23 @@
+# Host/IP and access key for the signs-ui instance that displays sign content. Optional. Leave unset
+# to skip updating signs-ui, or uncomment to use a locally running instance.
+#export SIGN_UI_URL=localhost:5000
+#export SIGN_UI_API_KEY=a6975e41192b888c
+
+# Path to the local sign config file when running locally. Optional. Leave unset to use an empty
+# config, or uncomment to use the output of a locally running signs-ui instance.
+#export SIGN_CONFIG_FILE=../signs_ui/priv/config.json
+
+# URL and access key for the V3 API. Required. Leaving the key unset will work, but access will be
+# subject to strict rate limits, so it is recommended to request a proper key.
+export API_V3_URL=https://api-dev-green.mbtace.com
+#export API_V3_KEY=
+
+# URL and auth key for the Chelsea bridge API. Required. These values can be found in the shared
+# 1Password vault, in the "Chelsea Street Bridge Application" entry, in fields `url` and `auth`.
+#export CHELSEA_BRIDGE_URL=
+#export CHELSEA_BRIDGE_AUTH=
+
+# URLs of the enhanced trip-update and vehicle-position feeds. Default to the real feed URLs if
+# not set here.
+#export TRIP_UPDATE_URL=
+#export VEHICLE_POSITIONS_URL=

--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 
 Here's a general overview of the realtime_signs application which should be helpful for getting oriented to how things work. Please keep this up to date -- if you change something major in the code (build process, renaming modules, significant functionality changes, new configuration, etc.) document it here!
 
+## Prerequisites
+
+* [asdf](https://asdf-vm.com/)
+* [direnv](https://direnv.net/)
+
 ## Development
 
 * Run `asdf install` from the repository root.
 * `mix deps.get` to fetch dependencies.
 * At this point you should be able to run `mix test` and get a clean build.
-* To start the server, run `mix run --no-halt`. See "relevant environment variables" below for parameters you might want to pass to the server.
+* Copy `.envrc.template` to `.envrc`, then edit `.envrc` and make sure all required environment variables are set. When finished, run `direnv allow` to activate them.
+* To start the server, run `mix run --no-halt`.
 
 ### Developing locally with [signs_ui](https://github.com/mbta/signs_ui)
 
 First, ensure you have a basic working environment as described above, and in the signs_ui README.
 1. Start signs_ui and tell it what API key to accept: `MESSAGES_API_KEYS=realtime_signs:a6975e41192b888c NODE_ENV=development mix run --no-halt`. The key is arbitrary but it must match what you provide in the next step.
-2. Start realtime_signs, and provide the local URL and API key, as well as the location of the config file: `SIGN_UI_URL=localhost:5000 SIGN_UI_API_KEY=a6975e41192b888c SIGN_CONFIG_FILE=../signs_ui/priv/config.json mix run --no-halt`
-3. Open up http://localhost:5000 and you should see the signs data being populated by your local app.
+2. Edit `.envrc` and ensure that `SIGN_UI_URL`, `SIGN_UI_API_KEY`, and `SIGN_CONFIG_FILE` are configured to point to the local signs_ui.
+3. Start realtime_signs.
+4. Open up http://localhost:5000 and you should see the signs data being populated by your local app.
 
 ### Running locally in a docker container
 If you need to run realtime signs in a local docker container, there are a few extra steps you'll need to take.
@@ -25,17 +32,8 @@ If you need to run realtime signs in a local docker container, there are a few e
 4. Run the image in a container with `docker run --env-file env.list [IMAG TAG]`
 
 ## Environment variables
-Environment variables are stored in AWS Secrets Manager. If a new env variable needs to be added, Secrets Manager will need to be updated and then the application will need to be re-deployed.
 
-### Relevant Environment Variables
-
-* `SIGN_HEAD_END_HOST`: hostname or IP of the head-end server that drives the actual physical signs, which `realtime_signs` pushes data to. Leave empty to skip the physical sign update.
-* `SIGN_UI_URL`: hostname or IP of the instance of `signs_ui` to which `realtime_signs` pushes data. Leave empty to skip updating the UI.
-* `SIGN_UI_API_KEY`: API key used when making requests to `signs_ui`. Not set by default.
-* `TRIP_UPDATE_URL` and `VEHICLE_POSITIONS_URL`: URLs of the enhanced trip-update and vehicle-position feeds. Default to the real feed URLs.
-* `API_V3_KEY` and `API_V3_URL`: Access key and URL for V3 API. Default respectively to a blank string and the URL of the dev-green API instance.
-* `CHELSEA_BRIDGE_URL` and `CHELSEA_BRIDGE_AUTH`: URL and auth key for the Chelsea bridge API. These values can be found in the shared 1Password vault, in the "Chelsea Street Bridge Application" entry, in fields `url` and `auth`.
-* `NUMBER_OF_HTTP_UPDATERS`: Number of `PaEss.HttpUpdater` processes that should run. These are responsible for posting updates to the PA/ESS head-end server, so this number is also the number of concurrent HTTP requests to that server.
+The application needs several environment variables to access external services. See `.envrc.template` for documentation. When running locally, these variables are provided by `direnv`. In deployed environments, they are provided by AWS Secrets Manager. When adding new environment variables, make sure to add them to both locations, as appropriate.
 
 ## Deploying
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -13,7 +13,7 @@ if config_env() != :test do
     vehicle_positions_url: System.get_env("VEHICLE_POSITIONS_URL", "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/VehiclePositions_enhanced.json"),
     s3_bucket: System.get_env("SIGNS_S3_BUCKET"),
     s3_path: System.get_env("SIGNS_S3_PATH"),
-    api_v3_url: System.get_env("API_V3_URL", "https://api-dev-green.mbtace.com"),
+    api_v3_url: System.get_env("API_V3_URL"),
     api_v3_key: System.get_env("API_V3_KEY"),
     chelsea_bridge_url: System.get_env("CHELSEA_BRIDGE_URL"),
     chelsea_bridge_auth: System.get_env("CHELSEA_BRIDGE_AUTH"),


### PR DESCRIPTION
#### Summary of changes

This updates the documentation to specify using direnv to manage environment variables locally. This gives us a convenient way to include detailed inline documentation, and to suggest some values for wiring up the local environment without hard-coding them. Notes:
* Removed documentation for `SIGN_HEAD_END_HOST`, since this is handled by the config module now.
* Removed documentation for `NUMBER_OF_HTTP_UPDATERS`, on the premise that it's almost never necessary to modify this in practice.
* Removed the default value for `API_V3_URL` in `runtime.exs`, for consistency. Confirmed that both deployed environments will supply this via environment variables.