### PR TITLE
Migrate off of consist field

### DIFF
--- a/lib/engine/locations.ex
+++ b/lib/engine/locations.ex
@@ -140,7 +140,6 @@ defmodule Engine.Locations do
       timestamp: location["vehicle"]["timestamp"],
       route_id: location["vehicle"]["trip"]["route_id"],
       trip_id: location["vehicle"]["trip"]["trip_id"],
-      consist: location["vehicle"]["vehicle"]["consist"],
       multi_carriage_details:
         parse_carriage_details(location["vehicle"]["multi_carriage_details"] || [])
     }

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -277,11 +277,6 @@ defmodule Fake.HTTPoison do
                 "trip_id" => "32568935"
               },
               "vehicle" => %{
-                "consist" => [
-                  %{
-                    "label" => "3260"
-                  }
-                ],
                 "id" => "G-10040",
                 "label" => "3260",
                 "license_plate" => nil
@@ -388,11 +383,6 @@ defmodule Fake.HTTPoison do
                 "trip_id" => "32568935"
               },
               "vehicle" => %{
-                "consist" => [
-                  %{
-                    "label" => "3260"
-                  }
-                ],
                 "id" => "G-10040",
                 "label" => "3260",
                 "license_plate" => nil

--- a/lib/locations/location.ex
+++ b/lib/locations/location.ex
@@ -5,7 +5,6 @@ defmodule Locations.Location do
             timestamp: nil,
             route_id: nil,
             trip_id: nil,
-            consist: [],
             multi_carriage_details: []
 
   @type t :: %__MODULE__{
@@ -15,7 +14,6 @@ defmodule Locations.Location do
           timestamp: DateTime.t() | nil,
           route_id: String.t() | nil,
           trip_id: String.t() | nil,
-          consist: list(),
           multi_carriage_details: list(Locations.CarriageDetails.t())
         }
 end

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -13,7 +13,6 @@ defmodule Predictions.Prediction do
             stopped?: false,
             stops_away: 0,
             boarding_status: nil,
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: nil
 
@@ -34,7 +33,6 @@ defmodule Predictions.Prediction do
           stopped?: boolean(),
           stops_away: integer(),
           boarding_status: String.t() | nil,
-          new_cars?: boolean(),
           revenue_trip?: boolean(),
           vehicle_id: String.t() | nil
         }

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -60,7 +60,7 @@ defmodule Signs.Utilities.Predictions do
           Content.Message.StoppedTrain.from_prediction(prediction)
 
         terminal_prediction?(prediction, sources) ->
-          Content.Message.Predictions.terminal(prediction, station_code, zone)
+          Content.Message.Predictions.terminal(prediction, station_code, zone, sign)
 
         true ->
           Content.Message.Predictions.non_terminal(

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -90,7 +90,6 @@ defmodule Predictions.PredictionsTest do
             stopped?: false,
             destination_stop_id: "70261",
             trip_id: "32568935",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "G-10040"
           }
@@ -107,7 +106,6 @@ defmodule Predictions.PredictionsTest do
             stopped?: true,
             boarding_status: "Stopped 1 stop away",
             trip_id: "32568935",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "G-10040"
           }
@@ -123,7 +121,6 @@ defmodule Predictions.PredictionsTest do
             stops_away: nil,
             stopped?: false,
             trip_id: "32568935",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "G-10040"
           }
@@ -264,7 +261,6 @@ defmodule Predictions.PredictionsTest do
                 "trip_id" => "40826503"
               },
               "vehicle" => %{
-                "consist" => [],
                 "id" => nil,
                 "label" => nil,
                 "license_plate" => nil
@@ -292,7 +288,6 @@ defmodule Predictions.PredictionsTest do
             stops_away: 1,
             destination_stop_id: "70261",
             trip_id: "32568935",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "G-10040"
           }
@@ -308,7 +303,6 @@ defmodule Predictions.PredictionsTest do
             stops_away: 1,
             destination_stop_id: "70261",
             trip_id: "32568935",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "G-10040"
           }
@@ -324,7 +318,6 @@ defmodule Predictions.PredictionsTest do
             stops_away: 1,
             destination_stop_id: "70060",
             trip_id: "trip_2",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "vehicle_2"
           }
@@ -340,7 +333,6 @@ defmodule Predictions.PredictionsTest do
             stops_away: 1,
             destination_stop_id: "70060",
             trip_id: "trip_2",
