### PR TITLE
Add sign id to logs and make content more human-readable

### DIFF
--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -35,16 +35,16 @@ defmodule MessageQueue do
   end
 
   @impl PaEss.Updater
-  def update_sign(pid \\ __MODULE__, text_id, top_line, bottom_line, duration, start) do
+  def update_sign(pid \\ __MODULE__, text_id, top_line, bottom_line, duration, start, sign_id) do
     GenServer.call(
       pid,
-      {:queue_update, {:update_sign, [text_id, top_line, bottom_line, duration, start]}}
+      {:queue_update, {:update_sign, [text_id, top_line, bottom_line, duration, start, sign_id]}}
     )
   end
 
   @impl PaEss.Updater
-  def send_audio(pid \\ __MODULE__, audio_id, audios, priority, timeout) do
-    GenServer.call(pid, {:queue_update, {:send_audio, [audio_id, audios, priority, timeout]}})
+  def send_audio(pid \\ __MODULE__, audio_id, audios, priority, timeout, sign_id) do
+    GenServer.call(pid, {:queue_update, {:send_audio, [audio_id, audios, priority, timeout, sign_id]}})
   end
 
   @spec get_message(GenServer.server()) :: message() | nil

--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -44,7 +44,10 @@ defmodule MessageQueue do
 
   @impl PaEss.Updater
   def send_audio(pid \\ __MODULE__, audio_id, audios, priority, timeout, sign_id) do
-    GenServer.call(pid, {:queue_update, {:send_audio, [audio_id, audios, priority, timeout, sign_id]}})
+    GenServer.call(
+      pid,
+      {:queue_update, {:send_audio, [audio_id, audios, priority, timeout, sign_id]}}
+    )
   end
 
   @spec get_message(GenServer.server()) :: message() | nil

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -138,7 +138,15 @@ defmodule PaEss.HttpUpdater do
     |> List.last()
   end
 
-  @spec process_send_audio(String.t(), [String.t()], Content.Audio.t(), integer(), integer(), String.t(), t()) ::
+  @spec process_send_audio(
+          String.t(),
+          [String.t()],
+          Content.Audio.t(),
+          integer(),
+          integer(),
+          String.t(),
+          t()
+        ) ::
           post_result()
   defp process_send_audio(station, zones, audio, priority, timeout, sign_id, state) do
     case Content.Audio.to_params(audio) do

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -1,14 +1,16 @@
 defmodule PaEss.Updater do
-  @callback update_sign(PaEss.text_id(), top_line, bottom_line, duration, start) ::
+  @callback update_sign(PaEss.text_id(), top_line, bottom_line, duration, start, sign_id) ::
               {:ok, :sent} | {:error, :bad_status} | {:error, :post_error}
             when top_line: Content.Message.t(),
                  bottom_line: Content.Message.t(),
                  duration: integer(),
-                 start: integer() | :now
+                 start: integer() | :now,
+                 sign_id: String.t()
 
-  @callback send_audio(PaEss.audio_id(), audios, priority, timeout) ::
+  @callback send_audio(PaEss.audio_id(), audios, priority, timeout, sign_id) ::
               {:ok, :sent} | {:error, any()}
             when priority: integer(),
                  timeout: integer(),
