### PR TITLE
unify sign update code paths

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -25,10 +25,9 @@ defmodule Signs.Realtime do
     :config_engine,
     :alerts_engine,
     :sign_updater,
-    :tick_content,
+    :last_update,
     :tick_audit,
     :tick_read,
-    :expiration_seconds,
     :read_period_seconds
   ]
 
@@ -60,10 +59,9 @@ defmodule Signs.Realtime do
           config_engine: module(),
           alerts_engine: module(),
           sign_updater: module(),
-          tick_content: non_neg_integer(),
+          last_update: DateTime.t(),
           tick_audit: non_neg_integer(),
           tick_read: non_neg_integer(),
-          expiration_seconds: non_neg_integer(),
           read_period_seconds: non_neg_integer(),
           announced_arrivals: [Predictions.Prediction.trip_id()],
           announced_approachings: [Predictions.Prediction.trip_id()],
@@ -94,10 +92,9 @@ defmodule Signs.Realtime do
       config_engine: config_engine,
       alerts_engine: alerts_engine,
       sign_updater: sign_updater,
-      tick_content: 130,
+      last_update: nil,
       tick_audit: 60,
       tick_read: 240 + Map.fetch!(config, "read_loop_offset"),
-      expiration_seconds: 130,
       read_period_seconds: 240,
       headway_stop_id: Map.get(config, "headway_stop_id"),
       uses_shuttles: Map.get(config, "uses_shuttles", true)
@@ -137,14 +134,13 @@ defmodule Signs.Realtime do
     sign =
       sign
       |> announce_passthrough_trains(predictions)
-      |> Utilities.Updater.update_sign(new_top, new_bottom)
+      |> Utilities.Updater.update_sign(new_top, new_bottom, current_time)
       |> Utilities.Reader.do_interrupting_reads(
         sign.current_content_top,
         sign.current_content_bottom
       )
       |> Utilities.Reader.read_sign()
       |> log_headway_accuracy()
-      |> do_expiration()
       |> decrement_ticks()
 
     schedule_run_loop(self())
@@ -183,28 +179,11 @@ defmodule Signs.Realtime do
     end)
   end
 
-  @spec do_expiration(Signs.Realtime.t()) :: Signs.Realtime.t()
-  def do_expiration(%{tick_content: 0} = sign) do
-    sign.sign_updater.update_sign(
-      sign.text_id,
-      sign.current_content_top,
-      sign.current_content_bottom,
-      sign.expiration_seconds + 15,
-      :now,
-      sign.id
-    )
-
-    %{sign | tick_content: sign.expiration_seconds}
-  end
-
-  def do_expiration(sign), do: sign
-
   @spec decrement_ticks(Signs.Realtime.t()) :: Signs.Realtime.t()
   def decrement_ticks(sign) do
     %{
       sign
-      | tick_content: sign.tick_content - 1,
-        tick_audit: sign.tick_audit - 1,
+      | tick_audit: sign.tick_audit - 1,
         tick_read: sign.tick_read - 1
     }
   end

--- a/lib/signs/utilities/updater.ex
+++ b/lib/signs/utilities/updater.ex
@@ -12,52 +12,32 @@ defmodule Signs.Utilities.Updater do
   @spec update_sign(
           Signs.Realtime.t(),
           Signs.Realtime.line_content(),
-          Signs.Realtime.line_content()
+          Signs.Realtime.line_content(),
+          DateTime.t()
         ) :: Signs.Realtime.t()
-  def update_sign(
-        sign,
-        top_msg,
-        bottom_msg
-      ) do
-    top_same_content? = Messages.same_content?(sign.current_content_top, top_msg)
-    bottom_same_content? = Messages.same_content?(sign.current_content_bottom, bottom_msg)
+  def update_sign(sign, top_msg, bottom_msg, current_time) do
+    top_changed? = not Messages.same_content?(sign.current_content_top, top_msg)
+    new_top = if top_changed?, do: top_msg, else: sign.current_content_top
+    bottom_changed? = not Messages.same_content?(sign.current_content_bottom, bottom_msg)
+    new_bottom = if bottom_changed?, do: bottom_msg, else: sign.current_content_bottom
 
