### PR TITLE
Add line specificity to mezzanine headway messages

### DIFF
--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -7,27 +7,27 @@ defmodule Content.Audio.VehiclesToDestination do
   alias PaEss.Utilities
 
   @enforce_keys [:language, :destination, :headway_range]
-  defstruct @enforce_keys ++ [:previous_departure_mins, :line]
+  defstruct @enforce_keys ++ [:previous_departure_mins, :routes]
 
   @type t :: %__MODULE__{
           language: Content.Audio.language(),
           destination: PaEss.destination() | nil,
           headway_range: Headway.HeadwayDisplay.headway_range(),
           previous_departure_mins: integer() | nil,
-          line: String.t() | nil
+          routes: [String.t()] | nil
         }
 
   def from_headway_message(
-        %Content.Message.Headways.Top{destination: nil, line: line},
+        %Content.Message.Headways.Top{destination: nil, routes: routes},
         %Content.Message.Headways.Bottom{range: range}
       )
-      when not is_nil(line) do
+      when not is_nil(routes) do
     [
       %__MODULE__{
         language: :english,
         destination: nil,
         headway_range: range,
-        line: line
+        routes: routes
       }
     ]
   end
@@ -98,14 +98,19 @@ defmodule Content.Audio.VehiclesToDestination do
     alias PaEss.Utilities
 
     def to_params(%Content.Audio.VehiclesToDestination{
-          line: line,
+          routes: routes,
           headway_range: {range_low, range_high}
         })
-        when not is_nil(line) do
-      if line =~ "train" do
-        {:ad_hoc, {"Trains every #{range_low} to #{range_high} minutes.", :audio}}
-      else
-        {:ad_hoc, {"#{line} trains every #{range_low} to #{range_high} minutes.", :audio}}
+        when not is_nil(routes) do
+      case routes do
+        ["Mattapan"] ->
+          {:ad_hoc, {"Mattapan trains every #{range_low} to #{range_high} minutes.", :audio}}
+
+        [route] ->
+          {:ad_hoc, {"#{route} line trains every #{range_low} to #{range_high} minutes.", :audio}}
+
+        _ ->
+          {:ad_hoc, {"Trains every #{range_low} to #{range_high} minutes.", :audio}}
       end
     end
 

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -20,7 +20,8 @@ defmodule Content.Audio.VehiclesToDestination do
   def from_headway_message(
         %Content.Message.Headways.Top{destination: nil, line: line},
         %Content.Message.Headways.Bottom{range: range}
-      ) do
+      )
+      when not is_nil(line) do
     [
       %__MODULE__{
         language: :english,

--- a/lib/content/message/headways/top.ex
+++ b/lib/content/message/headways/top.ex
@@ -11,9 +11,28 @@ defmodule Content.Message.Headways.Top do
 
   defimpl Content.Message do
     def to_string(%Content.Message.Headways.Top{
-          destination: nil,
           vehicle_type: type,
-          line: nil
+          line: line
+        })
+        when not is_nil(line) do
+      cond do
+        line =~ "Mattapan" ->
+          "Mattapan #{signify_vehicle_type(type)}"
+
+        line =~ "train" ->
+          Content.Message.to_string(%Content.Message.Headways.Top{
+            destination: nil,
+            vehicle_type: :train
+          })
+
+        true ->
+          "#{line} #{signify_vehicle_type(type)}"
+      end
+    end
+
+    def to_string(%Content.Message.Headways.Top{
+          destination: nil,
+          vehicle_type: type
         }) do
       type |> signify_vehicle_type |> String.capitalize()
     end
@@ -28,29 +47,9 @@ defmodule Content.Message.Headways.Top do
 
     def to_string(%Content.Message.Headways.Top{
           destination: destination,
-          vehicle_type: type,
-          line: nil
+          vehicle_type: type
         }) do
       "#{PaEss.Utilities.destination_to_sign_string(destination)} #{signify_vehicle_type(type)}"
-    end
-
-    def to_string(%Content.Message.Headways.Top{
-          vehicle_type: type,
-          line: line
-        }) do
-      cond do
-        line =~ "Mattapan" ->
-          "Mattapan #{signify_vehicle_type(type)}"
-
-        line =~ "train" ->
-          Content.Message.to_string(%Content.Message.Headways.Top{
-            destination: nil,
-            vehicle_type: :train
-          })
-
-        true ->
-          "#{line} #{signify_vehicle_type(type)}"
-      end
     end
 
     @spec signify_vehicle_type(Content.Message.Headways.Top.vehicle_type()) :: String.t()

--- a/lib/content/message/headways/top.ex
+++ b/lib/content/message/headways/top.ex
@@ -1,17 +1,19 @@
 defmodule Content.Message.Headways.Top do
   require Logger
-  defstruct [:destination, :vehicle_type]
+  defstruct [:destination, :vehicle_type, :line]
 
   @type vehicle_type :: :bus | :trolley | :train
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
-          vehicle_type: vehicle_type
+          vehicle_type: vehicle_type,
+          line: String.t() | nil
         }
 
   defimpl Content.Message do
     def to_string(%Content.Message.Headways.Top{
           destination: nil,
-          vehicle_type: type
+          vehicle_type: type,
+          line: nil
         }) do
       type |> signify_vehicle_type |> String.capitalize()
     end
@@ -26,9 +28,29 @@ defmodule Content.Message.Headways.Top do
 
     def to_string(%Content.Message.Headways.Top{
           destination: destination,
-          vehicle_type: type
+          vehicle_type: type,
+          line: nil
         }) do
       "#{PaEss.Utilities.destination_to_sign_string(destination)} #{signify_vehicle_type(type)}"
+    end
+
+    def to_string(%Content.Message.Headways.Top{
+          vehicle_type: type,
+          line: line
+        }) do
+      cond do
+        line =~ "Mattapan" ->
+          "Mattapan #{signify_vehicle_type(type)}"
+
+        line =~ "train" ->
+          Content.Message.to_string(%Content.Message.Headways.Top{
+            destination: nil,
+            vehicle_type: :train
+          })
+
+        true ->
+          "#{line} #{signify_vehicle_type(type)}"
+      end
     end
 
     @spec signify_vehicle_type(Content.Message.Headways.Top.vehicle_type()) :: String.t()

--- a/lib/content/message/headways/top.ex
+++ b/lib/content/message/headways/top.ex
@@ -1,32 +1,32 @@
 defmodule Content.Message.Headways.Top do
   require Logger
-  defstruct [:destination, :vehicle_type, :line]
+  defstruct [:destination, :vehicle_type, :routes]
 
   @type vehicle_type :: :bus | :trolley | :train
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
           vehicle_type: vehicle_type,
-          line: String.t() | nil
+          routes: [String.t()] | nil
         }
 
   defimpl Content.Message do
     def to_string(%Content.Message.Headways.Top{
           vehicle_type: type,
-          line: line
+          routes: routes
         })
