### PR TITLE
Turn off OL crowding

### DIFF
--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -204,14 +204,7 @@ defmodule Signs.Utilities.Audio do
       end
       |> tap(&log_crowding(&1, sign.id))
       |> Enum.map(fn %{__struct__: audio_type} = audio ->
-        if audio_type in [Audio.Approaching, Audio.TrainIsArriving] and
-             sign.id not in [
-               "ruggles_northbound",
-               "tufts_northbound",
-               "back_bay_northbound",
-               "back_bay_southbound",
-               "back_bay_mezzanine"
-             ] do
+        if audio_type in [Audio.Approaching, Audio.TrainIsArriving] and sign.id not in [] do
           %{audio | crowding_description: nil}
         else
           audio

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -843,7 +843,7 @@ defmodule Signs.Utilities.AudioTest do
       assert [
                %Content.Audio.Approaching{
                  destination: :oak_grove,
-                 crowding_description: {:front, :some_crowding}
+                 crowding_description: nil
                }
              ] = audios
     end
@@ -891,7 +891,7 @@ defmodule Signs.Utilities.AudioTest do
       assert [
                %Content.Audio.Approaching{
                  destination: :oak_grove,
-                 crowding_description: {:front, :some_crowding}
+                 crowding_description: nil
                }
              ] = audios
 
@@ -945,7 +945,7 @@ defmodule Signs.Utilities.AudioTest do
       assert [
                %Content.Audio.TrainIsArriving{
                  destination: :oak_grove,
-                 crowding_description: {:front, :some_crowding}
+                 crowding_description: nil
                }
              ] = audios
     end


### PR DESCRIPTION
#### Summary of changes
For turning off OL crowding once field testing is done but keep logic in case we need to turn on another individual station later.

The call to `Enum.map` can be fully removed once OL crowding goes fully live.