### PR TITLE
fix message id for crowding audio

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -46,13 +46,13 @@ defmodule Content.Audio.Approaching do
           end
 
         {var, nil} ->
-          {:canned, {"103", [var], :audio_visual}}
+          Utilities.take_message([var], :audio_visual)
 
         {var, crowding_description} ->
-          {:canned,
-           {"104",
-            [var, @space, Content.Utilities.crowding_description_var(crowding_description)],
-            :audio_visual}}
+          Utilities.take_message(
+            [var, Content.Utilities.crowding_description_var(crowding_description)],
+            :audio_visual
+          )
       end
     end
 

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -34,13 +34,13 @@ defmodule Content.Audio.TrainIsArriving do
           end
 
         {var, nil} ->
-          {:canned, {"103", [var], :audio_visual}}
+          Utilities.take_message([var], :audio_visual)
 
         {var, crowding_description} ->
-          {:canned,
-           {"104",
-            [var, "21000", Content.Utilities.crowding_description_var(crowding_description)],
-            :audio_visual}}
+          Utilities.take_message(
+            [var, Content.Utilities.crowding_description_var(crowding_description)],
+            :audio_visual
+          )
       end
     end
 

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -74,7 +74,7 @@ defmodule Content.Audio.ApproachingTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"104", ["32123", "21000", "876"], :audio_visual}}
+               {:canned, {"105", ["32123", "21000", "876"], :audio_visual}}
     end
   end
 end

--- a/test/content/audio/train_is_arriving_test.exs
+++ b/test/content/audio/train_is_arriving_test.exs
@@ -88,7 +88,7 @@ defmodule Content.Audio.TrainIsArrivingTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"104", ["32103", "21000", "870"], :audio_visual}}
+               {:canned, {"105", ["32103", "21000", "870"], :audio_visual}}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

This fixes an issue with the audio messages for OL crowding. With the included "space" var, the total number of vars is 3, which corresponds to message id "105", not "104". Switching to `Utilities.take_message` handles this mapping and the addition of the space automatically.