-                 audios: [Content.Audio.t()]
+                 audios: [Content.Audio.t()],
+                 sign_id: String.t()
 end

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -191,7 +191,7 @@ defmodule Signs.Bus do
     state
     |> then(fn state ->
       if should_update?({top, bottom}, current_time, state) do
-        sign_updater.update_sign({pa_ess_loc, text_zone}, top, bottom, 180, :now)
+        sign_updater.update_sign({pa_ess_loc, text_zone}, top, bottom, 180, :now, state.id)
         %{state | current_messages: {top, bottom}, last_update: current_time}
       else
         state
@@ -660,7 +660,7 @@ defmodule Signs.Bus do
     %{pa_ess_loc: pa_ess_loc, audio_zones: audio_zones, sign_updater: sign_updater} = state
 
     if audios != [] && audio_zones != [] do
-      sign_updater.send_audio({pa_ess_loc, audio_zones}, audios, 5, 180)
+      sign_updater.send_audio({pa_ess_loc, audio_zones}, audios, 5, 180, state.id)
     end
   end
 end

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -172,7 +172,7 @@ defmodule Signs.Realtime do
     Utilities.Predictions.get_passthrough_train_audio(predictions)
     |> Enum.reduce(sign, fn audio, sign ->
       if audio.trip_id not in sign.announced_passthroughs do
-        sign.sign_updater.send_audio(sign.audio_id, [audio], 5, 60)
+        sign.sign_updater.send_audio(sign.audio_id, [audio], 5, 60, sign.id)
 
         update_in(sign.announced_passthroughs, fn list ->
           Enum.take([audio.trip_id | list], @announced_history_length)
@@ -190,7 +190,8 @@ defmodule Signs.Realtime do
       sign.current_content_top,
       sign.current_content_bottom,
       sign.expiration_seconds + 15,
-      :now
+      :now,
+      sign.id
     )
 
     %{sign | tick_content: sign.expiration_seconds}

--- a/lib/signs/utilities/reader.ex
+++ b/lib/signs/utilities/reader.ex
@@ -105,7 +105,7 @@ defmodule Signs.Utilities.Reader do
         {false, sign}
 
       {audios, sign} ->
-        sign.sign_updater.send_audio(sign.audio_id, audios, 5, 60)
+        sign.sign_updater.send_audio(sign.audio_id, audios, 5, 60, sign.id)
         {true, sign}
     end
   end

--- a/lib/signs/utilities/updater.ex
+++ b/lib/signs/utilities/updater.ex
@@ -48,7 +48,8 @@ defmodule Signs.Utilities.Updater do
           top_msg,
           bottom_msg,
           sign.expiration_seconds + 15,
-          :now
+          :now,
+          sign.id
         )
 
         %{

--- a/test/message_queue_test.exs
+++ b/test/message_queue_test.exs
@@ -51,11 +51,11 @@ defmodule MessageQueueTest do
 
   describe "works through public interfaces" do
     {:ok, pid} = GenServer.start_link(MessageQueue, [])
-    {:ok, :sent} = MessageQueue.update_sign(pid, 1, 2, 3, 4, 5)
-    {:ok, :sent} = MessageQueue.send_audio(pid, 1, 2, 3, 4)
+    {:ok, :sent} = MessageQueue.update_sign(pid, 1, 2, 3, 4, 5, "sign_id")
+    {:ok, :sent} = MessageQueue.send_audio(pid, 1, 2, 3, 4, "sign_id")
 
-    assert MessageQueue.get_message(pid) == {:update_sign, [1, 2, 3, 4, 5]}
-    assert MessageQueue.get_message(pid) == {:send_audio, [1, 2, 3, 4]}
+    assert MessageQueue.get_message(pid) == {:update_sign, [1, 2, 3, 4, 5, "sign_id"]}
+    assert MessageQueue.get_message(pid) == {:send_audio, [1, 2, 3, 4, "sign_id"]}
     assert MessageQueue.get_message(pid) == nil
   end
 end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -1,6 +1,7 @@
 defmodule Fake.MessageQueue do
   def get_message do
-    {:update_sign, [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now, "sign_id"]}
+    {:update_sign,
+     [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now, "sign_id"]}
   end
 end
 
@@ -69,7 +70,14 @@ defmodule PaEss.HttpUpdaterTest do
 
       assert PaEss.HttpUpdater.process(
                {:update_sign,
-                [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now, "sign_id"]},
+                [
+                  {"SBOX", "c"},
+                  %Content.Message.Empty{},
+                  %Content.Message.Empty{},
+                  60,
+                  :now,
+                  "sign_id"
+                ]},
                state
              ) == {:ok, :sent}
     end
@@ -80,7 +88,10 @@ defmodule PaEss.HttpUpdaterTest do
       audio = %Fake.UnknownAudio{}
 
       assert {:ok, :no_audio} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"GKEN", ["m"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"GKEN", ["m"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
   end
 
@@ -116,7 +127,10 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBSQ", ["m"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"SBSQ", ["m"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
 
     test "Buses to Chelsea, in Spanish" do
@@ -129,7 +143,10 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBOX", ["e"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"SBOX", ["e"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
 
     test "Next train to Ashmont arrives in 4 minutes" do
@@ -144,7 +161,10 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["n"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"MCED", ["n"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
 
     test "Train to Mattapan arriving" do
@@ -155,7 +175,10 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["s"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"MCED", ["s"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
 
     test "Train to Ashmont arriving" do
@@ -167,7 +190,10 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, "sign_id"]}, state)
+               PaEss.HttpUpdater.process(
+                 {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, "sign_id"]},
+                 state
+               )
     end
 
     test "sends custom audio messages" do
@@ -229,7 +255,10 @@ defmodule PaEss.HttpUpdaterTest do
         minutes: 7
       }
 
-      PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["s"]}, [audio1, audio2], 5, 60, "sign_id"]}, state)
+      PaEss.HttpUpdater.process(
+        {:send_audio, [{"RPRK", ["s"]}, [audio1, audio2], 5, 60, "sign_id"]},
+        state
+      )
 
       assert_received {:post, q1}
       assert_received {:post, q2}
