### PR TITLE
Support Temporary Terminal mode

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -19,7 +19,8 @@ defmodule Engine.Config do
           time_fetcher: (() -> DateTime.t())
         }
 
-  @type sign_config :: :auto | :headway | :off | {:static_text, {String.t(), String.t()}}
+  @type sign_config ::
+          :auto | :headway | :off | :temporary_terminal | {:static_text, {String.t(), String.t()}}
 
   @table_signs :config_engine_signs
   @table_headways :config_engine_headways
@@ -181,6 +182,9 @@ defmodule Engine.Config do
 
       config_json["mode"] == "headway" ->
         :headway
+
+      config_json["mode"] == "temporary_terminal" ->
+        :temporary_terminal
 
       true ->
         :off

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -36,21 +36,16 @@ defmodule Signs.Utilities.Messages do
           get_alert_messages(alert_status, sign) ||
             Signs.Utilities.Headways.get_messages(sign, current_time)
 
-        sign_config == :temporary_terminal and
-            alert_status in [:shuttles_transfer_station, :suspension_transfer_station] ->
-          case Signs.Utilities.Predictions.get_messages(predictions, sign) do
-            {%Content.Message.Empty{}, %Content.Message.Empty{}} ->
-              Signs.Utilities.Headways.get_messages(sign, current_time)
-
-            messages ->
-              messages
-          end
-
         true ->
           case Signs.Utilities.Predictions.get_messages(predictions, sign) do
             {%Content.Message.Empty{}, %Content.Message.Empty{}} ->
-              get_alert_messages(alert_status, sign) ||
+              if sign_config == :temporary_terminal and
+                   alert_status in [:shuttles_transfer_station, :suspension_transfer_station] do
                 Signs.Utilities.Headways.get_messages(sign, current_time)
+              else
+                get_alert_messages(alert_status, sign) ||
+                  Signs.Utilities.Headways.get_messages(sign, current_time)
+              end
 
             {top_message, %Content.Message.Empty{}} ->
               {top_message,

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -33,12 +33,24 @@ defmodule Signs.Utilities.Messages do
           {Content.Message.Empty.new(), Content.Message.Empty.new()}
 
         sign_config == :headway ->
-          get_headway_or_alert_messages(sign, current_time, alert_status)
+          get_alert_messages(alert_status, sign) ||
+            Signs.Utilities.Headways.get_messages(sign, current_time)
+
+        sign_config == :temporary_terminal and
+            alert_status in [:shuttles_transfer_station, :suspension_transfer_station] ->
+          case Signs.Utilities.Predictions.get_messages(predictions, sign) do
+            {%Content.Message.Empty{}, %Content.Message.Empty{}} ->
+              Signs.Utilities.Headways.get_messages(sign, current_time)
+
+            messages ->
+              messages
+          end
 
         true ->
           case Signs.Utilities.Predictions.get_messages(predictions, sign) do
             {%Content.Message.Empty{}, %Content.Message.Empty{}} ->
-              get_headway_or_alert_messages(sign, current_time, alert_status)
+              get_alert_messages(alert_status, sign) ||
+                Signs.Utilities.Headways.get_messages(sign, current_time)
 
             {top_message, %Content.Message.Empty{}} ->
               {top_message,
@@ -148,16 +160,6 @@ defmodule Signs.Utilities.Messages do
       message ->
         {message, prediction}
     end
-  end
-
-  @spec get_headway_or_alert_messages(
-          Signs.Realtime.t(),
-          DateTime.t(),
-          Engine.Alerts.Fetcher.stop_status()
-        ) :: Signs.Realtime.sign_messages()
-  defp get_headway_or_alert_messages(sign, current_time, alert_status) do
-    get_alert_messages(alert_status, sign) ||
-      Signs.Utilities.Headways.get_messages(sign, current_time)
   end
 
   @spec get_paging_headway_or_alert_messages(


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add a Temporary Terminal mode in Signs UI](https://app.asana.com/0/1185117109217413/1205911324913693/f)

Adds handling of a new mode `:temporary_terminal` that will show predictions if there are any, and otherwise show headways.

If the sign is set to `:temporary_terminal` but the alert status does not indicate that the sign is at the boundary of an alert, t will default to `:auto` behavior. 
