### PR TITLE
Increase page durations to 6 seconds

### DIFF
--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -18,12 +18,12 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
            PaEss.Utilities.destination_to_sign_string(destination),
            "no service",
            @default_page_width
-         ), 5},
+         ), 6},
         {Content.Utilities.width_padded_string(
            PaEss.Utilities.destination_to_sign_string(destination),
            "use shuttle",
            @default_page_width
-         ), 5}
+         ), 6}
       ]
     end
   end

--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -18,12 +18,12 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
            PaEss.Utilities.destination_to_sign_string(destination),
            "no service",
            @default_page_width
-         ), 4},
+         ), 5},
         {Content.Utilities.width_padded_string(
            PaEss.Utilities.destination_to_sign_string(destination),
            "use shuttle",
            @default_page_width
-         ), 4}
+         ), 5}
       ]
     end
   end

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -13,8 +13,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {"Trains every", 5},
-        {format_paging_headway_range(range), 5}
+        {"Trains every", 6},
+        {format_paging_headway_range(range), 6}
       ]
     end
 
@@ -23,8 +23,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {destination_trains_every_string(destination), 5},
-        {destination_range_string(destination, range), 5}
+        {destination_trains_every_string(destination), 6},
+        {destination_range_string(destination, range), 6}
       ]
     end
 

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -13,8 +13,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {"Trains every", 4},
-        {format_paging_headway_range(range), 4}
+        {"Trains every", 5},
+        {format_paging_headway_range(range), 5}
       ]
     end
 
@@ -23,8 +23,8 @@ defmodule Content.Message.Headways.Paging do
           range: range
         }) do
       [
-        {destination_trains_every_string(destination), 4},
-        {destination_range_string(destination, range), 4}
+        {destination_trains_every_string(destination), 5},
+        {destination_range_string(destination, range), 5}
       ]
     end
 

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -184,8 +184,8 @@ defmodule Content.Message.Predictions do
 
         track_number ->
           [
-            {Content.Utilities.width_padded_string(headsign, duration_string, width), 4},
-            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 4}
+            {Content.Utilities.width_padded_string(headsign, duration_string, width), 5},
+            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 5}
           ]
 
         true ->

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -184,8 +184,8 @@ defmodule Content.Message.Predictions do
 
         track_number ->
           [
-            {Content.Utilities.width_padded_string(headsign, duration_string, width), 5},
-            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 5}
+            {Content.Utilities.width_padded_string(headsign, duration_string, width), 6},
+            {Content.Utilities.width_padded_string(headsign, "Trk #{track_number}", width), 6}
           ]
 
         true ->

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -55,9 +55,9 @@ defmodule Content.Message.StoppedTrain do
       stop_word = if n == 1, do: "stop", else: "stops"
 
       [
-        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 4},
-        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 4},
-        {Content.Utilities.width_padded_string(headsign, "away", 18), 4}
+        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 5},
+        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 5},
+        {Content.Utilities.width_padded_string(headsign, "away", 18), 5}
       ]
     end
   end

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -55,9 +55,9 @@ defmodule Content.Message.StoppedTrain do
       stop_word = if n == 1, do: "stop", else: "stops"
 
       [
-        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 5},
-        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 5},
-        {Content.Utilities.width_padded_string(headsign, "away", 18), 5}
+        {Content.Utilities.width_padded_string(headsign, "Stopped", 18), 6},
+        {Content.Utilities.width_padded_string(headsign, "#{n} #{stop_word}", 18), 6},
+        {Content.Utilities.width_padded_string(headsign, "away", 18), 6}
       ]
     end
   end

--- a/lib/headway/headway_display.ex
+++ b/lib/headway/headway_display.ex
@@ -133,7 +133,7 @@ defmodule Headway.HeadwayDisplay do
   end
 
   def format_bottom(%Content.Message.Headways.Bottom{prev_departure_mins: minutes, range: range}) do
-    [{format_headway_range(range), 5}, {"Departed #{minutes} min ago", 5}]
+    [{format_headway_range(range), 6}, {"Departed #{minutes} min ago", 6}]
   end
 
   @spec max_headway(headway_range) :: non_neg_integer | nil

--- a/test/content/messages/alert/no_service_use_shuttle_test.exs
+++ b/test/content/messages/alert/no_service_use_shuttle_test.exs
@@ -6,8 +6,8 @@ defmodule Content.Message.Alert.NoServiceUseShuttleTest do
       msg = %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
 
       assert Content.Message.to_string(msg) == [
-               {"Medfd/Tufts   no service", 4},
-               {"Medfd/Tufts  use shuttle", 4}
+               {"Medfd/Tufts   no service", 5},
+               {"Medfd/Tufts  use shuttle", 5}
              ]
     end
   end

--- a/test/content/messages/alert/no_service_use_shuttle_test.exs
+++ b/test/content/messages/alert/no_service_use_shuttle_test.exs
@@ -6,8 +6,8 @@ defmodule Content.Message.Alert.NoServiceUseShuttleTest do
       msg = %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
 
       assert Content.Message.to_string(msg) == [
-               {"Medfd/Tufts   no service", 5},
-               {"Medfd/Tufts  use shuttle", 5}
+               {"Medfd/Tufts   no service", 6},
+               {"Medfd/Tufts  use shuttle", 6}
              ]
     end
   end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -7,8 +7,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: :heath_street,
                range: {5, 7}
              }) == [
-               {"Heath St    trains every", 4},
-               {"Heath St      5 to 7 min", 4}
+               {"Heath St    trains every", 5},
+               {"Heath St      5 to 7 min", 5}
              ]
     end
 
