### PR TITLE
Single line alerts on the first line of a MZ sign should trigger a flip

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -100,6 +100,12 @@ defmodule Signs.Utilities.Messages do
       {%Content.Message.Headways.Paging{}, _} ->
         true
 
+      {%Content.Message.Alert.NoServiceUseShuttle{}, _} ->
+        true
+
+      {%Content.Message.Alert.DestinationNoService{}, _} ->
+        true
+
       _ ->
         false
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [[bug] Single-line alerts at Ashmont lobby on top line](https://app.asana.com/0/1185117109217413/1205634330387875/f)

Left out single-line alert messages when we added in the early AM logic and the `flip?` function. These messages take up 24 characters and therefore need to be on the bottom line of the sign.

Screenshot of fix running locally:
![Screenshot 2023-10-02 at 5 01 31 PM](https://github.com/mbta/realtime_signs/assets/16074540/aa31917f-5575-4045-b61e-1db8045dde01)

