### PR TITLE
Chore: Update workflow to v2

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
-    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@main
+    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@v2
     with:
       app-name: realtime-signs
       environment: dev-green
@@ -30,7 +30,6 @@ jobs:
       task-memory: 2048M
       task-port: 8080
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
-    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@main
+    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@v2
     with:
       app-name: realtime-signs
       environment: dev
@@ -32,7 +32,6 @@ jobs:
       task-memory: 2048M
       task-port: 80
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@main
+    uses: mbta/workflows/.github/workflows/deploy-on-prem.yml@v2
     with:
       app-name: realtime-signs
       environment: prod
@@ -16,7 +16,6 @@ jobs:
       task-memory: 2048M
       task-port: 80
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
#### Summary of changes
This PR updates the deploy workflow to use v2 of the `deploy-ecs` workflow. This updated workflow assumes an IAM role instead of relying on long-lasting AWS keys for an IAM user

Successful deploy [here](https://github.com/mbta/realtime_signs/actions/runs/6631759657)