@@ -249,7 +278,11 @@ defmodule PaEss.HttpUpdaterTest do
       minutes: 2
     }
 
-    PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["m", "s", "c"]}, [audio], 5, 60, "sign_id"]}, state)
+    PaEss.HttpUpdater.process(
+      {:send_audio, [{"RPRK", ["m", "s", "c"]}, [audio], 5, 60, "sign_id"]},
+      state
+    )
+
     assert_received {:post, q}
     assert q =~ "sta=RPRK110100"
   end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -1,6 +1,6 @@
 defmodule Fake.MessageQueue do
   def get_message do
-    {:update_sign, [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now]}
+    {:update_sign, [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now, "sign_id"]}
   end
 end
 
@@ -23,7 +23,7 @@ defmodule PaEss.HttpUpdaterTest do
 
       assert {:error, :bad_status} ==
                PaEss.HttpUpdater.process(
-                 {:update_sign, [{"bad_sign", "n"}, top, bottom, 60, 1234]},
+                 {:update_sign, [{"bad_sign", "n"}, top, bottom, 60, 1234, "sign_id"]},
                  state
                )
     end
@@ -37,7 +37,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} ==
                    PaEss.HttpUpdater.process(
-                     {:update_sign, [{"ABCD", "n"}, top, bottom, 60, :now]},
+                     {:update_sign, [{"ABCD", "n"}, top, bottom, 60, :now, "sign_id"]},
                      state
                    )
         end)
@@ -55,7 +55,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log([level: :info], fn ->
           assert {:error, :post_error} ==
                    PaEss.HttpUpdater.process(
-                     {:update_sign, [{"timeout", "n"}, top, bottom, 60, :now]},
+                     {:update_sign, [{"timeout", "n"}, top, bottom, 60, :now, "sign_id"]},
                      state
                    )
         end)
@@ -69,7 +69,7 @@ defmodule PaEss.HttpUpdaterTest do
 
       assert PaEss.HttpUpdater.process(
                {:update_sign,
-                [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now]},
+                [{"SBOX", "c"}, %Content.Message.Empty{}, %Content.Message.Empty{}, 60, :now, "sign_id"]},
                state
              ) == {:ok, :sent}
     end
@@ -80,7 +80,7 @@ defmodule PaEss.HttpUpdaterTest do
       audio = %Fake.UnknownAudio{}
 
       assert {:ok, :no_audio} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"GKEN", ["m"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"GKEN", ["m"]}, [audio], 5, 60, "sign_id"]}, state)
     end
   end
 
@@ -98,7 +98,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} ==
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"SBOX", ["c"]}, [audio], 5, 60]},
+                     {:send_audio, [{"SBOX", ["c"]}, [audio], 5, 60, "sign_id"]},
                      state
                    )
         end)
@@ -116,7 +116,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBSQ", ["m"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"SBSQ", ["m"]}, [audio], 5, 60, "sign_id"]}, state)
     end
 
     test "Buses to Chelsea, in Spanish" do
@@ -129,7 +129,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"SBOX", ["e"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"SBOX", ["e"]}, [audio], 5, 60, "sign_id"]}, state)
     end
 
     test "Next train to Ashmont arrives in 4 minutes" do
