### PR TITLE
Early AM predictions suppression content

### DIFF
--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -1,0 +1,58 @@
+defmodule Content.Audio.FirstTrainScheduled do
+  defstruct [:destination, :scheduled_time]
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination(),
+          scheduled_time: DateTime.t()
+        }
+
+  def from_messages(
+        %Content.Message.EarlyAm.DestinationTrain{destination: destination},
+        %Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled_time}
+      ) do
+    [
+      %__MODULE__{
+        destination: destination,
+        scheduled_time: scheduled_time
+      }
+    ]
+  end
+
+  def from_messages(%Content.Message.EarlyAm.DestinationScheduledTime{
+        destination: destination,
+        scheduled_time: scheduled_time
+      }) do
+    [
+      %__MODULE__{
+        destination: destination,
+        scheduled_time: scheduled_time
+      }
+    ]
+  end
+
+  defimpl Content.Audio do
+    @the_first "866"
+    @train "864"
+    @is "533"
+    @scheduled_to_arrive_at "865"
+
+    def to_params(%Content.Audio.FirstTrainScheduled{
+          destination: destination,
+          scheduled_time: scheduled_time
+        }) do
+      {:ok, destination} = PaEss.Utilities.destination_var(destination)
+
+      vars = [
+        @the_first,
+        destination,
+        @train,
+        @is,
+        @scheduled_to_arrive_at,
+        PaEss.Utilities.time_hour_var(scheduled_time.hour),
+        PaEss.Utilities.time_minutes_var(scheduled_time.minute)
+      ]
+
+      PaEss.Utilities.take_message(vars, :audio)
+    end
+  end
+end

--- a/lib/content/message/custom.ex
+++ b/lib/content/message/custom.ex
@@ -37,7 +37,7 @@ defmodule Content.Message.Custom do
 
     cond do
       String.length(message) > max_length -> false
-      Regex.match?(~r/^[a-zA-Z0-9,\/!@' ]*$/, message) -> true
+      Regex.match?(~r/^[a-zA-Z0-9,\/!@': ]*$/, message) -> true
       true -> false
     end
   end

--- a/lib/content/message/early_am/destination_scheduled_time.ex
+++ b/lib/content/message/early_am/destination_scheduled_time.ex
@@ -12,7 +12,7 @@ defmodule Content.Message.EarlyAm.DestinationScheduledTime do
           destination: destination,
           scheduled_time: scheduled_time
         }) do
-      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} due #{scheduled_time.hour}:#{Content.Utilities.format_minutes(scheduled_time.minute)}"
+      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} due #{Content.Utilities.render_datetime_as_time(scheduled_time)}"
     end
   end
 end

--- a/lib/content/message/early_am/destination_scheduled_time.ex
+++ b/lib/content/message/early_am/destination_scheduled_time.ex
@@ -1,0 +1,18 @@
+defmodule Content.Message.EarlyAm.DestinationScheduledTime do
+  @enforce_keys [:destination, :scheduled_time]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination(),
+          scheduled_time: DateTime.t()
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.EarlyAm.DestinationScheduledTime{
+          destination: destination,
+          scheduled_time: scheduled_time
+        }) do
+      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} due #{scheduled_time.hour}:#{Content.Utilities.format_minutes(scheduled_time.minute)}"
+    end
+  end
+end

--- a/lib/content/message/early_am/destination_train.ex
+++ b/lib/content/message/early_am/destination_train.ex
@@ -1,0 +1,14 @@
+defmodule Content.Message.EarlyAm.DestinationTrain do
+  @enforce_keys [:destination]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination()
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.EarlyAm.DestinationTrain{destination: destination}) do
+      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} train"
+    end
+  end
+end

--- a/lib/content/message/early_am/scheduled_time.ex
+++ b/lib/content/message/early_am/scheduled_time.ex
@@ -8,7 +8,7 @@ defmodule Content.Message.EarlyAm.ScheduledTime do
 
   defimpl Content.Message do
     def to_string(%Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled_time}) do
-      "due #{scheduled_time.hour}:#{Content.Utilities.format_minutes(scheduled_time.minute)}"
+      "due #{Content.Utilities.render_datetime_as_time(scheduled_time)}"
     end
   end
 end

--- a/lib/content/message/early_am/scheduled_time.ex
+++ b/lib/content/message/early_am/scheduled_time.ex
@@ -1,0 +1,14 @@
+defmodule Content.Message.EarlyAm.ScheduledTime do
+  @enforce_keys [:scheduled_time]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          scheduled_time: DateTime.t()
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled_time}) do
+      "due #{scheduled_time.hour}:#{Content.Utilities.format_minutes(scheduled_time.minute)}"
+    end
+  end
+end

--- a/lib/content/message/generic_paging.ex
+++ b/lib/content/message/generic_paging.ex
@@ -1,0 +1,19 @@
+defmodule Content.Message.GenericPaging do
+  @moduledoc """
+  Can be used to page between multiple full-page messages e.g. headways and early AM timestamp
+  """
+  @enforce_keys [:messages]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          messages: [Content.Message.t()]
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.GenericPaging{messages: messages}) do
+      Enum.map(messages, fn message ->
+        {Content.Message.to_string(message), 6}
+      end)
+    end
+  end
+end

