### PR TITLE
Add logic to compare to scheduled first arrival

### DIFF
--- a/lib/signs/utilities/early_am_suppression.ex
+++ b/lib/signs/utilities/early_am_suppression.ex
@@ -202,9 +202,19 @@ defmodule Signs.Utilities.EarlyAmSuppression do
                    scheduled_time: scheduled
                  }}
 
-              {headway_top, headway_bottom} ->
-                # Make sure routes is nil so that destination is used as headsign
-                {%{headway_top | destination: destination, routes: nil}, headway_bottom}
+              {headway_top, %Headways.Bottom{range: {_, high}} = headway_bottom} ->
+                # Check against schedule to account for mezzanine sources having different first scheduled arrivals
+                if DateTime.add(current_time, high, :minute) |> DateTime.compare(scheduled) == :gt do
+                  # Make sure routes is nil so that destination is used as headsign
+                  {%{headway_top | destination: destination, routes: nil}, headway_bottom}
+                else
+                  {%EarlyAm.DestinationTrain{
+                     destination: destination
+                   },
+                   %EarlyAm.ScheduledTime{
+                     scheduled_time: scheduled
+                   }}
+                end
             end
 
           [message] ->

--- a/test/signs/utilities/early_am_suppression_test.exs
+++ b/test/signs/utilities/early_am_suppression_test.exs
@@ -221,11 +221,14 @@ defmodule Signs.Utilities.EarlyAmSuppresionTest do
         {%Content.Message.Predictions{destination: :alewife, minutes: 3},
          %Content.Message.Predictions{destination: :braintree, minutes: 4, certainty: 360}}
 
+      northbound_headways_inactive = {~U[2023-07-14 09:00:00Z], :alewife}
+      southbound_headways_active = {~U[2023-07-14 08:05:00Z], :southbound}
+
       assert Signs.Utilities.EarlyAmSuppression.do_early_am_suppression(
                current_content,
                @current_time,
                {:fully_suppressed, :partially_suppressed},
-               @schedule,
+               {northbound_headways_inactive, southbound_headways_active},
                @mezzanine_sign
              ) ==
                {
@@ -241,7 +244,7 @@ defmodule Signs.Utilities.EarlyAmSuppresionTest do
                  %Content.Message.GenericPaging{
                    messages: [
                      %Content.Message.EarlyAm.ScheduledTime{
-                       scheduled_time: ~U[2023-07-14 08:00:00Z]
+                       scheduled_time: ~U[2023-07-14 09:00:00Z]
                      },
                      %Content.Message.Headways.Bottom{prev_departure_mins: nil, range: {8, 10}}
                    ]
@@ -254,11 +257,14 @@ defmodule Signs.Utilities.EarlyAmSuppresionTest do
         {%Content.Message.Predictions{destination: :alewife, minutes: 3, certainty: 360},
          %Content.Message.Predictions{destination: :braintree, minutes: 4, certainty: 360}}
 
+      southbound_headways_active = {~U[2023-07-14 08:05:00Z], :southbound}
+      northbound_headways_active = {~U[2023-07-14 08:05:00Z], :alewife}
+
       assert Signs.Utilities.EarlyAmSuppression.do_early_am_suppression(
                current_content,
                @current_time,
                {:partially_suppressed, :partially_suppressed},
-               @schedule,
+               {northbound_headways_active, southbound_headways_active},
                @mezzanine_sign
              ) ==
                {%Content.Message.Headways.Top{
@@ -391,11 +397,14 @@ defmodule Signs.Utilities.EarlyAmSuppresionTest do
            zone: "m"
          }}
 
+      southbound_headways_active = {~U[2023-07-14 08:05:00Z], :southbound}
+      northbound_headways_active = {~U[2023-07-14 08:05:00Z], :alewife}
+
       assert Signs.Utilities.EarlyAmSuppression.do_early_am_suppression(
                current_content,
                @current_time,
                {:partially_suppressed, :partially_suppressed},
-               @schedule,
+               {southbound_headways_active, northbound_headways_active},
                @mezzanine_sign
              ) ==
                {
@@ -444,11 +453,14 @@ defmodule Signs.Utilities.EarlyAmSuppresionTest do
            ]
          }}
 
+      southbound_headways_active = {~U[2023-07-14 08:05:00Z], :southbound}
+      northbound_headways_active = {~U[2023-07-14 08:05:00Z], :alewife}
+
       assert Signs.Utilities.EarlyAmSuppression.do_early_am_suppression(
                current_content,
                @current_time,
                {:partially_suppressed, :partially_suppressed},
-               @schedule,
+               {southbound_headways_active, northbound_headways_active},
                @mezzanine_sign
              ) ==
                {%Content.Message.Headways.Top{


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement early AM prediction changes](https://app.asana.com/0/1185117109217413/1204795336662073/f)

Fetching headways in RTS has some embedded logic that will fetch the first and last scheduled arrivals and compare the current time against them to see if headways should be shown or not. This logic is performed at the **sign** level rather than the source level.

In the early AM hours, this sign-level logic is causing both lines/sources of mezzanine signs to go to headways when one of the lines should have stayed on a timestamp message.

This PR adds some additional logic that does a check of the current time + upper headway range against the scheduled first arrival for the specific sources. If the headways should be active, then the logic passes on the headway messages. If the headways should not be active, it will default back to the timestamp message.