@@ -144,7 +144,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["n"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["n"]}, [audio], 5, 60, "sign_id"]}, state)
     end
 
     test "Train to Mattapan arriving" do
@@ -155,7 +155,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["s"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCED", ["s"]}, [audio], 5, 60, "sign_id"]}, state)
     end
 
     test "Train to Ashmont arriving" do
@@ -167,7 +167,7 @@ defmodule PaEss.HttpUpdaterTest do
       }
 
       assert {:ok, :sent} ==
-               PaEss.HttpUpdater.process({:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]}, state)
+               PaEss.HttpUpdater.process({:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, "sign_id"]}, state)
     end
 
     test "sends custom audio messages" do
@@ -181,7 +181,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} ==
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]},
+                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, "sign_id"]},
                      state
                    )
         end)
@@ -201,7 +201,7 @@ defmodule PaEss.HttpUpdaterTest do
         capture_log(fn ->
           assert {:ok, :sent} =
                    PaEss.HttpUpdater.process(
-                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60]},
+                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, "sign_id"]},
                      state
                    )
         end)
@@ -229,7 +229,7 @@ defmodule PaEss.HttpUpdaterTest do
         minutes: 7
       }
 
-      PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["s"]}, [audio1, audio2], 5, 60]}, state)
+      PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["s"]}, [audio1, audio2], 5, 60, "sign_id"]}, state)
 
       assert_received {:post, q1}
       assert_received {:post, q2}
@@ -249,7 +249,7 @@ defmodule PaEss.HttpUpdaterTest do
       minutes: 2
     }
 
-    PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["m", "s", "c"]}, [audio], 5, 60]}, state)
+    PaEss.HttpUpdater.process({:send_audio, [{"RPRK", ["m", "s", "c"]}, [audio], 5, 60, "sign_id"]}, state)
     assert_received {:post, q}
     assert q =~ "sta=RPRK110100"
   end

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -345,14 +345,14 @@ defmodule Signs.BusTest do
   end
 
   defp expect_messages(messages) do
-    expect(PaEss.Updater.Mock, :update_sign, fn {"ABCD", "m"}, top, bottom, 180, :now ->
+    expect(PaEss.Updater.Mock, :update_sign, fn {"ABCD", "m"}, top, bottom, 180, :now, _sign_id ->
       assert [Content.Message.to_string(top), Content.Message.to_string(bottom)] == messages
       :ok
     end)
   end
 
   defp expect_audios(audios) do
-    expect(PaEss.Updater.Mock, :send_audio, fn {"ABCD", ["m"]}, list, 5, 180 ->
+    expect(PaEss.Updater.Mock, :send_audio, fn {"ABCD", ["m"]}, list, 5, 180, _sign_id ->
       assert Enum.map(list, &Content.Audio.to_params(&1)) == audios
       :ok
     end)

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -57,12 +57,12 @@ defmodule Signs.RealtimeTest do
   end
 
   defmodule FakeUpdater do
-    def update_sign(id, top_msg, bottom_msg, duration, start) do
-      send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start})
+    def update_sign(id, top_msg, bottom_msg, duration, start, sign_id) do
+      send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start, sign_id})
     end
 
-    def send_audio(id, audio, priority, timeout) do
-      send(self(), {:send_audio, id, audio, priority, timeout})
+    def send_audio(id, audio, priority, timeout, sign_id) do
+      send(self(), {:send_audio, id, audio, priority, timeout, sign_id})
     end
   end
 
@@ -147,7 +147,7 @@ defmodule Signs.RealtimeTest do
 
       assert_received(
         {:update_sign, _id, %HT{destination: :southbound, vehicle_type: :train},
-         %HB{range: {11, 13}}, _dur, _start}
+         %HB{range: {11, 13}}, _dur, _start, _sign_id}
       )
 
       refute_received({:send_audio, _, _, _, _})
@@ -163,7 +163,7 @@ defmodule Signs.RealtimeTest do
 
       assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, sign)
       assert sign.announced_passthroughs == ["123"]
-      assert_received({:send_audio, _, [%Content.Audio.Passthrough{}], _, _})
+      assert_received({:send_audio, _, [%Content.Audio.Passthrough{}], _, _, _})
     end
   end
 

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -13,8 +13,8 @@ defmodule Signs.Utilities.ReaderTest do
   end
 
   defmodule FakeUpdater do
