### PR TITLE
Manual runs of message log jobs as Tasks

### DIFF
--- a/lib/jobs/message_latency_report.ex
+++ b/lib/jobs/message_latency_report.ex
@@ -104,11 +104,6 @@ defmodule Jobs.MessageLatencyReport do
       |> Stream.filter(&filter_by_date(&1, date))
       |> Stream.map(fn row -> row[:seconds] end)
       |> Enum.sort()
-      |> tap(fn _ ->
-        Logger.info(
-          with_message_latency_report_tag("Memory in use after sort: #{:erlang.memory(:total)}")
-        )
-      end)
       |> Stream.with_index()
       |> get_percentiles()
 

--- a/lib/realtime_signs_web/controllers/monitoring_controller.ex
+++ b/lib/realtime_signs_web/controllers/monitoring_controller.ex
@@ -17,8 +17,11 @@ defmodule RealtimeSignsWeb.MonitoringController do
   Param "date" can be in either YYYY-MM-DD or YYYYMMDD formats
   """
   def run_message_log_job(conn, %{"date" => date} = _params) do
-    Logger.info("Starting job to request and store message logs...")
-    RealtimeSigns.MessageLogJob.get_and_store_logs(date)
+    Task.start(fn ->
+      Logger.info("Starting job to request and store message logs...")
+      RealtimeSigns.MessageLogJob.get_and_store_logs(date)
+    end)
+
     send_resp(conn, 200, "")
   end
 
@@ -29,14 +32,16 @@ defmodule RealtimeSignsWeb.MonitoringController do
   Param "days" is an integer used to tell the job how many days back it should analyze
   """
   def run_message_latency_report(conn, %{"start_date" => start_date, "days" => days} = _params) do
-    Logger.info(
-      "Beginning manual run of message latency report starting from #{start_date} going back #{days} days"
-    )
+    Task.start(fn ->
+      Logger.info(
+        "Beginning manual run of message latency report starting from #{start_date} going back #{days} days"
+      )
 
-    Jobs.MessageLatencyReport.generate_message_latency_reports(
-      Date.from_iso8601!(start_date),
-      String.to_integer(days)
-    )
+      Jobs.MessageLatencyReport.generate_message_latency_reports(
+        Date.from_iso8601!(start_date),
+        String.to_integer(days)
+      )
+    end)
 
     send_resp(conn, 200, "")
   end


### PR DESCRIPTION
These manual runs currently run synchronously and the message latency report job appears to time out after a while if manually triggered via an HTTP request.

Judging from the logs, it looks like an automatic retry is triggered around the 1 minute mark which is probably killing the original process and preventing the job to run to completion which typically takes about 2 minutes. Then an error is finally returned to the client around the 2 minute mark which seems to suggest a 60 second default timeout from Phoenix for any given request. This seems to check out based off a few forum posts online. Rather than manually overriding this and extending the timeout, we can kick off the job as a background task and respond to the client immediately.
