### PR TITLE
Add Kenmore B stops to stops.json

### DIFF
--- a/priv/stops.json
+++ b/priv/stops.json
@@ -1,6 +1,6 @@
 {
   "Green-Trunk": [
-    {"station": "G Kenmore eastbound", "stop_ids": ["70150"]},
+    {"station": "G Kenmore eastbound", "stop_ids": ["70150", "71151"]},
     {"station": "G Hynes eastbound", "stop_ids": ["70152"]},
     {"station": "G Copley eastbound", "stop_ids": ["70154"]},
     {"station": "G Arlington eastbound", "stop_ids": ["70156"]},
@@ -23,7 +23,7 @@
     {"station": "G Arlington westbound", "stop_ids": ["70157"]},
     {"station": "G Copley westbound", "stop_ids": ["70155"]},
     {"station": "G Hynes westbound", "stop_ids": ["70153"]},
-    {"station": "G Kenmore westbound", "stop_ids": ["70151"]}
+    {"station": "G Kenmore westbound", "stop_ids": ["70151", "71150"]}
   ],
   "Green-E": [
     {"station": "G Copley eastbound", "stop_ids": ["70154"]},


### PR DESCRIPTION
#### Summary of changes
Ad-hoc

This PR adds the Kenmore B branch stops (per the current rating) to the Green Line trunk in the`stops.json` config file.

This makes it so that the Kenmore B branch platforms are not treated as a true terminal and do not show alert messaging when the Kenmore B stops are the endpoints of an alert. Instead, this change makes it so that Hynes is a neighboring stop of the B branch stops and will cause our intended alerts logic to be applied.