--- a/lib/content/message/platform_prediction_bottom.ex
+++ b/lib/content/message/platform_prediction_bottom.ex
@@ -1,0 +1,16 @@
+defmodule Content.Message.PlatformPredictionBottom do
+  defstruct [:stop_id, :minutes]
+
+  @type t :: %__MODULE__{
+          stop_id: String.t(),
+          minutes: integer() | :boarding | :arriving | :approaching | :max_time
+        }
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.PlatformPredictionBottom{stop_id: stop_id, minutes: minutes}) do
+      if minutes == :max_time or (is_integer(minutes) and minutes > 5),
+        do: "platform TBD",
+        else: "on #{Content.Utilities.stop_platform_name(stop_id)} platform"
+    end
+  end
+end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -106,9 +106,6 @@ defmodule Content.Utilities do
   def route_branch_letter("Green-E"), do: :e
   def route_branch_letter(_), do: nil
 
-  def format_minutes(minutes) do
-    if minutes < 10,
-      do: "0#{minutes}",
-      else: "#{minutes}"
-  end
+  def render_datetime_as_time(time),
+    do: Calendar.strftime(time, "%I:%M") |> String.replace_leading("0", "")
 end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -105,4 +105,10 @@ defmodule Content.Utilities do
   def route_branch_letter("Green-D"), do: :d
   def route_branch_letter("Green-E"), do: :e
   def route_branch_letter(_), do: nil
+
+  def format_minutes(minutes) do
+    if minutes < 10,
+      do: "0#{minutes}",
+      else: "#{minutes}"
+  end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -425,6 +425,19 @@ defmodule PaEss.Utilities do
   def green_line_branch_var(:d), do: "538"
   def green_line_branch_var(:e), do: "539"
 
+  def time_hour_var(hour) when hour >= 0 and hour < 24 do
+    adjusted_hour = rem(hour, 12)
+
+    if adjusted_hour == 0,
+      do: "8011",
+      else: Integer.to_string(7999 + adjusted_hour)
+  end
+
+  def time_minutes_var(min)
+      when min >= 0 and min < 60 do
+    Integer.to_string(9000 + min)
+  end
+
   @spec replace_abbreviations(String.t()) :: String.t()
   def replace_abbreviations(text) when is_binary(text) do
     Enum.reduce(

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -287,16 +287,15 @@ defmodule Signs.Utilities.Audio do
          _multi_source?
        ) do
     if length(top_messages) != length(bottom_messages) do
-      Logger.warn(
+      Logger.error(
         "message_to_audio_warning Utilities.Audio generic_paging_mismatch some audios will be dropped: #{inspect(top_messages)} #{inspect(bottom_messages)}"
       )
     end
 
     Enum.zip(top_messages, bottom_messages)
-    |> Enum.map(fn {top, bottom} ->
+    |> Enum.flat_map(fn {top, bottom} ->
       get_audio(top, bottom, false)
     end)
-    |> List.flatten()
   end
 
   defp get_audio(

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -306,11 +306,19 @@ defmodule Signs.Utilities.Audio do
     Audio.FirstTrainScheduled.from_messages(top, bottom)
   end
 
+  # Get audio for JFK/UMass special case two-line platform prediction
   defp get_audio(
          %Message.Predictions{station_code: "RJFK"} = top_content,
          %Message.PlatformPredictionBottom{},
          multi_source?
        ) do
+    # When the JFK/UMass Mezzanine sign is paging between two full pages where
+    # one page is a prediction with platform information on the second line,
+    # we have to override the zone field in Signs.Utilities.Messages.get_messages()
+    # to avoid triggering the usual paging platform prediction. The audio readout
+    # should be read normally though with platform info, so we add the zone back in here.
+    #
+    # Additionally, the second parameter here for from_sign_content/3 is arbitrary in this case.
     Audio.Predictions.from_sign_content(%{top_content | zone: "m"}, :bottom, multi_source?)
   end
 

--- a/test/content/audio/first_scheduled_train_test.exs
+++ b/test/content/audio/first_scheduled_train_test.exs
@@ -1,0 +1,57 @@
+defmodule Content.Audio.FirstTrainScheduledTest do
+  use ExUnit.Case, async: true
+
+  describe "Content.Audio.to_params protocol" do
+    test "First train to Ashmont scheduled to arrive at 5 o'clock" do
+      audio = %Content.Audio.FirstTrainScheduled{
+        destination: :ashmont,
+        scheduled_time: ~U[2023-07-19 05:00:00Z]
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"115",
+                 [
+                   "866",
+                   "21000",
+                   "4016",
+                   "21000",
+                   "864",
+                   "21000",
+                   "533",
+                   "21000",
+                   "865",
+                   "21000",
+                   "8004",
+                   "21000",
+                   "9000"
+                 ], :audio}}
+    end
+
+    test "First train to Ashmont scheduled to arrive at 5 oh 5" do
+      audio = %Content.Audio.FirstTrainScheduled{
+        destination: :ashmont,
+        scheduled_time: ~U[2023-07-19 05:05:00Z]
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"115",
+                 [
+                   "866",
+                   "21000",
+                   "4016",
+                   "21000",
+                   "864",
+                   "21000",
+                   "533",
+                   "21000",
+                   "865",
+                   "21000",
+                   "8004",
+                   "21000",
+                   "9005"
+                 ], :audio}}
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement early AM prediction changes](https://app.asana.com/0/1201753694073608/1204795336662073/f)

Add new content structs that will be used for early AM predictions suppreesion and related helpers/unit tests
