### PR TITLE
Exclude mezzanine zones from crowding announcements

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -82,7 +82,8 @@ defmodule Content.Message.Predictions do
         true -> compute_minutes(predicted_time, certainty)
       end
 
-    {crowding_data_confidence, crowding_description} = do_crowding(prediction)
+    {crowding_data_confidence, crowding_description} =
+      if zone == "m", do: {nil, nil}, else: do_crowding(prediction)
 
     case Content.Utilities.destination_for_prediction(
            prediction.route_id,

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -60,12 +60,13 @@ defmodule Content.Message.Predictions do
           Predictions.Prediction.t(),
           String.t(),
           String.t(),
+          Signs.Realtime.t(),
           Content.platform() | nil,
           integer()
         ) :: t() | nil
-  def non_terminal(prediction, station_code, zone, platform \\ nil, width \\ 18)
+  def non_terminal(prediction, station_code, zone, sign, platform \\ nil, width \\ 18)
 
-  def non_terminal(prediction, station_code, zone, platform, width) do
+  def non_terminal(prediction, station_code, zone, sign, platform, width) do
     # e.g., North Station which is non-terminal but has trips that begin there
     predicted_time = prediction.seconds_until_arrival || prediction.seconds_until_departure
 
@@ -83,7 +84,9 @@ defmodule Content.Message.Predictions do
       end
 
     {crowding_data_confidence, crowding_description} =
-      if zone == "m", do: {nil, nil}, else: do_crowding(prediction)
+      if Signs.Utilities.SourceConfig.multi_source?(sign.source_config),
+        do: {nil, nil},
+        else: do_crowding(prediction)
 
     case Content.Utilities.destination_for_prediction(
            prediction.route_id,

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -67,6 +67,7 @@ defmodule Signs.Utilities.Predictions do
             prediction,
             station_code,
             zone,
+            sign,
             platform(prediction, sources)
           )
       end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -3,6 +3,8 @@ defmodule Content.Message.PredictionsTest do
   import ExUnit.CaptureLog
 
   describe "non_terminal/3" do
+    @sign %{source_config: nil}
+
     test "logs a warning when we cant find a headsign" do
       prediction = %Predictions.Prediction{
         seconds_until_arrival: 0,
@@ -15,7 +17,7 @@ defmodule Content.Message.PredictionsTest do
 
       log =
         capture_log([level: :warn], fn ->
-          assert is_nil(Content.Message.Predictions.non_terminal(prediction, "test", "m"))
+          assert is_nil(Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign))
         end)
 
       assert log =~ "no_destination_for_prediction"
@@ -31,7 +33,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -46,7 +48,7 @@ defmodule Content.Message.PredictionsTest do
         boarding_status: "Boarding"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -61,7 +63,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Mattapan       ARR"
     end
@@ -76,7 +78,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
@@ -91,7 +93,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Mattapan     1 min"
     end
@@ -107,7 +109,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Mattapan   20+ min"
     end
@@ -122,7 +124,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", nil, 15)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign, nil, 15)
       assert Content.Message.to_string(msg) == "Mattapan  9 min"
     end
 
@@ -136,7 +138,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
     end
@@ -151,7 +153,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
@@ -166,7 +168,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont        ARR"
     end
@@ -181,7 +183,7 @@ defmodule Content.Message.PredictionsTest do
         boarding_status: "Boarding"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
@@ -196,7 +198,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70261"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
@@ -212,7 +214,7 @@ defmodule Content.Message.PredictionsTest do
         trip_id: "trip1"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert msg.trip_id == "trip1"
     end
@@ -228,7 +230,7 @@ defmodule Content.Message.PredictionsTest do
         new_cars?: true
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert msg.new_cars?
     end
@@ -243,7 +245,7 @@ defmodule Content.Message.PredictionsTest do
         stops_away: 2
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
 
       assert Content.Message.to_string(msg) == [
                {"Alewife (A)  5 min", 6},
@@ -261,7 +263,7 @@ defmodule Content.Message.PredictionsTest do
         stops_away: 2
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
 
       assert Content.Message.to_string(msg) == [
                {"Alewife (B)  5 min", 6},
@@ -279,7 +281,7 @@ defmodule Content.Message.PredictionsTest do
         stops_away: 2
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
 
       assert Content.Message.to_string(msg) == [
                {"Alewife      6 min", 6},
@@ -434,7 +436,7 @@ defmodule Content.Message.PredictionsTest do
         new_cars?: true
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m")
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert msg.new_cars?
     end


### PR DESCRIPTION
#### Summary of changes
Mezzanine zones should be omitted from announcing crowding information.

[Slack message](https://mbta.slack.com/archives/G012H4G4U06/p1695067847876489?thread_ts=1695065179.307539&cid=G012H4G4U06) for context
