### PR TITLE
Revert 688 bhw/disable crowding

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -45,8 +45,14 @@ defmodule Content.Audio.Approaching do
               handle_unknown_destination(audio)
           end
 
-        {var, _} ->
+        {var, nil} ->
           Utilities.take_message([var], :audio_visual)
+
+        {var, crowding_description} ->
+          Utilities.take_message(
+            [var, Content.Utilities.crowding_description_var(crowding_description)],
+            :audio_visual
+          )
       end
     end
 

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -33,8 +33,14 @@ defmodule Content.Audio.TrainIsArriving do
               nil
           end
 
-        {var, _} ->
+        {var, nil} ->
           Utilities.take_message([var], :audio_visual)
+
+        {var, crowding_description} ->
+          Utilities.take_message(
+            [var, Content.Utilities.crowding_description_var(crowding_description)],
+            :audio_visual
+          )
       end
     end
 

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -203,6 +203,20 @@ defmodule Signs.Utilities.Audio do
         new_audios
       end
       |> tap(&log_crowding(&1, sign.id))
+      |> Enum.map(fn %{__struct__: audio_type} = audio ->
+        if audio_type in [Audio.Approaching, Audio.TrainIsArriving] and
+             sign.id not in [
+               "ruggles_northbound",
+               "tufts_northbound",
+               "back_bay_northbound",
+               "back_bay_southbound",
+               "back_bay_mezzanine"
+             ] do
+          %{audio | crowding_description: nil}
+        else
+          audio
+        end
+      end)
 
     {new_audios, sign}
   end

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -73,9 +73,8 @@ defmodule Content.Audio.ApproachingTest do
         crowding_description: {:train_level, :crowded}
       }
 
-      # Crowding disabled
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"103", ["32123"], :audio_visual}}
+               {:canned, {"105", ["32123", "21000", "876"], :audio_visual}}
     end
   end
 end

--- a/test/content/audio/train_is_arriving_test.exs
+++ b/test/content/audio/train_is_arriving_test.exs
@@ -87,9 +87,8 @@ defmodule Content.Audio.TrainIsArrivingTest do
         crowding_description: {:front, :crowded}
       }
 
-      # Crowding disabled
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"103", ["32103"], :audio_visual}}
+               {:canned, {"105", ["32103", "21000", "870"], :audio_visual}}
     end
   end
 end

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -834,7 +834,8 @@ defmodule Signs.Utilities.AudioTest do
             crowding_data_confidence: :high,
             crowding_description: {:front, :some_crowding}
           },
-          current_content_bottom: %Content.Message.Empty{}
+          current_content_bottom: %Content.Message.Empty{},
+          id: "back_bay_southbound"
       }
 
       {audios, _} = from_sign(sign)
@@ -881,7 +882,8 @@ defmodule Signs.Utilities.AudioTest do
             crowding_description: {:front, :some_crowding},
             trip_id: "trip1"
           },
-          current_content_bottom: %Content.Message.Empty{}
+          current_content_bottom: %Content.Message.Empty{},
+          id: "back_bay_southbound"
       }
 
       {audios, sign} = from_sign(sign)
@@ -934,7 +936,8 @@ defmodule Signs.Utilities.AudioTest do
             trip_id: "trip2"
           },
           current_content_bottom: %Content.Message.Empty{},
-          announced_approachings_with_crowding: ["trip1"]
+          announced_approachings_with_crowding: ["trip1"],
+          id: "back_bay_southbound"
       }
 
       {audios, _} = from_sign(sign)


### PR DESCRIPTION
#### Summary of changes
This reverts commit 87da0b4bcfcf2751ed38423e078877672b0639d5.

Enable crowding audio but limit it to a few stations for field testing purposes.
