### PR TITLE
Log route-based subway predictions filtering

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -159,7 +159,17 @@ defmodule Signs.Realtime do
   defp fetch_predictions(%{sources: sources}, state) do
     Enum.flat_map(sources, fn source ->
       state.prediction_engine.for_stop(source.stop_id, source.direction_id)
-      |> Enum.filter(&(source.routes == nil or &1.route_id in source.routes))
+      |> Enum.filter(fn prediction ->
+        if source.routes == nil or prediction.route_id in source.routes do
+          true
+        else
+          Logger.info(
+            "filter_prediction_by_route sign_id=#{state.id} stop_id=#{source.stop_id} direction_id=#{source.direction_id} route_id=#{prediction.route_id}"
+          )
+
+          false
+        end
+      end)
     end)
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate removing route-based filtering for predictions](https://app.asana.com/0/1201753694073608/1205057928541600/f)

This filtering appears to not be useful since there are always distinct platform stop ids for the distinct routes at a given station. We want to see how often, if at all, predictions are getting filtered out by route with this temporary logging.