### PR TITLE
Add workflow for deploying to dev-green

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -1,0 +1,34 @@
+name: Deploy to Dev-green
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: windows-2019
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+  deploy:
+    name: Deploy
+    needs: build
+    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@main
+    with:
+      app-name: realtime-signs
+      environment: dev-green
+      on-prem-cluster: hsctd-dev-managers
+      splunk-index: realtime-signs-dev-green
+      task-cpu: .5
+      task-memory: 2048M
+      task-port: 80
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      docker-repo: ${{ secrets.DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
#### Summary of changes
Adds a new GH workflow for deploying to Realtime Signs dev-green.

Note: The dev-green environment is not set up yet as of 9/12. Currently working with infra to do that.
