### PR TITLE
Add takes for general headway directions

### DIFF
--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -60,14 +60,7 @@ defmodule Content.Audio.FollowingTrain do
     def to_params(audio) do
       case Utilities.destination_var(audio.destination) do
         {:ok, dest_var} ->
-          if audio.destination in [
-               :southbound,
-               :northbound,
-               :westbound,
-               :eastbound,
-               :inbound,
-               :outbound
-             ] do
+          if Utilities.directional_destination?(audio.destination) do
             do_ad_hoc_message(audio)
           else
             green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -40,14 +40,7 @@ defmodule Content.Audio.NextTrainCountdown do
           green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
 
           cond do
-            audio.destination in [
-              :southbound,
-              :northbound,
-              :eastbound,
-              :westbound,
-              :inbound,
-              :outbound
-            ] ->
+            Utilities.directional_destination?(audio.destination) ->
               do_ad_hoc_message(audio)
 
             !is_nil(audio.track_number) ->

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -38,14 +38,7 @@ defmodule Content.Audio.StoppedTrain do
     def to_params(audio) do
       case PaEss.Utilities.destination_var(audio.destination) do
         {:ok, dest_var} ->
-          if audio.destination in [
-               :southbound,
-               :northbound,
-               :eastbound,
-               :westbound,
-               :inbound,
-               :outbound
-             ] do
+          if Utilities.directional_destination?(audio.destination) do
             do_ad_hoc_message(audio)
           else
             vars = [

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -25,14 +25,7 @@ defmodule Content.Audio.TrainIsBoarding do
     def to_params(audio) do
       case PaEss.Utilities.destination_var(audio.destination) do
         {:ok, destination_var} ->
-          if audio.destination in [
-               :southbound,
-               :northbound,
-               :eastbound,
-               :westbound,
-               :inbound,
-               :outbound
-             ] do
+          if PaEss.Utilities.directional_destination?(audio.destination) do
             do_ad_hoc_message(audio)
           else
             do_to_params(audio, destination_var)

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -359,7 +359,7 @@ defmodule PaEss.Utilities do
   def ad_hoc_trip_description(destination, route_id \\ nil)
 
   def ad_hoc_trip_description(destination, nil)
-      when destination in [:eastbound, :westbound, :southbound, :northbound] do
+      when destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound] do
     case destination_to_ad_hoc_string(destination) do
       {:ok, destination_string} ->
         {:ok, "#{destination_string} train"}
@@ -375,7 +375,7 @@ defmodule PaEss.Utilities do
   end
 
   def ad_hoc_trip_description(destination, route_id)
-      when destination in [:eastbound, :westbound, :southbound, :northbound] do
+      when destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound] do
     case {destination_to_ad_hoc_string(destination), route_to_ad_hoc_string(route_id)} do
       {{:ok, destination_string}, {:ok, route_string}} ->
         {:ok, "#{destination_string} #{route_string} train"}

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -207,6 +207,12 @@ defmodule PaEss.Utilities do
   def destination_var(:heath_street), do: {:ok, "4204"}
   def destination_var(:union_square), do: {:ok, "695"}
   def destination_var(:medford_tufts), do: {:ok, "852"}
