### PR TITLE
Revert "Revert "Determine emptier car location and crowding description""

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -7,14 +7,16 @@ defmodule Content.Audio.Approaching do
   alias PaEss.Utilities
 
   @enforce_keys [:destination]
-  defstruct @enforce_keys ++ [:trip_id, :platform, :route_id, new_cars?: false]
+  defstruct @enforce_keys ++
+              [:trip_id, :platform, :route_id, new_cars?: false, crowding_description: nil]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           trip_id: Predictions.Prediction.trip_id() | nil,
           platform: Content.platform() | nil,
           route_id: String.t() | nil,
-          new_cars?: boolean
+          new_cars?: boolean,
+          crowding_description: {atom(), atom()} | nil
         }
 
   defimpl Content.Audio do

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -46,51 +46,34 @@ defmodule Content.Audio.Predictions do
         ]
 
       predictions.minutes == :arriving ->
-        if predictions.crowding_data_confidence == :high do
-          # TODO: Pass along crowding data classification once available
-          [
-            %TrainIsArriving{
-              destination: predictions.destination,
-              trip_id: predictions.trip_id,
-              platform: predictions.platform,
-              route_id: predictions.route_id
-            }
-          ]
-        else
-          [
-            %TrainIsArriving{
-              destination: predictions.destination,
-              trip_id: predictions.trip_id,
-              platform: predictions.platform,
-              route_id: predictions.route_id
-            }
-          ]
-        end
+        [
+          %TrainIsArriving{
+            destination: predictions.destination,
+            trip_id: predictions.trip_id,
+            platform: predictions.platform,
+            route_id: predictions.route_id,
+            crowding_description:
+              if(predictions.crowding_data_confidence == :high,
+                do: predictions.crowding_description
+              )
+          }
+        ]
 
       predictions.minutes == :approaching and (line == :top or multi_source?) and
           predictions.route_id in @heavy_rail_routes ->
-        if predictions.crowding_data_confidence == :high do
-          # TODO: Pass along crowding data classification once available
-          [
-            %Approaching{
-              destination: predictions.destination,
-              trip_id: predictions.trip_id,
-              platform: predictions.platform,
-              route_id: predictions.route_id,
-              new_cars?: predictions.new_cars?
-            }
-          ]
-        else
-          [
-            %Approaching{
-              destination: predictions.destination,
-              trip_id: predictions.trip_id,
-              platform: predictions.platform,
-              route_id: predictions.route_id,
-              new_cars?: predictions.new_cars?
-            }
-          ]
-        end
+        [
+          %Approaching{
+            destination: predictions.destination,
+            trip_id: predictions.trip_id,
+            platform: predictions.platform,
+            route_id: predictions.route_id,
+            new_cars?: predictions.new_cars?,
+            crowding_description:
+              if(predictions.crowding_data_confidence == :high,
+                do: predictions.crowding_description
+              )
+          }
+        ]
 
       predictions.minutes == :approaching ->
         [

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -7,13 +7,14 @@ defmodule Content.Audio.TrainIsArriving do
   alias PaEss.Utilities
 
   @enforce_keys [:destination]
-  defstruct @enforce_keys ++ [:trip_id, :platform, :route_id]
+  defstruct @enforce_keys ++ [:trip_id, :platform, :route_id, crowding_description: nil]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           trip_id: Predictions.Prediction.trip_id() | nil,
           platform: Content.platform() | nil,
-          route_id: String.t() | nil
+          route_id: String.t() | nil,
+          crowding_description: {atom(), atom()} | nil
         }
 
   defimpl Content.Audio do

--- a/lib/engine/locations.ex
+++ b/lib/engine/locations.ex
@@ -142,11 +142,11 @@ defmodule Engine.Locations do
       trip_id: location["vehicle"]["trip"]["trip_id"],
       consist: location["vehicle"]["vehicle"]["consist"],
       multi_carriage_details:
-        location["vehicle"]["multi_carriage_details"] &&
-          Enum.map(
-            location["vehicle"]["multi_carriage_details"],
-            &parse_carriage_details/1
-          )
+        (location["vehicle"]["multi_carriage_details"] &&
+           Enum.map(
+             location["vehicle"]["multi_carriage_details"],
+             &parse_carriage_details/1
+           )) || []
     }
   end
 

--- a/lib/engine/locations.ex
+++ b/lib/engine/locations.ex
@@ -142,21 +142,19 @@ defmodule Engine.Locations do
       trip_id: location["vehicle"]["trip"]["trip_id"],
       consist: location["vehicle"]["vehicle"]["consist"],
       multi_carriage_details:
-        (location["vehicle"]["multi_carriage_details"] &&
-           Enum.map(
-             location["vehicle"]["multi_carriage_details"],
-             &parse_carriage_details/1
-           )) || []
+        parse_carriage_details(location["vehicle"]["multi_carriage_details"] || [])
     }
   end
 
   defp parse_carriage_details(multi_carriage_details) do
-    %Locations.CarriageDetails{
-      label: multi_carriage_details["label"],
-      occupancy_status: occupancy_status_to_atom(multi_carriage_details["occupancy_status"]),
-      occupancy_percentage: multi_carriage_details["occupancy_percentage"],
-      carriage_sequence: multi_carriage_details["carriage_sequence"]
-    }
+    Enum.map(multi_carriage_details, fn carriage_details ->
+      %Locations.CarriageDetails{
+        label: carriage_details["label"],
+        occupancy_status: occupancy_status_to_atom(carriage_details["occupancy_status"]),
+        occupancy_percentage: carriage_details["occupancy_percentage"],
+        carriage_sequence: carriage_details["carriage_sequence"]
+      }
+    end)
   end
 
   defp occupancy_status_to_atom(status) do


### PR DESCRIPTION
Reverts mbta/realtime_signs#684

Errors were occurring in Dev because the `multi_carriage_details` field is still only in dev-green and that was causing `get_crowding_description` to attempt to call `Enum.map(nil)`.

Adding a default of `[]` to the parsing logic. Tested against the prod RTR feed to make sure there are no errors.