### PR TITLE
increase red line gap filtering

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -220,14 +220,14 @@ defmodule Signs.Utilities.Predictions do
   # cause some predictions to not show up until right before they leave the
   # terminal. This makes it appear that the next train will be much later than
   # it is. At stations near Ashmont and Braintree, we're discarding any
-  # predictions following a gap of more than 18 minutes from the previous one,
+  # predictions following a gap of more than 21 minutes from the previous one,
   # since this is a reasonable indicator of this problem.
   defp filter_large_red_line_gaps([first | _] = predictions)
        when first.stop_id in ~w(70105 Braintree-01 Braintree-02 70104 70102 70100 70094 70092 70090 70088) do
     [%{seconds_until_departure: 0} | predictions]
     |> Enum.chunk_every(2, 1, :discard)
     |> Enum.take_while(fn [prev, current] ->
-      current.seconds_until_departure - prev.seconds_until_departure < 18 * 60
+      current.seconds_until_departure - prev.seconds_until_departure < 21 * 60
     end)
     |> Enum.map(&List.last/1)
   end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Refine RL prediction filtering](https://app.asana.com/0/1185117109217413/1205285065466009/f)

This increases the threshold for filtering red line prediction "gaps" from 18 to 21 minutes.