### PR TITLE
Address early AM bugs

### DIFF
--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -13,12 +13,13 @@ defmodule Content.Message.StoppedTrain do
   require Logger
 
   @enforce_keys [:destination, :stops_away]
-  defstruct @enforce_keys ++ [:certainty]
+  defstruct @enforce_keys ++ [:certainty, :stop_id]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           stops_away: non_neg_integer(),
-          certainty: non_neg_integer() | nil
+          certainty: non_neg_integer() | nil,
+          stop_id: String.t()
         }
 
   @spec from_prediction(Predictions.Prediction.t()) :: t() | nil
@@ -34,7 +35,8 @@ defmodule Content.Message.StoppedTrain do
         %__MODULE__{
           destination: destination,
           stops_away: stops_away,
-          certainty: prediction.arrival_certainty || prediction.departure_certainty
+          certainty: prediction.arrival_certainty || prediction.departure_certainty,
+          stop_id: prediction.stop_id
         }
 
       {:error, _} ->


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement early AM prediction changes](https://app.asana.com/0/1185117109217413/1204795336662073/f)

While observing early AM predictions play out with Kevin and Jim, we spotted two bugs.

The first was that the Prudential MZ sign was filtering out reverse E branch predictions. This is because the filtering logic was using sign_ids to exempt Prudential and Symphony EB. Now, the logic uses stop_ids Prudential's MZ EB line will now also be included in the filtering logic. This required an additional change to pass the `stop_id` to `StoppedTrain` messages so that the filtering logic could access it.
![Screenshot 2023-08-17 at 10 31 40 AM](https://github.com/mbta/realtime_signs/assets/16074540/e6c13a73-9744-4b81-8152-fb2dd85c7fa7)


The second bug was one where the second line of MZ headway messages was sometimes getting cut off. This was because one of the lines was exiting the early AM state and therefore just passing along half of the headway message from the original content generation logic. To resolve this, the logic now will put the original headway message back together if the line has early AM state `:none` so that the proceeding logic will have both lines to work with.
![Screenshot 2023-08-14 at 11 17 34 AM](https://github.com/mbta/realtime_signs/assets/16074540/a69190fe-9fb6-44b7-816a-5e815a06c823)