### PR TITLE
replace 20+ minutes with actual predictions

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -89,20 +89,6 @@ defmodule Content.Audio.Predictions do
           }
         ]
 
-      predictions.minutes == :max_time ->
-        [
-          %NextTrainCountdown{
-            destination: predictions.destination,
-            route_id: predictions.route_id,
-            minutes: div(Content.Utilities.max_time_seconds(), 60),
-            verb: if(predictions.terminal?, do: :departs, else: :arrives),
-            track_number: Content.Utilities.stop_track_number(predictions.stop_id),
-            platform: predictions.platform,
-            station_code: predictions.station_code,
-            zone: predictions.zone
-          }
-        ]
-
       is_integer(predictions.minutes) ->
         [
           %NextTrainCountdown{

--- a/lib/content/message/platform_prediction_bottom.ex
+++ b/lib/content/message/platform_prediction_bottom.ex
@@ -3,13 +3,13 @@ defmodule Content.Message.PlatformPredictionBottom do
 
   @type t :: %__MODULE__{
           stop_id: String.t(),
-          minutes: integer() | :boarding | :arriving | :approaching | :max_time,
+          minutes: integer() | :boarding | :arriving | :approaching,
           destination: PaEss.destination()
         }
 
   defimpl Content.Message do
     def to_string(%Content.Message.PlatformPredictionBottom{stop_id: stop_id, minutes: minutes}) do
-      if minutes == :max_time or (is_integer(minutes) and minutes > 5),
+      if is_integer(minutes) and minutes > 5,
         do: "platform TBD",
         else: "on #{Content.Utilities.stop_platform_name(stop_id)} platform"
     end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -2,10 +2,6 @@ defmodule Content.Utilities do
   @type track_number :: non_neg_integer()
   @type green_line_branch :: :b | :c | :d | :e
 
-  defmacro max_time_seconds do
-    quote do: 20 * 60
-  end
-
   def width_padded_string(left, right, width) do
     max_left_length = width - (String.length(right) + 1)
     new_left = left |> String.slice(0, max_left_length) |> String.pad_trailing(max_left_length)

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -158,12 +158,8 @@ defmodule PaEss.Utilities do
     Integer.to_string(9100 + n)
   end
 
-  def countdown_minutes_var(n) when n >= 0 and n < 30 do
+  def countdown_minutes_var(n) when n >= 0 and n <= 100 do
     Integer.to_string(5000 + n)
-  end
-
-  def countdown_minutes_var(n) when n >= 30 do
-    Integer.to_string(5030)
   end
 
   @doc "Constructs message from TAKE variables"

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -10,6 +10,8 @@ defmodule Signs.Utilities.Predictions do
   alias Signs.Utilities.SourceConfig
 
   @reverse_prediction_certainty 360
+  @max_prediction_sec 60 * 60
+  @reverse_prediction_cutoff_sec 20 * 60
 
   @spec get_messages(Signs.Realtime.predictions(), Signs.Realtime.t()) ::
           Signs.Realtime.sign_messages()
@@ -153,7 +155,9 @@ defmodule Signs.Utilities.Predictions do
   end
 
   defp approximate_time?(sec, certainty) do
-    sec && (sec > 60 * 60 || (sec > 20 * 60 && certainty == @reverse_prediction_certainty))
+    sec &&
+      (sec > @max_prediction_sec ||
+         (sec > @reverse_prediction_cutoff_sec && certainty == @reverse_prediction_certainty))
   end
 
   @spec stopped_train?(Predictions.Prediction.t()) :: boolean()

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -229,7 +229,7 @@ defmodule Content.Audio.NextTrainCountdownTest do
       assert Content.Audio.to_params(audio) == {:canned, {"90", ["4021", "503", "5005"], :audio}}
     end
 
-    test "Uses audio for 30 minutes when train is more than 30 minutes away" do
+    test "can read larger numbers" do
       audio = %Content.Audio.NextTrainCountdown{
         destination: :wonderland,
         route_id: "Blue",
@@ -239,7 +239,7 @@ defmodule Content.Audio.NextTrainCountdownTest do
         platform: nil
       }
 
-      assert Content.Audio.to_params(audio) == {:canned, {"90", ["4044", "503", "5030"], :audio}}
+      assert Content.Audio.to_params(audio) == {:canned, {"90", ["4044", "503", "5050"], :audio}}
     end
 
     test "Next D train in 5 minutes" do

--- a/test/content/audio/predictions_test.exs
+++ b/test/content/audio/predictions_test.exs
@@ -216,10 +216,11 @@ defmodule Content.Audio.PredictionsTest do
              ] = from_sign_content(predictions, :top, false)
     end
 
-    test "returns a NextTrainCountdown with 30 mins if predictions is :max_time" do
+    test "returns a NextTrainCountdown with approximate minutes" do
       predictions = %Message.Predictions{
         destination: :ashmont,
-        minutes: :max_time,
+        minutes: 20,
+        approximate?: true,
         route_id: "Red",
         stop_id: "70065"
       }

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -96,9 +96,10 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
 
-    test "Says 20+ min when train is 20 or more minutes away" do
+    test "shows approximate minutes for longer turnaround predictions" do
       prediction = %Predictions.Prediction{
-        seconds_until_arrival: 45 * 60,
+        seconds_until_arrival: 25 * 60,
+        arrival_certainty: 360,
         direction_id: 0,
         route_id: "Mattapan",
         stopped?: false,

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -334,11 +334,17 @@ defmodule Signs.RealtimeTest do
 
     test "When the train is stopped a long time away from a terminal, shows max time instead of stopped" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :mattapan, seconds_until_departure: 2020, stopped: 8)]
+        [
+          prediction(
+            destination: :mattapan,
+            seconds_until_departure: 2020,
+            stopped: 8,
+            departure_certainty: 360
+          )
+        ]
       end)
 
-      expect_messages({"Mattapan   20+ min", ""})
-      expect_audios([{:canned, {"90", ["4100", "502", "5020"], :audio}}])
+      expect_messages({"Mattapan   30+ min", ""})
 
       Signs.Realtime.handle_info(:run_loop, %{
         @sign
@@ -348,11 +354,10 @@ defmodule Signs.RealtimeTest do
 
     test "When the train is stopped a long time away, shows max time instead of stopped" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :mattapan, arrival: 1200, stopped: 8)]
+        [prediction(destination: :mattapan, arrival: 3700, stopped: 8)]
       end)
 
-      expect_messages({"Mattapan   20+ min", ""})
-      expect_audios([{:canned, {"90", ["4100", "503", "5020"], :audio}}])
+      expect_messages({"Mattapan   60+ min", ""})
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
@@ -594,7 +599,7 @@ defmodule Signs.RealtimeTest do
       seconds_until_arrival: Keyword.get(opts, :seconds_until_arrival),
       arrival_certainty: nil,
       seconds_until_departure: Keyword.get(opts, :seconds_until_departure),
-      departure_certainty: nil,
+      departure_certainty: Keyword.get(opts, :departure_certainty),
       seconds_until_passthrough: Keyword.get(opts, :seconds_until_passthrough),
       direction_id: Keyword.get(opts, :direction_id, 0),
       schedule_relationship: nil,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Replace 20+ min with actual predictions](https://app.asana.com/0/1185117109217413/1203830107648831/f)

See ticket for complete description. Additional notes:
* Fixes an issue where we were inadvertently doing immediate audio announcements of 20+ predictions.
* Fixes an edge case where predictions with nil arrival or departure times would always suppress stopped status.