### PR TITLE
Prepare for supporting GL Terminal predictions

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -92,6 +92,8 @@ defmodule Content.Utilities do
   def stop_track_number("Forest Hills-02"), do: 2
   def stop_track_number("Oak Grove-01"), do: 1
   def stop_track_number("Oak Grove-02"), do: 2
+  def stop_track_number("Union Square-01"), do: 1
+  def stop_track_number("Union Square-02"), do: 2
   def stop_track_number(_), do: nil
 
   def stop_platform_name("70086"), do: "Ashmont"

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5592,7 +5592,7 @@
           "platform": null,
           "terminal": false,
           "announce_arriving": false,
-          "announce_boarding": false
+          "announce_boarding": true
         }
       ]
     }
@@ -7731,7 +7731,29 @@
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": false
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true
         }
       ]
     }
@@ -7756,7 +7778,29 @@
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": false
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true 
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true 
         }
       ]
     }
@@ -7785,7 +7829,29 @@
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": false
+          "announce_boarding": true
+        },
+        {
+          "stop_id": "Union Square-01",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true 
+        },
+        {
+          "stop_id": "Union Square-02",
+          "direction_id": 0,
+          "routes": [
+            "Green-D"
+          ],
+          "platform": null,
+          "terminal": true,
+          "announce_arriving": false,
+          "announce_boarding": true 
         }
       ]
     }
@@ -8319,7 +8385,7 @@
           "platform": null,
           "terminal": true,
           "announce_arriving": false,
-          "announce_boarding": false
+          "announce_boarding": true
         }
       ]
     }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add stop IDs for new GL terminal predictions](https://app.asana.com/0/1185117109217413/1205396140780846/f)

According to the Glides team, the places that will start having Glides-based predictions are:
- Boston College
- Cleveland Circle
- Riverside
- Union Square
- Medford/Tufts
- Mattapan

We only have countdown clocks at Riverside, Union Sq, and Medford/Tufts out of this list.

The configuration won't need to change for Medford Tufts or Riverside with the exception of starting to announce boardings.

The Union Sq platforms each serve both directions so they have special platform stop ids that help us tell riders which track a train is predicted to leave from. This is the same setup that we use at most heavy rail terminals.
