### PR TITLE
Limit headways at end of service

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -8,6 +8,7 @@ defmodule Engine.ScheduledHeadways do
   use GenServer
   require Logger
   require Signs.Utilities.SignsConfig
+  alias Engine.Config.Headway
 
   @type state :: %{
           headways_ets_table: term(),
@@ -111,7 +112,7 @@ defmodule Engine.ScheduledHeadways do
         table \\ :scheduled_headways_first_last_departures,
         stop_ids,
         current_time,
-        buffer_mins
+        %Headway{range_high: range_high, range_low: range_low}
       ) do
     first_last_departures = get_first_last_departures(table, stop_ids)
 
@@ -127,7 +128,8 @@ defmodule Engine.ScheduledHeadways do
 
     case {earliest_first, earliest_last} do
       {%DateTime{} = first, %DateTime{} = last} ->
-        first = DateTime.add(first, -1 * buffer_mins * 60)
+        first = DateTime.add(first, -1 * range_high * 60)
+        last = DateTime.add(last, -1 * range_low * 60)
 
         DateTime.compare(current_time, first) == :gt and
           DateTime.compare(current_time, last) == :lt

--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -128,8 +128,8 @@ defmodule Engine.ScheduledHeadways do
 
     case {earliest_first, earliest_last} do
       {%DateTime{} = first, %DateTime{} = last} ->
-        first = DateTime.add(first, -1 * range_high * 60)
-        last = DateTime.add(last, -1 * range_low * 60)
+        first = DateTime.add(first, -1 * (range_high + 1) * 60)
+        last = DateTime.add(last, -1 * (range_low - 1) * 60)
 
         DateTime.compare(current_time, first) == :gt and
           DateTime.compare(current_time, last) == :lt

--- a/lib/engine/scheduled_headways_api.ex
+++ b/lib/engine/scheduled_headways_api.ex
@@ -1,4 +1,4 @@
 defmodule Engine.ScheduledHeadwaysAPI do
-  @callback display_headways?([String.t()], DateTime.t(), non_neg_integer()) :: boolean()
+  @callback display_headways?([String.t()], DateTime.t(), Engine.Config.Headway.t()) :: boolean()
   @callback get_first_scheduled_departure([binary]) :: nil | DateTime.t()
 end

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -61,7 +61,7 @@ defmodule Signs.Utilities.Headways do
     with headways when not is_nil(headways) <-
            sign.config_engine.headway_config(headway_group, current_time),
          true <-
-           sign.headway_engine.display_headways?(stop_ids, current_time, headways.range_high) do
+           sign.headway_engine.display_headways?(stop_ids, current_time, headways) do
       headways
     else
       _ -> nil


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Limit Headway display during end of service](https://app.asana.com/0/1205101743911491/1205695443333800/f)

Change to stop showing headway messages slightly before the last scheduled trip to be a little more accurate. 

Also added a 1 min buffer to both the start of headway messages as well as the end to be slightly more accurate. For example, if the last scheduled train is at 1:00AM and the low range of headways is 5 minutes, then it would still be fair to show headways until the clock changes to 12:56AM, but 12:56AM would be the time of the last scheduled train - **4** minutes, rather than 5 minutes.