### PR TITLE
fix time zone bug in headway accuracy logging

### DIFF
--- a/lib/headway_analysis/server.ex
+++ b/lib/headway_analysis/server.ex
@@ -41,7 +41,9 @@ defmodule HeadwayAnalysis.Server do
   @impl true
   def handle_info(:update, state) do
     schedule_update(self())
-    current_time = Timex.now()
+
+    current_time =
+      DateTime.utc_now() |> DateTime.shift_zone!(Application.get_env(:realtime_signs, :time_zone))
 
     {headway_low, headway_high} =
       case state.config_engine.headway_config(state.headway_group, current_time) do


### PR DESCRIPTION
#### Summary of changes

The headway accuracy logging was using UTC timestamps, which caused it to report the wrong headway values around the peak/off-peak transition.