@@ -17,8 +17,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: nil,
                range: {5, 7}
              }) == [
-               {"Trains every", 4},
-               {"5 to 7 min", 4}
+               {"Trains every", 5},
+               {"5 to 7 min", 5}
              ]
     end
   end

--- a/test/content/messages/headways/paging_test.exs
+++ b/test/content/messages/headways/paging_test.exs
@@ -7,8 +7,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: :heath_street,
                range: {5, 7}
              }) == [
-               {"Heath St    trains every", 5},
-               {"Heath St      5 to 7 min", 5}
+               {"Heath St    trains every", 6},
+               {"Heath St      5 to 7 min", 6}
              ]
     end
 
@@ -17,8 +17,8 @@ defmodule Content.Message.Headways.PagingTest do
                destination: nil,
                range: {5, 7}
              }) == [
-               {"Trains every", 5},
-               {"5 to 7 min", 5}
+               {"Trains every", 6},
+               {"5 to 7 min", 6}
              ]
     end
   end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -401,8 +401,8 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == [
-               {"Oak Grove    2 min", 5},
-               {"Oak Grove    Trk 2", 5}
+               {"Oak Grove    2 min", 6},
+               {"Oak Grove    Trk 2", 6}
              ]
     end
 

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -401,8 +401,8 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.terminal(prediction)
 
       assert Content.Message.to_string(msg) == [
-               {"Oak Grove    2 min", 4},
-               {"Oak Grove    Trk 2", 4}
+               {"Oak Grove    2 min", 5},
+               {"Oak Grove    Trk 2", 5}
              ]
     end
 

--- a/test/content/messages/stopped_train_test.exs
+++ b/test/content/messages/stopped_train_test.exs
@@ -7,9 +7,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 5},
-                 {"Braintree  2 stops", 5},
-                 {"Braintree     away", 5}
+                 {"Braintree  Stopped", 6},
+                 {"Braintree  2 stops", 6},
+                 {"Braintree     away", 6}
                ]
     end
 
@@ -18,9 +18,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 5},
-                 {"Braintree   1 stop", 5},
-                 {"Braintree     away", 5}
+                 {"Braintree  Stopped", 6},
+                 {"Braintree   1 stop", 6},
+                 {"Braintree     away", 6}
                ]
     end
   end

--- a/test/content/messages/stopped_train_test.exs
+++ b/test/content/messages/stopped_train_test.exs
@@ -7,9 +7,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 4},
-                 {"Braintree  2 stops", 4},
-                 {"Braintree     away", 4}
+                 {"Braintree  Stopped", 5},
+                 {"Braintree  2 stops", 5},
+                 {"Braintree     away", 5}
                ]
     end
 
@@ -18,9 +18,9 @@ defmodule Content.Message.StoppedTrainTest do
 
       assert Content.Message.to_string(msg) ==
                [
-                 {"Braintree  Stopped", 4},
-                 {"Braintree   1 stop", 4},
-                 {"Braintree     away", 4}
+                 {"Braintree  Stopped", 5},
+                 {"Braintree   1 stop", 5},
+                 {"Braintree     away", 5}
                ]
     end
   end

--- a/test/headway/headway_display_test.exs
+++ b/test/headway/headway_display_test.exs
@@ -328,7 +328,7 @@ defmodule Headway.HeadwayDisplayTest do
   describe "format_bottom/2" do
     test "shows how long ago the last departure was" do
       assert format_bottom(%Content.Message.Headways.Bottom{prev_departure_mins: 5, range: {1, 5}}) ==
-               [{"Every 1 to 5 min", 5}, {"Departed 5 min ago", 5}]
+               [{"Every 1 to 5 min", 6}, {"Departed 5 min ago", 6}]
     end
 
     test "when last departure is 0 minutes, does not show the last departure" do

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -273,7 +273,7 @@ defmodule PaEss.HttpUpdaterTest do
       msg = %Content.Message.StoppedTrain{destination: :ashmont, stops_away: 3}
 
       assert PaEss.HttpUpdater.to_command(msg, 55, :now, "n", 1) ==
-               "e55~n1-\"Ashmont       away\".4-\"Ashmont    Stopped\".4-\"Ashmont    3 stops\".4"
+               "e55~n1-\"Ashmont       away\".5-\"Ashmont    Stopped\".5-\"Ashmont    3 stops\".5"
     end
   end
 

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -273,7 +273,7 @@ defmodule PaEss.HttpUpdaterTest do
       msg = %Content.Message.StoppedTrain{destination: :ashmont, stops_away: 3}
 
       assert PaEss.HttpUpdater.to_command(msg, 55, :now, "n", 1) ==
-               "e55~n1-\"Ashmont       away\".3-\"Ashmont    Stopped\".3-\"Ashmont    3 stops\".3"
+               "e55~n1-\"Ashmont       away\".4-\"Ashmont    Stopped\".4-\"Ashmont    3 stops\".4"
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [ARINC investigates crashes seemingly caused by MZ dual-paging](https://app.asana.com/0/1201753694073608/1204553377557896/f)

Increase page durations again to 6 seconds to see if this stabilizes double line paging for rail signs.

Now that pages are getting pretty long, we should stop increasing the durations and rely on ARINC addressing the issue at the SCU level if this doesn't work.