### PR TITLE
Default to arrival time for schedules

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -213,7 +213,9 @@ defmodule Engine.ScheduledHeadways do
     Map.new(schedule_data, fn {stop_id, schedules} ->
       {stop_id,
        Enum.reduce(schedules, [], fn sched, acc ->
-         departure_time = get_in(sched, ["attributes", "departure_time"])
+         departure_time =
+           get_in(sched, ["attributes", "departure_time"]) ||
+             get_in(sched, ["attributes", "arrival_time"])
 
          with false <- is_nil(departure_time),
               {:ok, parsed_time} <- Timex.parse(departure_time, "{ISO:Extended}") do

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -111,7 +111,7 @@ defmodule Engine.ScheduledHeadwaysTest do
           ["first_last_departures"]
         )
 
-      assert DateTime.to_naive(first_departure) == ~N[2017-07-04 08:45:00]
+      assert DateTime.to_naive(first_departure) == ~N[2017-07-04 08:35:00]
       assert DateTime.to_naive(last_departure) == ~N[2017-07-04 09:20:00]
     end
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Revise display logic for departure/arrival times](https://app.asana.com/0/1185117109217413/1206103644850840/f)

Small change to add some resiliency to our schedules logic considering some weird data we saw from the API.
