### PR TITLE
OL crowding revision

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -206,9 +206,10 @@ defmodule Content.Message.Predictions do
           else: :f
       end
 
-    {get_emptier_location(
-       {Enum.count(relative_crowding_levels, &Kernel.==(&1, :e)), relative_crowding_levels}
-     ), crowding_level_to_atom(min_crowding_level)}
+    num_cars_min_crowding = Enum.count(relative_crowding_levels, &Kernel.==(&1, :e))
+
+    {get_emptier_location({num_cars_min_crowding, relative_crowding_levels}),
+     crowding_level_to_atom(min_crowding_level), num_cars_min_crowding}
   end
 
   defp occupancy_status_to_crowding_level(occupancy_status) do
@@ -227,7 +228,7 @@ defmodule Content.Message.Predictions do
       1 -> :not_crowded
       2 -> :some_crowding
       3 -> :crowded
-      4 -> :unknown_croding
+      4 -> :unknown_crowding
     end
   end
 

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -227,7 +227,6 @@ defmodule Content.Message.Predictions do
       3 -> :crowded
       4 -> :unknown_crowding
     end
-    |> IO.inspect()
   end
 
   defp get_emptier_location(car_crowding_levels) do

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -195,7 +195,7 @@ defmodule Content.Message.Predictions do
 
   defp get_crowding_description(carriage_details) do
     crowding_levels =
-      Enum.map(carriage_details, &occupancy_status_to_crowding_level(&1.occupancy_status))
+      Enum.map(carriage_details, &occupancy_percentage_to_crowding_level(&1.occupancy_percentage))
 
     min_crowding_level = Enum.min(crowding_levels)
 
@@ -211,14 +211,12 @@ defmodule Content.Message.Predictions do
      ), crowding_level_to_atom(min_crowding_level)}
   end
 
-  defp occupancy_status_to_crowding_level(occupancy_status) do
-    case occupancy_status do
-      :many_seats_available -> 1
-      :few_seats_available -> 1
-      :standing_room_only -> 2
-      :crushed_standing_room_only -> 3
-      :full -> 3
-      _ -> 4
+  defp occupancy_percentage_to_crowding_level(occupancy_percentage) do
+    cond do
+      occupancy_percentage <= 12 -> 1
+      occupancy_percentage <= 40 -> 2
+      occupancy_percentage > 40 -> 3
+      occupancy_percentage == nil -> 4
     end
   end
 
@@ -229,6 +227,7 @@ defmodule Content.Message.Predictions do
       3 -> :crowded
       4 -> :unknown_crowding
     end
+    |> IO.inspect()
   end
 
   defp get_emptier_location(car_crowding_levels) do

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -206,10 +206,9 @@ defmodule Content.Message.Predictions do
           else: :f
       end
 
-    num_cars_min_crowding = Enum.count(relative_crowding_levels, &Kernel.==(&1, :e))
-
-    {get_emptier_location({num_cars_min_crowding, relative_crowding_levels}),
-     crowding_level_to_atom(min_crowding_level), num_cars_min_crowding}
+    {get_emptier_location(
+       {Enum.count(relative_crowding_levels, &Kernel.==(&1, :e)), relative_crowding_levels}
+     ), crowding_level_to_atom(min_crowding_level)}
   end
 
   defp occupancy_status_to_crowding_level(occupancy_status) do

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -111,13 +111,13 @@ defmodule Content.Utilities do
 
   def crowding_description_var(crowding_description) do
     case crowding_description do
-      {:front, _} -> "870"
-      {:back, _} -> "871"
-      {:middle, _} -> "872"
-      {:front_and_back, _} -> "873"
-      {:train_level, :not_crowded} -> "874"
-      {:train_level, :some_crowding} -> "875"
-      {:train_level, :crowded} -> "876"
+      {:front, _, _} -> "870"
+      {:back, _, _} -> "871"
+      {:middle, _, _} -> "872"
+      {:front_and_back, _, _} -> "873"
+      {:train_level, :not_crowded, num_cars} when num_cars != 6 -> "874"
+      {:train_level, :some_crowding, num_cars} when num_cars != 6 -> "875"
+      {:train_level, :crowded, _} -> "876"
       _ -> "21000"
     end
   end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -115,7 +115,7 @@ defmodule Content.Utilities do
       {:back, _} -> "871"
       {:middle, _} -> "872"
       {:front_and_back, _} -> "873"
-      {:train_level, :crowded, _} -> "876"
+      {:train_level, :crowded} -> "876"
       _ -> "21000"
     end
   end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -111,12 +111,10 @@ defmodule Content.Utilities do
 
   def crowding_description_var(crowding_description) do
     case crowding_description do
-      {:front, _, _} -> "870"
-      {:back, _, _} -> "871"
-      {:middle, _, _} -> "872"
-      {:front_and_back, _, _} -> "873"
-      {:train_level, :not_crowded, num_cars} when num_cars != 6 -> "874"
-      {:train_level, :some_crowding, num_cars} when num_cars != 6 -> "875"
+      {:front, _} -> "870"
+      {:back, _} -> "871"
+      {:middle, _} -> "872"
+      {:front_and_back, _} -> "873"
       {:train_level, :crowded, _} -> "876"
       _ -> "21000"
     end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🟠🧑‍🤝‍🧑🔊 Text/Audio revisions](https://app.asana.com/0/1185117109217413/1205551289750420/f)

This PR makes some minor tweaks to the OL crowding logic.
- Crowding levels are now based off of occupancy percentages rather than occupancy status
- "some crowding" and "not crowded" train-level readouts are no longer used