### PR TITLE
calculate all routes from signs json

### DIFF
--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -12,7 +12,8 @@ defmodule Engine.Alerts do
   @type state :: %{
           tables: ets_tables(),
           fetcher: module(),
-          fetch_ms: integer()
+          fetch_ms: integer(),
+          all_route_ids: [String.t()]
         }
 
   @stops_table :alerts_by_stop
@@ -87,7 +88,8 @@ defmodule Engine.Alerts do
         routes_table: routes_ets_table_name
       },
       fetcher: fetcher,
-      fetch_ms: fetch_ms
+      fetch_ms: fetch_ms,
+      all_route_ids: Signs.Utilities.SignsConfig.all_route_ids()
     }
 
     {:ok, state}
@@ -97,7 +99,7 @@ defmodule Engine.Alerts do
   def handle_info(:fetch, state) do
     schedule_fetch(self(), state.fetch_ms)
 
-    case state.fetcher.get_statuses() do
+    case state.fetcher.get_statuses(state.all_route_ids) do
       {:ok, %{:stop_statuses => stop_statuses, :route_statuses => route_statuses}} ->
         :ets.delete_all_objects(state.tables.stops_table)
         :ets.insert(state.tables.stops_table, Enum.into(stop_statuses, []))

--- a/lib/engine/alerts/api_fetcher.ex
+++ b/lib/engine/alerts/api_fetcher.ex
@@ -5,7 +5,7 @@ defmodule Engine.Alerts.ApiFetcher do
 
   @impl Engine.Alerts.Fetcher
 
-  @spec get_statuses() ::
+  @spec get_statuses([String.t()]) ::
           {:ok,
            %{
              :stop_statuses => %{
@@ -16,8 +16,8 @@ defmodule Engine.Alerts.ApiFetcher do
              }
            }}
           | {:error, any()}
-  def get_statuses do
-    case get_alerts() do
+  def get_statuses(route_ids) do
+    case get_alerts(route_ids) do
       {:ok, data} ->
         {stop_statuses, route_statuses} = determine_stop_statuses(data)
         route_statuses = Map.merge(route_statuses, determine_route_statuses(data))
@@ -33,8 +33,8 @@ defmodule Engine.Alerts.ApiFetcher do
     end
   end
 
-  @spec get_alerts() :: {:ok, [%{}]} | {:error, atom()}
-  defp get_alerts do
+  @spec get_alerts([String.t()]) :: {:ok, [%{}]} | {:error, atom()}
+  defp get_alerts(route_ids) do
     alerts_url = Application.get_env(:realtime_signs, :api_v3_url) <> "/alerts"
 
     headers = api_key_headers(Application.get_env(:realtime_signs, :api_v3_key))
@@ -47,8 +47,7 @@ defmodule Engine.Alerts.ApiFetcher do
              timeout: 2000,
              recv_timeout: 2000,
              params: %{
-               "filter[route]" =>
-                 "Green-B,Green-C,Green-D,Green-E,Red,Orange,Blue,Mattapan,741,742,743,746",
+               "filter[route]" => Enum.join(route_ids, ","),
                "filter[datetime]" => "NOW"
              }
            ),

--- a/lib/engine/alerts/fetcher.ex
+++ b/lib/engine/alerts/fetcher.ex
@@ -8,7 +8,7 @@ defmodule Engine.Alerts.Fetcher do
           | :station_closure
           | :none
 
-  @callback get_statuses() ::
+  @callback get_statuses([String.t()]) ::
               {:ok,
                %{
                  :stop_statuses => %{stop_id() => stop_status()},

--- a/lib/signs/utilities/signs_config.ex
+++ b/lib/signs/utilities/signs_config.ex
@@ -35,6 +35,29 @@ defmodule Signs.Utilities.SignsConfig do
     end
   end
 
+  def all_route_ids do
+    config = children_config()
+
+    train_routes =
+      for %{"type" => "realtime"} = sign <- config,
+          %{"sources" => sources} <- List.wrap(sign["source_config"]),
+          %{"routes" => routes} <- sources,
+          route <- routes do
+        route
+      end
+
+    bus_routes =
+      for %{"type" => "bus"} = sign <- config,
+          source_list <- [sign["sources"], sign["top_sources"], sign["bottom_sources"]],
+          source_list,
+          %{"routes" => routes} <- source_list,
+          %{"route_id" => route_id} <- routes do
+        route_id
+      end
+
+    Enum.uniq(train_routes ++ bus_routes)
+  end
+
   @spec get_stop_ids_for_sign(map()) :: [String.t()]
   def get_stop_ids_for_sign(sign) do
     sign["source_config"]

--- a/test/engine/alerts/api_fetcher_test.exs
+++ b/test/engine/alerts/api_fetcher_test.exs
@@ -3,7 +3,7 @@ defmodule Engine.Alerts.ApiFetcherTest do
 
   describe "get_statuses/1" do
     test "downloads and parses the alerts" do
-      assert Engine.Alerts.ApiFetcher.get_statuses() == {
+      assert Engine.Alerts.ApiFetcher.get_statuses([]) == {
                :ok,
                %{
                  :stop_statuses => %{
@@ -30,7 +30,7 @@ defmodule Engine.Alerts.ApiFetcherTest do
       Application.put_env(:realtime_signs, :api_v3_url, "https://notreal")
       on_exit(fn -> Application.put_env(:realtime_signs, :api_v3_url, old_env) end)
 
-      assert {:error, _} = Engine.Alerts.ApiFetcher.get_statuses()
+      assert {:error, _} = Engine.Alerts.ApiFetcher.get_statuses([])
     end
   end
 end

--- a/test/engine/alerts_test.exs
+++ b/test/engine/alerts_test.exs
@@ -30,7 +30,7 @@ defmodule Engine.AlertsTest do
       @behaviour Engine.Alerts.Fetcher
 
       @impl true
-      def get_statuses do
+      def get_statuses(_) do
         {:ok,
          %{
            :stop_statuses => %{
@@ -49,7 +49,7 @@ defmodule Engine.AlertsTest do
       @behaviour Engine.Alerts.Fetcher
 
       @impl true
-      def get_statuses do
+      def get_statuses(_) do
         {:error, :didnt_work}
       end
     end
@@ -72,7 +72,8 @@ defmodule Engine.AlertsTest do
       state = %{
         tables: tables,
         fetcher: FakeAlertsFetcherHappy,
-        fetch_ms: 30_000
+        fetch_ms: 30_000,
+        all_route_ids: []
       }
 
       {:noreply, _state} = Engine.Alerts.handle_info(:fetch, state)
@@ -132,7 +133,8 @@ defmodule Engine.AlertsTest do
       state = %{
         tables: tables,
         fetcher: FakeAlertsFetcherSad,
-        fetch_ms: 30_000
+        fetch_ms: 30_000,
+        all_route_ids: []
       }
 
       log =


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Display individual bus route alerts](https://app.asana.com/0/1185117109217413/1204324618353138/f)

This is a bit of pre-work that came out of investigating the linked ticket. Calculates the list of route ids dynamically from the config, rather than hard-coding. This should ensure we're getting alerts for all bus routes, not just SL.