### PR TITLE
Increase page duration to 5 seconds

### DIFF
--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -18,12 +18,12 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
            PaEss.Utilities.destination_to_sign_string(destination),
            "no service",
            @default_page_width
-         ), 4},
+         ), 5},
         {Content.Utilities.width_padded_string(
            PaEss.Utilities.destination_to_sign_string(destination),
            "use shuttle",
            @default_page_width
-         ), 4}
+         ), 5}
       ]
     end
   end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -13,8 +13,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {"Trains every", 4},
-        {format_paging_headway_range(range), 4}
+        {"Trains every", 5},
+        {format_paging_headway_range(range), 5}
       ]
     end
 
@@ -23,8 +23,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {destination_trains_every_string(destination), 4},
-        {destination_range_string(destination, range), 4}
+        {destination_trains_every_string(destination), 5},
+        {destination_range_string(destination, range), 5}
       ]
     end
 

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -184,8 +184,8 @@ defmodule Content.Message.Predictions do
 
         track_number ->
           [
-            {Content.Utilities.width_padded_string(headsign, duration_string, width), 4},
-            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 4}
+            {Content.Utilities.width_padded_string(headsign, duration_string, width), 5},
+            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 5}
           ]
 
         true ->

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -55,9 +55,9 @@ defmodule Content.Message.StoppedTrain do
       stop_word = if n == 1, do: "stop", else: "stops"
 
       [
-        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 4},
-        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 4},
-        {Content.Utilities.width_padded_string(headsign, "away", 18), 4}
+        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 5},
+        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 5},
+        {Content.Utilities.width_padded_string(headsign, "away", 18), 5}
       ]
     end
   end

--- a/test/content/messages/alert/no_service_use_shuttle_test.exs
+++ b/test/content/messages/alert/no_service_use_shuttle_test.exs
@@ -6,8 +6,8 @@ defmodule Content.Message.Alert.NoServiceUseShuttleTest do
       msg = %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
 
       assert Content.Message.to_string(msg) == [
-               {"Medfd/Tufts   no service", 4},
-               {"Medfd/Tufts  use shuttle", 4}
+               {"Medfd/Tufts   no service", 5},
+               {"Medfd/Tufts  use shuttle", 5}
              ]
     end
   end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -7,8 +7,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: :heath_street,
                range: {5, 7}
              }) == [
-               {"Heath St    trains every", 4},
-               {"Heath St      5 to 7 min", 4}
+               {"Heath St    trains every", 5},
+               {"Heath St      5 to 7 min", 5}
              ]
     end
 
@@ -17,8 +17,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: nil,
                range: {5, 7}
              }) == [
-               {"Trains every", 4},
-               {"5 to 7 min", 4}
+               {"Trains every", 5},
+               {"5 to 7 min", 5}
              ]
     end
   end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -401,8 +401,8 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == [
-               {"Oak Grove    2 min", 4},
-               {"Oak Grove    Trk 2", 4}
+               {"Oak Grove    2 min", 5},
+               {"Oak Grove    Trk 2", 5}
              ]
     end
 

--- a/test/content/messages/stopped_train_test.exs
+++ b/test/content/messages/stopped_train_test.exs
@@ -7,9 +7,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 4},
-                 {"Braintree  2 stops", 4},
-                 {"Braintree     away", 4}
+                 {"Braintree  Stopped", 5},
+                 {"Braintree  2 stops", 5},
+                 {"Braintree     away", 5}
                ]
     end
 
@@ -18,9 +18,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 4},
-                 {"Braintree   1 stop", 4},
-                 {"Braintree     away", 4}
+                 {"Braintree  Stopped", 5},
+                 {"Braintree   1 stop", 5},
+                 {"Braintree     away", 5}
                ]
     end
   end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -273,7 +273,7 @@ defmodule PaEss.HttpUpdaterTest do
       msg = %Content.Message.StoppedTrain{destination: :ashmont, stops_away: 3}
 
       assert PaEss.HttpUpdater.to_command(msg, 55, :now, "n", 1) ==
-               "e55~n1-\"Ashmont       away\".3-\"Ashmont    Stopped\".3-\"Ashmont    3 stops\".3"
+               "e55~n1-\"Ashmont       away\".4-\"Ashmont    Stopped\".4-\"Ashmont    3 stops\".4"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ARINC investigates crashes seemingly caused by MZ dual-paging](https://app.asana.com/0/1201753694073608/1204553377557896/f)

This PR increases page durations to 5 seconds from 4 for rail-related paging messages. This is an effort to prevent signs from crashing when both lines of the sign are paging at the same time.  In the past when the JFK/UMass sign exhibited similar behavior, increasing the page duration stabilized the sign.

If we observe that signs still crash when the paging is at a 5 second interval, we can try 6. After 6 though, I feel that the pages may be getting too long and we'd probably want to consider other solutions.
