### PR TITLE
Split Lechmere into two visual zones

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -9152,7 +9152,7 @@
     "max_minutes": 60
   },
   {
-    "id": "bus.Lechmere_bus_mezzanine",
+    "id": "bus.Lechmere_inner",
     "pa_ess_loc": "SLEC",
     "read_loop_interval": 360,
     "read_loop_offset": 180,
@@ -9179,7 +9179,21 @@
             "direction_id": 0
           }
         ]
-      },
+      }
+    ],
+    "max_minutes": 60
+  },
+  {
+    "id": "bus.Lechmere_outer",
+    "pa_ess_loc": "SLEC",
+    "read_loop_interval": 360,
+    "read_loop_offset": 0,
+    "text_zone": "c",
+    "audio_zones": [
+      "m"
+    ],
+    "type": "bus",
+    "configs": [
       {
         "sources": [
           {

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -9181,7 +9181,28 @@
         ]
       }
     ],
+    "extra_audio_configs": [
+      { 
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "87",
+            "direction_id": 0
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "stop_id": "70500",
+            "route_id": "88",
+            "direction_id": 0
+          }
+        ]
+      }
+    ],
     "max_minutes": 60
+
   },
   {
     "id": "bus.Lechmere_outer",
@@ -9189,9 +9210,7 @@
     "read_loop_interval": 360,
     "read_loop_offset": 0,
     "text_zone": "c",
-    "audio_zones": [
-      "m"
-    ],
+    "audio_zones": [],
     "type": "bus",
     "configs": [
       {


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Split Lechmere busway into two visual zones](https://app.asana.com/0/1185117109217413/1205857754053049/f)

Split the Lechmere busway into two visual zones that share the same audio zone.

Inner zone should show routes 69 and 80 and the outer zone should show route 87 and 88.
