### PR TITLE
disable crowding audio messages

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -45,14 +45,8 @@ defmodule Content.Audio.Approaching do
               handle_unknown_destination(audio)
           end
 
-        {var, nil} ->
+        {var, _} ->
           Utilities.take_message([var], :audio_visual)
-
-        {var, crowding_description} ->
-          Utilities.take_message(
-            [var, Content.Utilities.crowding_description_var(crowding_description)],
-            :audio_visual
-          )
       end
     end
 

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -33,14 +33,8 @@ defmodule Content.Audio.TrainIsArriving do
               nil
           end
 
-        {var, nil} ->
+        {var, _} ->
           Utilities.take_message([var], :audio_visual)
-
-        {var, crowding_description} ->
-          Utilities.take_message(
-            [var, Content.Utilities.crowding_description_var(crowding_description)],
-            :audio_visual
-          )
       end
     end
 

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -73,8 +73,9 @@ defmodule Content.Audio.ApproachingTest do
         crowding_description: {:train_level, :crowded}
       }
 
+      # Crowding disabled
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"105", ["32123", "21000", "876"], :audio_visual}}
+               {:canned, {"103", ["32123"], :audio_visual}}
     end
   end
 end

--- a/test/content/audio/train_is_arriving_test.exs
+++ b/test/content/audio/train_is_arriving_test.exs
@@ -87,8 +87,9 @@ defmodule Content.Audio.TrainIsArrivingTest do
         crowding_description: {:front, :crowded}
       }
 
+      # Crowding disabled
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"105", ["32103", "21000", "870"], :audio_visual}}
+               {:canned, {"103", ["32103"], :audio_visual}}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

This turns off generation of crowding audio for now, so we can deploy the rest of the code in the meantime. We can revert this PR when we're ready to enable it.