### PR TITLE
Temporarily enable back bay and tufts

### DIFF
--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -148,8 +148,8 @@ defmodule Signs.Utilities.Audio do
              sign.id not in [
                "back_bay_northbound",
                "back_bay_southbound",
-               "tufts_northbound",
-               "tufts_southbound"
+               "chinatown_northbound",
+               "chinatown_northbound_lobby"
              ] do
           %{audio | crowding_description: nil}
         else

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -144,7 +144,13 @@ defmodule Signs.Utilities.Audio do
     # Disable crowding messages for now
     new_audios =
       Enum.map(new_audios, fn %{__struct__: audio_type} = audio ->
-        if audio_type in [Audio.Approaching, Audio.TrainIsArriving] and sign.id not in [] do
+        if audio_type in [Audio.Approaching, Audio.TrainIsArriving] and
+             sign.id not in [
+               "back_bay_northbound",
+               "back_bay_southbound",
+               "tufts_northbound",
+               "tufts_southbound"
+             ] do
           %{audio | crowding_description: nil}
         else
           audio


### PR DESCRIPTION
#### Summary of changes
Temporarily enable crowding announcements on Back Bay and Tufts platforms for a field test on 10/24
