### PR TITLE
centralize and deduplicate prediction fetching

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -7,12 +7,13 @@ defmodule Signs.Utilities.Messages do
   alias Content.Message.Alert
 
   @spec get_messages(
+          Signs.Realtime.predictions(),
           Signs.Realtime.t(),
           Engine.Config.sign_config(),
           DateTime.t(),
           Engine.Alerts.Fetcher.stop_status()
         ) :: Signs.Realtime.sign_messages()
-  def get_messages(sign, sign_config, current_time, alert_status) do
+  def get_messages(predictions, sign, sign_config, current_time, alert_status) do
     cond do
       match?({:static_text, {_, _}}, sign_config) ->
         {:static_text, {line1, line2}} = sign_config
@@ -26,7 +27,7 @@ defmodule Signs.Utilities.Messages do
         get_headway_or_alert_messages(sign, current_time, alert_status)
 
       true ->
-        case Signs.Utilities.Predictions.get_messages(sign) do
+        case Signs.Utilities.Predictions.get_messages(predictions, sign) do
           {%Content.Message.Empty{}, %Content.Message.Empty{}} ->
             get_headway_or_alert_messages(sign, current_time, alert_status)
 

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -13,57 +13,53 @@ defmodule Signs.Utilities.MessagesTest do
   end
 
   defmodule FakePredictions do
-    def for_stop("1", 0) do
-      [
-        %Predictions.Prediction{
-          stop_id: "1",
-          direction_id: 0,
-          route_id: "Red",
-          stopped?: false,
-          stops_away: 1,
-          destination_stop_id: "70093",
-          seconds_until_arrival: 120,
-          seconds_until_departure: 180
-        },
-        %Predictions.Prediction{
-          stop_id: "1",
-          direction_id: 0,
-          route_id: "Red",
-          stopped?: false,
-          stops_away: 1,
-          destination_stop_id: "70093",
-          seconds_until_arrival: 240,
-          seconds_until_departure: 300
-        }
-      ]
-    end
-
-    def for_stop("no_departures", 0) do
-      [
-        %Predictions.Prediction{
-          stop_id: "1",
-          direction_id: 0,
-          route_id: "Red",
-          stopped?: false,
-          stops_away: 1,
-          destination_stop_id: "70093",
-          seconds_until_arrival: 120
-        },
-        %Predictions.Prediction{
-          stop_id: "1",
-          direction_id: 0,
-          route_id: "Red",
-          stopped?: false,
-          stops_away: 1,
-          destination_stop_id: "70093",
-          seconds_until_arrival: 240
-        }
-      ]
-    end
-
     def for_stop(_stop_id, _direction_id), do: []
     def stopped_at?(_stop_id), do: false
   end
+
+  @predictions [
+    %Predictions.Prediction{
+      stop_id: "1",
+      direction_id: 0,
+      route_id: "Red",
+      stopped?: false,
+      stops_away: 1,
+      destination_stop_id: "70093",
+      seconds_until_arrival: 120,
+      seconds_until_departure: 180
+    },
+    %Predictions.Prediction{
+      stop_id: "1",
+      direction_id: 0,
+      route_id: "Red",
+      stopped?: false,
+      stops_away: 1,
+      destination_stop_id: "70093",
+      seconds_until_arrival: 240,
+      seconds_until_departure: 300
+    }
+  ]
+
+  @nd_predictions [
+    %Predictions.Prediction{
+      stop_id: "1",
+      direction_id: 0,
+      route_id: "Red",
+      stopped?: false,
+      stops_away: 1,
+      destination_stop_id: "70093",
+      seconds_until_arrival: 120
+    },
+    %Predictions.Prediction{
+      stop_id: "1",
+      direction_id: 0,
+      route_id: "Red",
+      stopped?: false,
+      stops_away: 1,
+      destination_stop_id: "70093",
+      seconds_until_arrival: 240
+    }
+  ]
 
   defmodule FakeDepartures do
     @test_departure_time Timex.to_datetime(~N[2019-08-29 15:41:31], "America/New_York")