-    case top_same_content? and bottom_same_content? do
-      true ->
+    if top_changed?, do: log_line_update(sign, new_top, "top")
+    if bottom_changed?, do: log_line_update(sign, new_bottom, "bottom")
+
+    if !sign.last_update ||
+         Timex.after?(current_time, Timex.shift(sign.last_update, seconds: 130)) ||
+         top_changed? ||
+         bottom_changed? do
+      sign.sign_updater.update_sign(sign.text_id, new_top, new_bottom, 145, :now, sign.id)
+
+      %{
         sign
-
-      _ ->
-        top_msg =
-          if top_same_content? do
-            sign.current_content_top
-          else
-            log_line_update(sign, top_msg, "top")
-            top_msg
-          end
-
-        bottom_msg =
-          if bottom_same_content? do
-            sign.current_content_bottom
-          else
-            log_line_update(sign, bottom_msg, "bottom")
-            bottom_msg
-          end
-
-        sign.sign_updater.update_sign(
-          sign.text_id,
-          top_msg,
-          bottom_msg,
-          sign.expiration_seconds + 15,
-          :now,
-          sign.id
-        )
-
-        %{
-          sign
-          | current_content_top: top_msg,
-            current_content_bottom: bottom_msg,
-            tick_content: sign.expiration_seconds
-        }
+        | current_content_top: new_top,
+          current_content_bottom: new_bottom,
+          last_update: current_time
+      }
+    else
+      sign
     end
   end
 

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -33,10 +33,9 @@ defmodule Signs.Utilities.AudioTest do
     config_engine: Engine.Config,
     alerts_engine: nil,
     sign_updater: nil,
-    tick_content: 1,
+    last_update: Timex.now(),
     tick_audit: 1,
     tick_read: 1,
-    expiration_seconds: 100,
     read_period_seconds: 100
   }
 

--- a/test/signs/utilities/headways_test.exs
+++ b/test/signs/utilities/headways_test.exs
@@ -53,10 +53,9 @@ defmodule Signs.Utilities.HeadwaysTest do
     config_engine: Engine.Config,
     alerts_engine: FakeAlerts,
     sign_updater: FakeUpdater,
-    tick_content: 130,
+    last_update: Timex.now(),
     tick_audit: 240,
     tick_read: 240,
-    expiration_seconds: 130,
     read_period_seconds: 240
   }
 

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -102,10 +102,9 @@ defmodule Signs.Utilities.MessagesTest do
     config_engine: Engine.Config,
     alerts_engine: FakeAlerts,
     sign_updater: FakeUpdater,
-    tick_content: 1,
+    last_update: Timex.now(),
     tick_audit: 240,
     tick_read: 1,
-    expiration_seconds: 100,
     read_period_seconds: 100
   }
 

--- a/test/signs/utilities/predictions_test.exs
+++ b/test/signs/utilities/predictions_test.exs
@@ -22,10 +22,9 @@ defmodule Signs.Utilities.PredictionsTest do
     config_engine: Engine.Config,
     alerts_engine: nil,
     sign_updater: FakeUpdater,
-    tick_content: 130,
+    last_update: Timex.now(),
     tick_audit: 240,
     tick_read: 240,
-    expiration_seconds: 130,
     read_period_seconds: 240
   }
 

--- a/test/signs/utilities/reader_test.exs
+++ b/test/signs/utilities/reader_test.exs
@@ -40,10 +40,9 @@ defmodule Signs.Utilities.ReaderTest do
     config_engine: Engine.Config,
     alerts_engine: nil,
     sign_updater: FakeUpdater,
-    tick_content: 1,
+    last_update: Timex.now(),
     tick_audit: 240,
     tick_read: 1,
-    expiration_seconds: 100,
     read_period_seconds: 100
   }
 


### PR DESCRIPTION
#### Summary of changes

This rearranges the sign update logic so that both content- and expiration-related updates happen via the same unified code path. It also measures expiration using timestamps directly, rather than indirectly counting "ticks" between updates.