-        when not is_nil(line) do
-      cond do
-        line =~ "Mattapan" ->
+        when not is_nil(routes) do
+      case routes do
+        ["Mattapan"] ->
           "Mattapan #{signify_vehicle_type(type)}"
 
-        line =~ "train" ->
+        [route] ->
+          "#{route} line #{signify_vehicle_type(type)}"
+
+        _ ->
           Content.Message.to_string(%Content.Message.Headways.Top{
             destination: nil,
             vehicle_type: :train
           })
-
-        true ->
-          "#{line} #{signify_vehicle_type(type)}"
       end
     end
 

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -328,13 +328,14 @@ defmodule PaEss.Utilities do
   def line_to_var("Mattapan Line"), do: "3009"
   def line_to_var(_), do: "864"
 
-  def get_line_from_routes_list(routes) do
-    unique_routes =
-      routes
-      |> Enum.map(fn route -> route |> String.split("-") |> List.first() end)
-      |> Enum.uniq()
+  def get_unique_routes(routes) do
+    routes
+    |> Enum.map(fn route -> route |> String.split("-") |> List.first() end)
+    |> Enum.uniq()
+  end
 
-    case unique_routes do
+  def get_line_from_routes_list(routes) do
+    case get_unique_routes(routes) do
       [route] ->
         "#{route} Line"
 

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -20,11 +20,12 @@ defmodule Signs.Utilities.Headways do
 
       headways ->
         if Signs.Utilities.SourceConfig.multi_source?(sign.source_config) do
-          line =
-            SourceConfig.sign_routes(sign.source_config)
-            |> PaEss.Utilities.get_line_from_routes_list()
-
-          {%Content.Message.Headways.Top{line: line, vehicle_type: :train},
+          {%Content.Message.Headways.Top{
+             routes:
+               SourceConfig.sign_routes(sign.source_config)
+               |> PaEss.Utilities.get_unique_routes(),
+             vehicle_type: :train
+           },
            %Content.Message.Headways.Bottom{
              range: {headways.range_low, headways.range_high},
              prev_departure_mins: nil

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -19,11 +19,23 @@ defmodule Signs.Utilities.Headways do
         {%Content.Message.Empty{}, %Content.Message.Empty{}}
 
       headways ->
-        {%Content.Message.Headways.Top{destination: destination, vehicle_type: :train},
-         %Content.Message.Headways.Bottom{
-           range: {headways.range_low, headways.range_high},
-           prev_departure_mins: nil
-         }}
+        if Signs.Utilities.SourceConfig.multi_source?(sign.source_config) do
+          line =
+            SourceConfig.sign_routes(sign.source_config)
+            |> PaEss.Utilities.get_line_from_routes_list()
+
+          {%Content.Message.Headways.Top{line: line, vehicle_type: :train},
+           %Content.Message.Headways.Bottom{
+             range: {headways.range_low, headways.range_high},
+             prev_departure_mins: nil
+           }}
+        else
+          {%Content.Message.Headways.Top{destination: destination, vehicle_type: :train},
+           %Content.Message.Headways.Bottom{
+             range: {headways.range_low, headways.range_high},
+             prev_departure_mins: nil
+           }}
+        end
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Extend alert specificity to Headway visual and audio](https://app.asana.com/0/1201753694073608/1204971672094872/f)

Adds line specificity to mezzanine headway messages.

Example:
`Orange Line Trains`
`Every 5 to 7 min`