@@ -119,7 +115,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = {:static_text, {"Test message", "Please ignore"}}
       alert_status = :suspension_closed_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Custom.new("Test message", :top),
                 Content.Message.Custom.new("Please ignore", :bottom)}
     end
@@ -129,7 +125,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :off
       alert_status = :none
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Empty.new(), Content.Message.Empty.new()}
     end
 
@@ -146,7 +142,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_transfer_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Empty.new(), Content.Message.Empty.new()}
     end
 
@@ -163,7 +159,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :suspension_transfer_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages([], sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Empty.new(), Content.Message.Empty.new()}
     end
 
@@ -180,7 +176,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_transfer_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Empty.new(), Content.Message.Empty.new()}
     end
 
@@ -189,7 +185,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_transfer_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {
                  %Content.Message.Predictions{
                    destination: :ashmont,
@@ -227,7 +223,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_closed_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {%Content.Message.Alert.NoService{}, %Content.Message.Alert.UseShuttleBus{}}
     end
 
@@ -245,7 +241,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_closed_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {%Content.Message.Alert.NoService{}, Content.Message.Empty.new()}
     end
 
@@ -262,7 +258,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :shuttles_closed_station
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {
                  %Content.Message.Predictions{
                    destination: :ashmont,
@@ -300,7 +296,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :suspension_closed_station
       sign_config = :auto
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {%Content.Message.Alert.NoService{}, Content.Message.Empty.new()}
     end
 
@@ -317,7 +313,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :station_closure
       sign_config = :auto
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@nd_predictions, sign, sign_config, Timex.now(), alert_status) ==
                {%Content.Message.Alert.NoService{}, Content.Message.Empty.new()}
     end
 
@@ -334,7 +330,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :suspension_closed_station
       sign_config = :auto
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {
                  %Content.Message.Predictions{
                    destination: :ashmont,
@@ -364,7 +360,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :none
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status) ==
                {
                  %Content.Message.Predictions{
                    destination: :ashmont,
@@ -405,7 +401,7 @@ defmodule Signs.Utilities.MessagesTest do
 
       current_time = Timex.shift(FakeDepartures.test_departure_time(), minutes: 5)
 
-      assert Messages.get_messages(sign, sign_config, current_time, alert_status) ==
+      assert Messages.get_messages([], sign, sign_config, current_time, alert_status) ==
                {
                  %Content.Message.Headways.Top{
                    destination: :mattapan,
@@ -431,7 +427,7 @@ defmodule Signs.Utilities.MessagesTest do
       sign_config = :auto
       alert_status = :none
 
-      assert Messages.get_messages(sign, sign_config, Timex.now(), alert_status) ==
+      assert Messages.get_messages([], sign, sign_config, Timex.now(), alert_status) ==
                {Content.Message.Empty.new(), Content.Message.Empty.new()}
     end
 
@@ -451,7 +447,7 @@ defmodule Signs.Utilities.MessagesTest do
                  vehicle_type: :train
                },
                %Content.Message.Headways.Bottom{range: {8, 11}}
-             } = Messages.get_messages(sign, sign_config, Timex.now(), alert_status)
+             } = Messages.get_messages([], sign, sign_config, Timex.now(), alert_status)
     end
 
     test "when sign is forced into headway mode but alerts are present, alert takes precedence" do
@@ -460,7 +456,7 @@ defmodule Signs.Utilities.MessagesTest do
       alert_status = :station_closure
 
       assert {%Content.Message.Alert.NoService{}, %Content.Message.Empty{}} =
-               Messages.get_messages(sign, sign_config, Timex.now(), alert_status)
+               Messages.get_messages(@predictions, sign, sign_config, Timex.now(), alert_status)
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

This extracts the rail prediction fetching to the top of the sign loop, and passes the predictions down to code paths that need them. This has two benefits:
* The data flow is clearer, due to centralizing access to external data sources.
* The predictions are only fetched once (rather than twice), so it's a bit more efficient.