### PR TITLE
Remove filtering subway predictions by route

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -159,17 +159,6 @@ defmodule Signs.Realtime do
   defp fetch_predictions(%{sources: sources}, state) do
     Enum.flat_map(sources, fn source ->
       state.prediction_engine.for_stop(source.stop_id, source.direction_id)
-      |> Enum.filter(fn prediction ->
-        if source.routes == nil or prediction.route_id in source.routes do
-          true
-        else
-          Logger.info(
-            "filter_prediction_by_route sign_id=#{state.id} stop_id=#{source.stop_id} direction_id=#{source.direction_id} route_id=#{prediction.route_id}"
-          )
-
-          false
-        end
-      end)
     end)
   end
 

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -78,7 +78,6 @@ defmodule Signs.Utilities.SourceConfig do
 
   * stop_id: The GTFS stop_id that it uses for prediction data.
   * routes: A list of routes that are relevant to this sign regarding alerts.
-    Predictions are also filtered based on this field.
   * direction_id: 0 or 1, used in tandem with the stop ID for predictions
   * platform: mostly null, but :ashmont | :braintree for JFK/UMass, where it's used for the "next
     train to X is approaching, on the Y platform" audio.


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate removing route-based filtering for predictions](https://app.asana.com/0/1201753694073608/1205057928541600/f)

This logic uses the `routes` fields in the source config for a stop to filter out predictions. This has caused a few instances, most recently for the new GLX stops, where trains that are being predicted in the feed do not show up on countdown clocks because the prediction is technically for a different route. A more specific example is an occasional Green Line B, C, or D train going up to Medford Tufts but not showing up on the countdown clocks because those signs source configs only had `Green-E` in the `routes` field.

In cases where there are multiple routes serving a station, there are always separate platform stop_ids that are used for each route (or route(s) for Green Line). JFK/UMass could be a potential special case but again, all platforms at that station have distinct platform stop_ids. Therefore, it should be safe and preferable to remove this filtering logic.

In addition, the historical context of this logic is that it was added to handle splitting out B and C/D predictions at Kenmore when the platform stop_ids were shared. Now we have distinct ones for the Kenmore B platforms so that further supports that we can safely remove the filtering logic https://github.com/mbta/realtime_signs/pull/166

Testing done:
- Deployed temporary logging for when predictions are filtered out by route and there were zero instances a week


