### PR TITLE
Fix dev green deploys

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -26,7 +26,7 @@ jobs:
       splunk-index: realtime-signs-dev-green
       task-cpu: .5
       task-memory: 2048M
-      task-port: 80
+      task-port: 8080
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,6 +24,7 @@ if config_env() != :test do
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
     message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
     monitoring_api_key: System.get_env("MONITORING_API_KEY")
+    active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH", "/headend.json"),
 end
 
 if config_env() == :dev do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,7 +24,7 @@ if config_env() != :test do
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
     message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
     monitoring_api_key: System.get_env("MONITORING_API_KEY"),
-    active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH", "/headend.json"),
+    active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH", "/headend.json")
 end
 
 if config_env() == :dev do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,7 +24,7 @@ if config_env() != :test do
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
     message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
     monitoring_api_key: System.get_env("MONITORING_API_KEY"),
-    active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH", "/headend.json")
+    active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH")
 end
 
 if config_env() == :dev do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,7 +23,7 @@ if config_env() != :test do
     message_log_s3_bucket: System.get_env("MESSAGE_LOG_S3_BUCKET"),
     message_log_s3_folder: System.get_env("MESSAGE_LOG_S3_FOLDER"),
     message_log_report_s3_folder: System.get_env("MESSAGE_LOG_REPORT_S3_FOLDER"),
-    monitoring_api_key: System.get_env("MONITORING_API_KEY")
+    monitoring_api_key: System.get_env("MONITORING_API_KEY"),
     active_headend_path: System.get_env("ACTIVE_HEADEND_S3_PATH", "/headend.json"),
 end
 

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -124,10 +124,6 @@ defmodule Engine.Config do
     updater = Application.get_env(:realtime_signs, :external_config_getter)
 
     case updater.get_active_headend_ip() do
-      {:ok, ""} ->
-        Application.put_env(:realtime_signs, :sign_head_end_host, nil)
-        Logger.info("active_headend_ip: current: nil")
-
       {:ok, active_headend_ip} ->
         Application.put_env(:realtime_signs, :sign_head_end_host, active_headend_ip)
         Logger.info("active_headend_ip: current: #{active_headend_ip}")

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -124,6 +124,10 @@ defmodule Engine.Config do
     updater = Application.get_env(:realtime_signs, :external_config_getter)
 
     case updater.get_active_headend_ip() do
+      {:ok, ""} ->
+        Application.put_env(:realtime_signs, :sign_head_end_host, nil)
+        Logger.info("active_headend_ip: current: nil")
+
       {:ok, active_headend_ip} ->
         Application.put_env(:realtime_signs, :sign_head_end_host, active_headend_ip)
         Logger.info("active_headend_ip: current: #{active_headend_ip}")

--- a/lib/external_config/s3.ex
+++ b/lib/external_config/s3.ex
@@ -3,8 +3,6 @@ defmodule ExternalConfig.S3 do
 
   @behaviour ExternalConfig.Interface
 
-  @active_headend_path "/headend.json"
-
   @impl ExternalConfig.Interface
   def get(current_version) do
     s3_client = Application.get_env(:realtime_signs, :s3_client)
@@ -37,8 +35,9 @@ defmodule ExternalConfig.S3 do
     s3_client = Application.get_env(:realtime_signs, :s3_client)
     aws_client = Application.get_env(:realtime_signs, :aws_client)
     bucket = Application.get_env(:realtime_signs, :s3_bucket)
+    active_headend_path = Application.get_env(:realtime_signs, :active_headend_path)
 
-    case s3_client.get_object(bucket, @active_headend_path)
+    case s3_client.get_object(bucket, active_headend_path)
          |> aws_client.request() do
       {:ok, response} ->
         body = Jason.decode!(response.body)
@@ -53,10 +52,11 @@ defmodule ExternalConfig.S3 do
     s3_client = Application.get_env(:realtime_signs, :s3_client)
     aws_client = Application.get_env(:realtime_signs, :aws_client)
     bucket = Application.get_env(:realtime_signs, :s3_bucket)
+    active_headend_path = Application.get_env(:realtime_signs, :active_headend_path)
 
     case s3_client.put_object(
            bucket,
-           @active_headend_path,
+           active_headend_path,
            Jason.encode!(%{active_headend_ip: ip})
          )
          |> aws_client.request() do


### PR DESCRIPTION
#### Summary of changes
We need to bind the dev-green container to a different port as port 80 is already being used by dev. Tested the workflow from the branch and was able to successfully deploy the instance.

Upon doing this, I started seeing 403 errors in Splunk indicating that Realtime Signs dev-green wasn't able to read the config file from S3. I realized that the resource list for S3 needed to be updated in Terraform to allow Realtime Signs to read the file.

While making the Terraform update, I also decided to make a similar change for the `headend.json` file that we keep in S3. This file was added fairly recently to let us manage what headend server Realtime Signs sends messages through via S3. For dev-green, the IP for the headend server should be `nil` because there is no dev-green equivalent amongst the PAESS headend servers. When the config value is set to `nil`, Realtime Signs will skip sending messages to the headend server and only send them to Signs UI, which is desirable for dev-green.