### PR TITLE
Fix GL routes in signs.json

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6483,7 +6483,6 @@
             "stop_id": "70150",
             "direction_id": 1,
             "routes": [
-              "Green-B",
               "Green-C",
               "Green-D"
             ],
@@ -6496,9 +6495,7 @@
             "stop_id": "71150",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D"
+              "Green-B"
             ],
             "platform": null,
             "terminal": false,
@@ -6515,7 +6512,6 @@
             "stop_id": "70151",
             "direction_id": 0,
             "routes": [
-              "Green-B",
               "Green-C",
               "Green-D"
             ],
@@ -6528,9 +6524,7 @@
             "stop_id": "71151",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D"
+              "Green-B"
             ],
             "platform": null,
             "terminal": false,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -6372,9 +6372,7 @@
           "stop_id": "71150",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D"
+            "Green-B"
           ],
           "platform": null,
           "terminal": false,
@@ -6401,9 +6399,7 @@
           "stop_id": "71151",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D"
+            "Green-B"
           ],
           "platform": null,
           "terminal": false,
@@ -6430,7 +6426,6 @@
           "stop_id": "70150",
           "direction_id": 1,
           "routes": [
-            "Green-B",
             "Green-C",
             "Green-D"
           ],
@@ -6459,7 +6454,6 @@
           "stop_id": "70151",
           "direction_id": 0,
           "routes": [
-            "Green-B",
             "Green-C",
             "Green-D"
           ],
@@ -6491,8 +6485,7 @@
             "routes": [
               "Green-B",
               "Green-C",
-              "Green-D",
-              "Green-E"
+              "Green-D"
             ],
             "platform": null,
             "terminal": false,
@@ -6505,8 +6498,7 @@
             "routes": [
               "Green-B",
               "Green-C",
-              "Green-D",
-              "Green-E"
+              "Green-D"
             ],
             "platform": null,
             "terminal": false,
@@ -6525,8 +6517,7 @@
             "routes": [
               "Green-B",
               "Green-C",
-              "Green-D",
-              "Green-E"
+              "Green-D"
             ],
             "platform": null,
             "terminal": false,
@@ -6539,8 +6530,7 @@
             "routes": [
               "Green-B",
               "Green-C",
-              "Green-D",
-              "Green-E"
+              "Green-D"
             ],
             "platform": null,
             "terminal": false,
@@ -7354,8 +7344,6 @@
           "stop_id": "70203",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7384,8 +7372,6 @@
           "stop_id": "70204",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7414,8 +7400,6 @@
           "stop_id": "70205",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7444,8 +7428,6 @@
           "stop_id": "70206",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7474,8 +7456,6 @@
           "stop_id": "70206",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7504,8 +7484,6 @@
           "stop_id": "70207",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7534,8 +7512,6 @@
           "stop_id": "70208",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7565,8 +7541,6 @@
             "stop_id": "70207",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
               "Green-D",
               "Green-E"
             ],
@@ -7585,8 +7559,6 @@
             "stop_id": "70208",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
               "Green-D",
               "Green-E"
             ],
@@ -7616,8 +7588,6 @@
           "stop_id": "70501",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7646,8 +7616,6 @@
           "stop_id": "70502",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
             "Green-D",
             "Green-E"
           ],
@@ -7677,8 +7645,6 @@
             "stop_id": "70501",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
               "Green-D",
               "Green-E"
             ],
@@ -7697,8 +7663,6 @@
             "stop_id": "70502",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
               "Green-D",
               "Green-E"
             ],
@@ -7873,9 +7837,6 @@
           "stop_id": "70513",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -7903,9 +7864,6 @@
           "stop_id": "70514",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -7932,9 +7890,6 @@
             "stop_id": "70513",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -7952,9 +7907,6 @@
             "stop_id": "70514",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -7983,9 +7935,6 @@
           "stop_id": "70505",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8013,9 +7962,6 @@
           "stop_id": "70506",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8044,9 +7990,6 @@
             "stop_id": "70505",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8064,9 +8007,6 @@
             "stop_id": "70506",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8095,9 +8035,6 @@
           "stop_id": "70507",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8125,9 +8062,6 @@
           "stop_id": "70508",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8156,9 +8090,6 @@
             "stop_id": "70507",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8176,9 +8107,6 @@
             "stop_id": "70508",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8207,9 +8135,6 @@
           "stop_id": "70509",
           "direction_id": 1,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8237,9 +8162,6 @@
           "stop_id": "70510",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8268,9 +8190,6 @@
             "stop_id": "70509",
             "direction_id": 1,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8288,9 +8207,6 @@
             "stop_id": "70510",
             "direction_id": 0,
             "routes": [
-              "Green-B",
-              "Green-C",
-              "Green-D",
               "Green-E"
             ],
             "platform": null,
@@ -8317,9 +8233,6 @@
           "stop_id": "70512",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8345,9 +8258,6 @@
           "stop_id": "70512",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,
@@ -8377,9 +8287,6 @@
           "stop_id": "70512",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "platform": null,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7135,10 +7135,7 @@
           "direction_id": 0,
           "platform": null,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
+            "Green-D"
           ],
           "terminal": false,
           "announce_arriving": false,
@@ -7150,9 +7147,6 @@
           "direction_id": 0,
           "platform": null,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
             "Green-E"
           ],
           "terminal": false,
@@ -7180,10 +7174,7 @@
           "stop_id": "70196",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
+            "Green-B"
           ],
           "platform": null,
           "terminal": false,
@@ -7195,10 +7186,7 @@
           "stop_id": "70197",
           "direction_id": 0,
           "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
+            "Green-C"
           ],
           "platform": null,
           "terminal": false,


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate modifying headway destination based on (GL branch) service suspensions](https://app.asana.com/0/1185117109217413/1205572772013992/f)

In #663 we removed an old piece of logic that filtered predictions based off of the `routes` field in the source config. Now that that's gone, we don't need to do weird stuff in the `signs.json` file in order to get outlier predictions to show (ex. the occasional D train going down the Medford branch).

This change adjusts the routes fields for a handful of GL stations so that they accurately reflect what branches typically serve them. The change is also meant to set us up in anticipation of future logic for checking for downstream suspensions.
