### PR TITLE
default signs configs to off

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -32,7 +32,7 @@ defmodule Engine.Config do
   def sign_config(table_name \\ @table_signs, sign_id) do
     case :ets.lookup(table_name, sign_id) do
       [{^sign_id, config}] -> config
-      _ -> :auto
+      _ -> :off
     end
   end
 
@@ -45,8 +45,8 @@ defmodule Engine.Config do
   @spec chelsea_bridge_config(:ets.tab()) :: :off | :auto
   def chelsea_bridge_config(table_name \\ @table_chelsea_bridge) do
     case :ets.lookup(table_name, :status) do
-      [{_, "off"}] -> :off
-      _ -> :auto
+      [{_, "auto"}] -> :auto
+      _ -> :off
     end
   end
 
@@ -182,7 +182,7 @@ defmodule Engine.Config do
         :headway
 
       true ->
-        :auto
+        :off
     end
   end
 

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -17,11 +17,11 @@ defmodule Engine.ConfigTest do
       assert Engine.Config.sign_config("chelsea_outbound") == :off
     end
 
-    test "is auto when the sign is unspecified" do
+    test "is off when the sign is unspecified" do
       Engine.Config.update()
 
       Process.sleep(50)
-      assert Engine.Config.sign_config("unspecified_sign") == :auto
+      assert Engine.Config.sign_config("unspecified_sign") == :off
     end
 
     test "returns custom text when it's not expired" do


### PR DESCRIPTION
#### Summary of changes

This changes the default sign behavior from 'auto' to 'off' if no explicit config is present. This matches what we show in signs_ui in this case, and provides a more conservative approach to adding new signs in the future. Also applies to the Chelsea bridge config.