### PR TITLE
Add more detailed audio logging

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -124,7 +124,15 @@ defmodule PaEss.HttpUpdater do
           t()
         ) ::
           post_result()
-  defp process_send_audio(station, zones, audio, priority, timeout, sign_id, state) do
+  defp process_send_audio(
+         station,
+         zones,
+         %{__struct__: struct} = audio,
+         priority,
+         timeout,
+         sign_id,
+         state
+       ) do
     case Content.Audio.to_params(audio) do
       {:canned, {message_id, vars, type}} ->
         encoded =
@@ -141,7 +149,15 @@ defmodule PaEss.HttpUpdater do
           |> URI.encode_query()
 
         {arinc_ms, signs_ui_ms, result} = send_payload(encoded, state)
-        log("send_audio", encoded, arinc_ms: arinc_ms, signs_ui_ms: signs_ui_ms, sign_id: sign_id)
+
+        log("send_audio", encoded,
+          arinc_ms: arinc_ms,
+          signs_ui_ms: signs_ui_ms,
+          sign_id: sign_id,
+          message_type: to_string(struct) |> String.split(".") |> List.last(),
+          message_details: Map.from_struct(audio) |> inspect()
+        )
+
         result
 
       {:ad_hoc, {text, type}} ->
@@ -162,7 +178,9 @@ defmodule PaEss.HttpUpdater do
         log("send_custom_audio", encoded,
           arinc_ms: arinc_ms,
           signs_ui_ms: signs_ui_ms,
-          sign_id: sign_id
+          sign_id: sign_id,
+          message_type: to_string(struct) |> String.split(".") |> List.last(),
+          message_details: Map.from_struct(audio) |> inspect()
         )
 
         result


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Improve send_audio logging in Splunk](https://app.asana.com/0/1185117109217413/1205407137195560/f)

Include the type of audio struct that a message is being derived from in our `send_audio` and `send_custom` audio logs.

Also include a string representation of any fields and their values that belong to the struct.
