### PR TITLE
support up to 45 vars in audio messages

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -175,7 +175,14 @@ defmodule PaEss.Utilities do
 
   @spec take_message_id([String.t()]) :: String.t()
   def take_message_id(vars) do
-    Integer.to_string(102 + length(vars))
+    # Maps var count to corresponding message id. Since these were added at different times,
+    # the message id ranges are not contiguous.
+    case length(vars) do
+      n when n <= 30 -> 102 + n
+      31 -> 220
+      n when n <= 45 -> 190 + n
+    end
+    |> Integer.to_string()
   end
 
   @doc "Take ID for terminal destinations"

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -3,7 +3,7 @@ defmodule Signs.Bus do
   require Logger
 
   @line_max 18
-  @var_max 30
+  @var_max 45
   @drawbridge_minutes "135"
   @drawbridge_soon "136"
   @drawbridge_minutes_spanish "152"

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -38,8 +38,8 @@ defmodule Content.Audio.UtilitiesTest do
 
   test "take_message_id/1" do
     assert take_message_id(["1", "2", "3"]) == "105"
-    assert take_message_id(Stream.cycle(["1"]) |> Enum.take(31)) == "220"
-    assert take_message_id(Stream.cycle(["1"]) |> Enum.take(40)) == "230"
+    assert take_message_id(List.duplicate("1", 31)) == "220"
+    assert take_message_id(List.duplicate("1", 40)) == "230"
   end
 
   test "destination_var/1" do

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -38,6 +38,8 @@ defmodule Content.Audio.UtilitiesTest do
 
   test "take_message_id/1" do
     assert take_message_id(["1", "2", "3"]) == "105"
+    assert take_message_id(Stream.cycle(["1"]) |> Enum.take(31)) == "220"
+    assert take_message_id(Stream.cycle(["1"]) |> Enum.take(40)) == "230"
   end
 
   test "destination_var/1" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Use 31-45 var messages when appropriate](https://app.asana.com/0/1201753694073608/1204612335144707/f)

This adds support for additional audio message ids recently added to the signs, with support for up to 45 vars. As of now, only some of the bus signs generate audios this long.