### PR TITLE
send audio messages to signs-ui

### DIFF
--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -62,7 +62,7 @@ defmodule PaEss.HttpUpdaterTest do
         end)
 
       assert log =~ ~r" arinc_ms=\d+"
-      refute log =~ ~r" signs_ui_ms=\d+"
+      assert log =~ ~r" signs_ui_ms=0"
     end
 
     test "replies with {:ok, :sent} when successful" do
@@ -261,6 +261,7 @@ defmodule PaEss.HttpUpdaterTest do
       )
 
       assert_received {:post, q1}
+      assert_received {:post, _}
       assert_received {:post, q2}
       assert q1 =~ "var=4016"
       assert q2 =~ "var=4021"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Signs-UI shows a flag/toggle when audio has been sent to a zone](https://app.asana.com/0/1201753694073608/1204564881899174/f)

This sends audio messages to signs_ui, now that it can accept them. It consolidates the code paths for posting and logging messages, and fixes a case where we should have been logging `sign_id` but weren't.