### PR TITLE
Change Brookline Village to use Union Sq headsign

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6096,7 +6096,7 @@
     "type": "realtime",
     "source_config": {
       "headway_group": "green_d",
-      "headway_direction_name": "North Station",
+      "headway_direction_name": "Union Square",
       "sources": [
         {
           "stop_id": "70180",


### PR DESCRIPTION
#### Summary of changes
Ad-hoc:

Brookline Village was still using North Station as the headsign. This was probably just an oversight from back when we first started sending predictions to GLX signs.