-    def send_audio(audio_id, audio, priority, timeout) do
-      send(self(), {:send_audio, audio_id, audio, priority, timeout})
+    def send_audio(audio_id, audio, priority, timeout, sign_id) do
+      send(self(), {:send_audio, audio_id, audio, priority, timeout, sign_id})
     end
   end
 
@@ -62,7 +62,7 @@ defmodule Signs.Utilities.ReaderTest do
 
       Reader.read_sign(sign)
 
-      assert_received({:send_audio, _id, _, _p, _t})
+      assert_received({:send_audio, _id, _, _p, _t, _})
     end
 
     test "when the sign is on a read interval, sends a single-line custom announcement" do
@@ -75,7 +75,7 @@ defmodule Signs.Utilities.ReaderTest do
 
       Reader.read_sign(sign)
 
-      assert_received({:send_audio, _id, [%Content.Audio.Custom{}], _priority, _timeout})
+      assert_received({:send_audio, _id, [%Content.Audio.Custom{}], _priority, _timeout, _sign_id})
     end
   end
 

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -75,7 +75,9 @@ defmodule Signs.Utilities.ReaderTest do
 
       Reader.read_sign(sign)
 
-      assert_received({:send_audio, _id, [%Content.Audio.Custom{}], _priority, _timeout, _sign_id})
+      assert_received(
+        {:send_audio, _id, [%Content.Audio.Custom{}], _priority, _timeout, _sign_id}
+      )
     end
   end
 

--- a/test/signs/utilities/updater_test.exs
+++ b/test/signs/utilities/updater_test.exs
@@ -11,12 +11,12 @@ defmodule Signs.Utilities.UpdaterTest do
   end
 
   defmodule FakeUpdater do
-    def update_sign(id, top_msg, bottom_msg, duration, start) do
-      send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start})
+    def update_sign(id, top_msg, bottom_msg, duration, start, sign_id) do
+      send(self(), {:update_sign, id, top_msg, bottom_msg, duration, start, sign_id})
     end
 
-    def send_audio(audio_id, audio, priority, timeout) do
-      send(self(), {:send_audio, audio_id, audio, priority, timeout})
+    def send_audio(audio_id, audio, priority, timeout, sign_id) do
+      send(self(), {:send_audio, audio_id, audio, priority, timeout, sign_id})
     end
   end
 
@@ -56,8 +56,8 @@ defmodule Signs.Utilities.UpdaterTest do
 
       sign = Updater.update_sign(@sign, same_top, same_bottom)
 
-      refute_received({:send_audio, _, _, _, _})
-      refute_received({:update_sign, _, _, _, _, _})
+      refute_received({:send_audio, _, _, _, _, _})
+      refute_received({:update_sign, _, _, _, _, _, _})
       assert sign.tick_content == 1
     end
 
@@ -67,7 +67,7 @@ defmodule Signs.Utilities.UpdaterTest do
 
       sign = Updater.update_sign(@sign, diff_top, diff_bottom)
 
-      assert_received({:update_sign, _id, %P{minutes: 3}, %P{minutes: 2}, _dur, _start})
+      assert_received({:update_sign, _id, %P{minutes: 3}, %P{minutes: 2}, _dur, _start, _sign_id})
       assert sign.tick_content == 100
     end
 
@@ -83,7 +83,7 @@ defmodule Signs.Utilities.UpdaterTest do
       diff_top = {src, %P{destination: :ashmont, minutes: :boarding}}
       diff_bottom = {src, %P{destination: :alewife, minutes: 19}}
       Updater.update_sign(sign, diff_top, diff_bottom)
-      refute_received({:send_audio, _, _, _, _})
+      refute_received({:send_audio, _, _, _, _, _})
     end
 
     test "logs when stopped train message turns on" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add human readable logging to RTS messages for Transit Data](https://app.asana.com/0/1201753694073608/1204564881899172/f)

This PR introduces a change to pass the `sign_id` along so that we can log it when we send requests to ARINC. This is so that we can more easily query for requests that went to specific sign zones.

It also adds new fields for the top and bottom content to make it easier to parse out what was sent to a sign zone.