-            new_cars?: false,
             revenue_trip?: true,
             vehicle_id: "vehicle_2"
           }
@@ -411,7 +403,6 @@ defmodule Predictions.PredictionsTest do
                     stops_away: 1,
                     destination_stop_id: "70263",
                     trip_id: "32568935",
-                    new_cars?: false,
                     revenue_trip?: true,
                     vehicle_id: "G-10040"
                   }
@@ -506,7 +497,6 @@ defmodule Predictions.PredictionsTest do
                    boarding_status: nil,
                    destination_stop_id: "70262",
                    direction_id: 0,
-                   new_cars?: false,
                    revenue_trip?: true,
                    route_id: "Mattapan",
                    schedule_relationship: :scheduled,
@@ -521,270 +511,6 @@ defmodule Predictions.PredictionsTest do
                  }
                ]
              }
-    end
-
-    test "identifies new Orange Line cars" do
-      feed_message = %{
-        "entity" => [
-          %{
-            "alert" => nil,
-            "id" => "1490783458_32568935",
-            "is_deleted" => false,
-            "trip_update" => %{
-              "delay" => nil,
-              "stop_time_update" => [
-                %{
-                  "arrival" => %{
-                    "delay" => nil,
-                    "time" => 1_491_570_180,
-                    "uncertainty" => nil
-                  },
-                  "departure" => nil,
-                  "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70001",
-                  "stops_away" => 1,
-                  "stopped?" => false,
-                  "stop_sequence" => 1
-                }
-              ],
-              "timestamp" => nil,
-              "trip" => %{
-                "direction_id" => 0,
-                "route_id" => "Orange",
-                "schedule_relationship" => "SCHEDULED",
-                "start_date" => "20170329",
-                "start_time" => nil,
-                "trip_id" => "32568935"
-              },
-              "vehicle" => %{
-                "id" => "O-545EF880",
-                "label" => "1400",
-                "license_plate" => nil,
-                "consist" => [
-                  %{"label" => "1400"},
-                  %{"label" => "1401"},
-                  %{"label" => "1402"},
-                  %{"label" => "1403"},
-                  %{"label" => "1404"},
-                  %{"label" => "1405"}
-                ]
-              }
-            },
-            "vehicle" => nil
-          }
-        ],
-        "header" => %{
-          "gtfs_realtime_version" => "1.0",
-          "incrementality" => "FULL_DATASET",
-          "timestamp" => 1_490_783_458
-        }
-      }
-
-      assert {%{
-                {"70001", 0} => [
-                  %Predictions.Prediction{
-                    new_cars?: true
-                  }
-                ]
-              }, _} = get_all(feed_message, @current_time)
-    end
-
-    test "identifies old Orange Line cars" do
-      feed_message = %{
-        "entity" => [
-          %{
-            "alert" => nil,
-            "id" => "1490783458_32568935",
-            "is_deleted" => false,
-            "trip_update" => %{
-              "delay" => nil,
-              "stop_time_update" => [
-                %{
-                  "arrival" => %{
-                    "delay" => nil,
-                    "time" => 1_491_570_180,
-                    "uncertainty" => nil
-                  },
-                  "departure" => nil,
-                  "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70001",
-                  "stops_away" => 1,
-                  "stopped?" => false,
-                  "stop_sequence" => 1
-                }
-              ],
-              "timestamp" => nil,
-              "trip" => %{
-                "direction_id" => 0,
-                "route_id" => "Orange",
-                "schedule_relationship" => "SCHEDULED",
-                "start_date" => "20170329",
-                "start_time" => nil,
-                "trip_id" => "32568935"
-              },
-              "vehicle" => %{
-                "id" => "O-545EF880",
-                "label" => "1400",
-                "license_plate" => nil,
-                "consist" => [
-                  %{"label" => "1294"},
-                  %{"label" => "1295"},
-                  %{"label" => "1223"},
-                  %{"label" => "1222"},
-                  %{"label" => "1270"},
-                  %{"label" => "1271"}
-                ]
-              }
-            },
-            "vehicle" => nil
-          }
-        ],
-        "header" => %{
-          "gtfs_realtime_version" => "1.0",
-          "incrementality" => "FULL_DATASET",
-          "timestamp" => 1_490_783_458
-        }
-      }
-
-      assert {%{
-                {"70001", 0} => [
-                  %Predictions.Prediction{
-                    new_cars?: false
-                  }
-                ]
-              }, _} = get_all(feed_message, @current_time)
-    end
-
-    test "identifies new Red Line cars" do
-      feed_message = %{
-        "entity" => [
-          %{
-            "alert" => nil,
-            "id" => "1490783458_32568935",
-            "is_deleted" => false,
-            "trip_update" => %{
-              "delay" => nil,
-              "stop_time_update" => [
-                %{
-                  "arrival" => %{
-                    "delay" => nil,
-                    "time" => 1_491_570_180,
-                    "uncertainty" => nil
-                  },
-                  "departure" => nil,
-                  "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70061",
-                  "stops_away" => 1,
-                  "stopped?" => false,
-                  "stop_sequence" => 1
-                }
-              ],
-              "timestamp" => nil,
-              "trip" => %{
-                "direction_id" => 1,
-                "route_id" => "Red",
-                "schedule_relationship" => "SCHEDULED",
-                "start_date" => "20170329",
-                "start_time" => nil,
-                "trip_id" => "32568935"
-              },
-              "vehicle" => %{
-                "id" => "R-545EF880",
-                "label" => "1900",
-                "license_plate" => nil,
-                "consist" => [
-                  %{"label" => "1900"},
-                  %{"label" => "1901"},
-                  %{"label" => "1902"},
-                  %{"label" => "1903"},
-                  %{"label" => "1905"},
-                  %{"label" => "1904"}
-                ]
-              }
-            },
-            "vehicle" => nil
-          }
-        ],
-        "header" => %{
-          "gtfs_realtime_version" => "1.0",
-          "incrementality" => "FULL_DATASET",
-          "timestamp" => 1_490_783_458
-        }
-      }
-
-      assert {%{
-                {"70061", 1} => [
-                  %Predictions.Prediction{
-                    new_cars?: true
-                  }
-                ]
-              }, _} = get_all(feed_message, @current_time)
-    end
-
-    test "identifies old Red Line cars" do
-      feed_message = %{
-        "entity" => [
-          %{
-            "alert" => nil,
-            "id" => "1490783458_32568935",
-            "is_deleted" => false,
-            "trip_update" => %{
-              "delay" => nil,
-              "stop_time_update" => [
-                %{
-                  "arrival" => %{
-                    "delay" => nil,
-                    "time" => 1_491_570_180,
-                    "uncertainty" => nil
-                  },
-                  "departure" => nil,
-                  "schedule_relationship" => "SCHEDULED",
-                  "stop_id" => "70061",
-                  "stops_away" => 1,
-                  "stopped?" => false,
-                  "stop_sequence" => 1
-                }
-              ],
-              "timestamp" => nil,
-              "trip" => %{
-                "direction_id" => 1,
-                "route_id" => "Red",
-                "schedule_relationship" => "SCHEDULED",
-                "start_date" => "20170329",
-                "start_time" => nil,
-                "trip_id" => "32568935"
-              },
-              "vehicle" => %{
-                "id" => "R-545EF880",
-                "label" => "1706",
-                "license_plate" => nil,
-                "consist" => [
-                  %{"label" => "1706"},
-                  %{"label" => "1707"},
-                  %{"label" => "1502"},
-                  %{"label" => "1503"},
-                  %{"label" => "1750"},
-                  %{"label" => "1751"}
-                ]
-              }
-            },
-            "vehicle" => nil
-          }
-        ],
-        "header" => %{
-          "gtfs_realtime_version" => "1.0",
-          "incrementality" => "FULL_DATASET",
-          "timestamp" => 1_490_783_458
-        }
-      }
-
-      assert {%{
-                {"70061", 1} => [
-                  %Predictions.Prediction{
-                    new_cars?: false
-                  }
-                ]
-              }, _} = get_all(feed_message, @current_time)
     end
 
     test "include predictions with low uncertainty" do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Transition from 'consist' to `multi_carriage_details'](https://app.asana.com/0/1185117109217413/1205822469391764/f)

The transit data team is moving away from the `consist` field by mid December. We only use consist data to identify when a Red Line train so the migration doesn't have a major impact on us, but does mean that we need to fetch the same info from the locations feed now rather than directly from the predictions feed.