+  def destination_var(:southbound), do: {:ok, "787"}
+  def destination_var(:northbound), do: {:ok, "788"}
+  def destination_var(:eastbound), do: {:ok, "867"}
+  def destination_var(:westbound), do: {:ok, "868"}
+  def destination_var(:inbound), do: {:ok, "33003"}
+  def destination_var(:outbound), do: {:ok, "33004"}
   def destination_var(_), do: {:error, :unknown}
 
   @doc """

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -354,48 +354,16 @@ defmodule PaEss.Utilities do
     end
   end
 
+  def directional_destination?(destination),
+    do: destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound]
+
   @spec ad_hoc_trip_description(PaEss.destination(), String.t() | nil) ::
           {:ok, String.t()} | {:error, :unknown}
   def ad_hoc_trip_description(destination, route_id \\ nil)
 
-  def ad_hoc_trip_description(destination, nil)
-      when destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound] do
-    case destination_to_ad_hoc_string(destination) do
-      {:ok, destination_string} ->
-        {:ok, "#{destination_string} train"}
-
-      _ ->
-        {:error, :unknown}
-    end
-  end
-
   def ad_hoc_trip_description(destination, route_id)
       when destination == :eastbound and route_id in ["Green-B", "Green-C", "Green-D", "Green-E"] do
     ad_hoc_trip_description(destination)
-  end
-
-  def ad_hoc_trip_description(destination, route_id)
-      when destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound] do
-    case {destination_to_ad_hoc_string(destination), route_to_ad_hoc_string(route_id)} do
-      {{:ok, destination_string}, {:ok, route_string}} ->
-        {:ok, "#{destination_string} #{route_string} train"}
-
-      {{:ok, _destination_string}, {:error, :unknown}} ->
-        ad_hoc_trip_description(destination)
-
-      _ ->
-        {:error, :unknown}
-    end
-  end
-
-  def ad_hoc_trip_description(destination, nil) do
-    case destination_to_ad_hoc_string(destination) do
-      {:ok, destination_string} ->
-        {:ok, "train to #{destination_string}"}
-
-      _ ->
-        {:error, :unknown}
-    end
   end
 
   def ad_hoc_trip_description(destination, route_id)
@@ -413,15 +381,48 @@ defmodule PaEss.Utilities do
   end
 
   def ad_hoc_trip_description(destination, route_id) do
-    case {destination_to_ad_hoc_string(destination), route_to_ad_hoc_string(route_id)} do
-      {{:ok, destination_string}, {:ok, route_string}} ->
-        {:ok, "#{route_string} train to #{destination_string}"}
+    case {directional_destination?(destination), route_id} do
+      {true, nil} ->
+        case destination_to_ad_hoc_string(destination) do
+          {:ok, destination_string} ->
+            {:ok, "#{destination_string} train"}
 
-      {{:ok, _destination_string}, {:error, :unknown}} ->
-        ad_hoc_trip_description(destination)
+          _ ->
+            {:error, :unknown}
+        end
 
-      _ ->
-        {:error, :unknown}
+      {true, route_id} ->
+        case {destination_to_ad_hoc_string(destination), route_to_ad_hoc_string(route_id)} do
+          {{:ok, destination_string}, {:ok, route_string}} ->
+            {:ok, "#{destination_string} #{route_string} train"}
+
+          {{:ok, _destination_string}, {:error, :unknown}} ->
+            ad_hoc_trip_description(destination)
+
+          _ ->
+            {:error, :unknown}
+        end
+
+      {false, nil} ->
+        case destination_to_ad_hoc_string(destination) do
+          {:ok, destination_string} ->
+            {:ok, "train to #{destination_string}"}
+
+          _ ->
+            {:error, :unknown}
+        end
+
+      {false, route_id} ->
+        case {destination_to_ad_hoc_string(destination), route_to_ad_hoc_string(route_id)} do
+          {{:ok, destination_string}, {:ok, route_string}} ->
+            {:ok, "#{route_string} train to #{destination_string}"}
+
+          {{:ok, _destination_string}, {:error, :unknown}} ->
+            ad_hoc_trip_description(destination)
+
+          _ ->
+            {:error, :unknown}
+        end
     end
   end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement early AM prediction changes](https://app.asana.com/0/1201753694073608/1204795336662073/f)

While implementing early AM logic, the need for having pre-recorded takes for Southbound, Northbound, etc. came up so that we could use pre-recorded takes in order to read out times (e.g. 5:03 as "five-oh-three"). I'm not certain if ARINC's TTS would handle reading times correctly and we had the takes for time readouts already so it was simple enough to just add a couple more takes for the general headway directions instead.

This had an unintended side-affect of causing all normal prediction-style readouts from using the new takes as well rather than defaulting to an ad-hoc TTS readout. This would result in readouts such as "The next train to Southbound arrives in 5 minutes".

We could rework the audio logic to use the new takes and switch up the wording, but that seemed out of scope of the original task so instead, this PR just adds the new takes but maintains the status quo of doing ad-hoc readouts for general headway directions for existing message types.
