### PR TITLE
Clean up stops.json and add new stops for B/E branches

### DIFF
--- a/priv/stops.json
+++ b/priv/stops.json
@@ -25,31 +25,29 @@
     {"station": "G Hynes westbound", "stop_ids": ["70153"]},
     {"station": "G Kenmore westbound", "stop_ids": ["70151"]}
   ],
-  "Green-E-eastbound": [
+  "Green-E": [
+    {"station": "G Northeastern eastbound", "stop_ids": ["70244"]},
     {"station": "G Symphony eastbound", "stop_ids": ["70242"]},
     {"station": "G Prudential eastbound", "stop_ids": ["70240"]},
-    {"station": "G Copley eastbound", "stop_ids": ["70154"]}
+    {"station": "G Copley eastbound", "stop_ids": ["70154"]},
+    {"station": "G Copley westbound", "stop_ids": ["70155"]},
+    {"station": "G Prudential westbound", "stop_ids": ["70239"]},
+    {"station": "G Symphony westbound", "stop_ids": ["70241"]},
+    {"station": "G Northeastern westbound", "stop_ids": ["70243"]}
   ],
-  "Green-E-eastbound-glx": [
+  "Green-E-glx": [
     {"station": "G Lechmere eastbound", "stop_ids": ["70501"]},
     {"station": "G East Somerville eastbound", "stop_ids": ["70513"]},
     {"station": "G Gilman Square eastbound", "stop_ids": ["70505"]},
     {"station": "G Magoun Square eastbound", "stop_ids": ["70507"]},
     {"station": "G Ball Square eastbound", "stop_ids": ["70509"]},
-    {"station": "G College Ave eastbound", "stop_ids": ["70511"]}
-  ],
-  "Green-E-westbound": [
-    {"station": "G Symphony westbound", "stop_ids": ["70241"]},
-    {"station": "G Prudential westbound", "stop_ids": ["70239"]},
-    {"station": "G Copley westbound", "stop_ids": ["70155"]}
-  ],
-  "Green-E-westbound-glx": [
-    {"station": "G Lechmere westbound", "stop_ids": ["70502"]},
-    {"station": "G East Somerville westbound", "stop_ids": ["70514"]},
-    {"station": "G Gilman Square westbound", "stop_ids": ["70506"]},
-    {"station": "G Magoun Square westbound", "stop_ids": ["70508"]},
+    {"station": "G College Ave eastbound", "stop_ids": ["70511"]},
+    {"station": "G College Ave westbound", "stop_ids": ["70512"]},
     {"station": "G Ball Square westbound", "stop_ids": ["70510"]},
-    {"station": "G College Ave westbound", "stop_ids": ["70512"]}
+    {"station": "G Magoun Square westbound", "stop_ids": ["70508"]},
+    {"station": "G Gilman Square westbound", "stop_ids": ["70506"]},
+    {"station": "G East Somerville westbound", "stop_ids": ["70514"]},
+    {"station": "G Lechmere westbound", "stop_ids": ["70502"]}
   ],
   "Green-D": [
     {"station": "G Kenmore outbound", "stop_ids": ["70151"]},
@@ -82,12 +80,18 @@
     {"station": "G Kenmore inbound", "stop_ids": ["70150"]}
   ],
   "Green-B": [
-    {"station": "G Kenmore eastbound", "stop_ids": ["71150"]},
-    {"station": "G Babcock eastbound", "stop_ids": ["170136"]},
+    {"station": "G Kenmore B eastbound", "stop_ids": ["71150"]},
+    {"station": "G Blandford eastbound", "stop_ids": ["70148"]},
+    {"station": "G BU East eastbound", "stop_ids": ["70146"]},
+    {"station": "G BU Central eastbound", "stop_ids": ["70144"]},
     {"station": "G Amory eastbound", "stop_ids": ["170140"]},
-    {"station": "G Amory westbound", "stop_ids": ["170141"]},
+    {"station": "G Babcock eastbound", "stop_ids": ["170136"]},
     {"station": "G Babcock westbound", "stop_ids": ["170137"]},
-    {"station": "G Kenmore westbound", "stop_ids": ["71151"]}
+    {"station": "G Amory westbound", "stop_ids": ["170141"]},
+    {"station": "G BU Central westbound", "stop_ids": ["70145"]},
+    {"station": "G BU East westbound", "stop_ids": ["70147"]},
+    {"station": "G Blandford westbound", "stop_ids": ["70149"]},
+    {"station": "G Kenmore B westbound", "stop_ids": ["71151"]}
   ],
   "Mattapan": [
     {"station": "M Mattapan inbound", "stop_ids": ["70276"]},

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -86,6 +86,8 @@
     {"station": "G BU Central eastbound", "stop_ids": ["70144"]},
     {"station": "G Amory eastbound", "stop_ids": ["170140"]},
     {"station": "G Babcock eastbound", "stop_ids": ["170136"]},
+    {"station": "G Packards eastbound", "stop_ids": ["70134"]},
+    {"station": "G Packards westbound", "stop_ids": ["70135"]},
     {"station": "G Babcock westbound", "stop_ids": ["170137"]},
     {"station": "G Amory westbound", "stop_ids": ["170141"]},
     {"station": "G BU Central westbound", "stop_ids": ["70145"]},

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -26,14 +26,14 @@
     {"station": "G Kenmore westbound", "stop_ids": ["70151"]}
   ],
   "Green-E": [
-    {"station": "G Northeastern eastbound", "stop_ids": ["70244"]},
-    {"station": "G Symphony eastbound", "stop_ids": ["70242"]},
-    {"station": "G Prudential eastbound", "stop_ids": ["70240"]},
     {"station": "G Copley eastbound", "stop_ids": ["70154"]},
-    {"station": "G Copley westbound", "stop_ids": ["70155"]},
-    {"station": "G Prudential westbound", "stop_ids": ["70239"]},
+    {"station": "G Prudential eastbound", "stop_ids": ["70240"]},
+    {"station": "G Symphony eastbound", "stop_ids": ["70242"]},
+    {"station": "G Northeastern eastbound", "stop_ids": ["70244"]},
+    {"station": "G Northeastern westbound", "stop_ids": ["70243"]},
     {"station": "G Symphony westbound", "stop_ids": ["70241"]},
-    {"station": "G Northeastern westbound", "stop_ids": ["70243"]}
+    {"station": "G Prudential westbound", "stop_ids": ["70239"]},
+    {"station": "G Copley westbound", "stop_ids": ["70155"]}
   ],
   "Green-E-glx": [
     {"station": "G Lechmere eastbound", "stop_ids": ["70501"]},


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate Babcock alert treatment](https://app.asana.com/0/1201753694073608/1204800787143423/f)

Stemming from the above linked investigation, this PR adds a few new stops to the `stops.json` file for the B branch so that alerts that start between Kenmore and Amory get applied correctly to the countdown clocks as well as Babcock. Similarly add Northeastern so that Symphony gets proper treatment.

It also cleans up the file a bit and consolidates some of the lists. The lists for Green E and GLX don't need to be in the same list in order to work as intended.