### PR TITLE
Union Sq defaults to using custom alert messaging

### DIFF
--- a/lib/content/audio/closure.ex
+++ b/lib/content/audio/closure.ex
@@ -25,6 +25,10 @@ defmodule Content.Audio.Closure do
     [%Content.Audio.Closure{alert: :suspension_closed_station, routes: routes}]
   end
 
+  def from_messages(%Content.Message.Alert.NoService{}, %Content.Message.Alert.UseRoutes{}) do
+    [%Content.Audio.Closure{alert: :use_routes_alert}]
+  end
+
   def from_messages(top, bottom) do
     Logger.error("message_to_audio_error Audio.Closure #{inspect(top)} #{inspect(bottom)}")
     []
@@ -46,6 +50,11 @@ defmodule Content.Audio.Closure do
         PaEss.Utilities.get_line_from_routes_list(routes) |> PaEss.Utilities.line_to_var()
 
       PaEss.Utilities.take_message([@there_is_no, line_var, @service_at_this_station], :audio)
+    end
+
+    # Hardcoded for Union Square
+    def to_params(%Content.Audio.Closure{alert: :use_routes_alert, routes: []}) do
+      {:ad_hoc, {"No Train Service. Use routes 86, 87, or 91", :audio}}
     end
   end
 end

--- a/lib/content/message/alert/use_routes.ex
+++ b/lib/content/message/alert/use_routes.ex
@@ -1,0 +1,15 @@
+defmodule Content.Message.Alert.UseRoutes do
+  @moduledoc """
+  Custom default message for Union Sq because it does not get shuttle service
+  """
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+
+  defimpl Content.Message do
+    def to_string(_) do
+      "Use Routes 86, 87, or 91"
+    end
+  end
+end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -180,18 +180,15 @@ defmodule Signs.Utilities.Messages do
   end
 
   defp get_alert_messages(alert_status, %{text_id: {"GUNS", _}}) do
-    cond do
-      alert_status in [:none, :alert_along_route] ->
-        nil
-
-      true ->
-        {%Alert.NoService{}, %Alert.UseRoutes{}}
-    end
+    if alert_status in [:none, :alert_along_route],
+      do: nil,
+      else: {%Alert.NoService{}, %Alert.UseRoutes{}}
   end
 
   @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
           Signs.Realtime.sign_messages() | nil
   defp get_alert_messages(alert_status, sign) do
+    IO.inspect(sign)
     sign_routes = Signs.Utilities.SourceConfig.sign_routes(sign.source_config)
 
     case {alert_status, sign.uses_shuttles} do

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -179,6 +179,16 @@ defmodule Signs.Utilities.Messages do
     Content.Message.Empty.new()
   end
 
+  defp get_alert_messages(alert_status, %{text_id: {"GUNS", _}}) do
+    cond do
+      alert_status in [:none, :alert_along_route] ->
+        nil
+
+      true ->
+        {%Alert.NoService{}, %Alert.UseRoutes{}}
+    end
+  end
+
   @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
           Signs.Realtime.sign_messages() | nil
   defp get_alert_messages(alert_status, sign) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Adjust the default message for alerts that include Union Sq](https://app.asana.com/0/1185117109217413/1206049304225903/f)

Union Sq never gets shuttle service so OIOs have requested that we change Union Sq's default alert messaging to say

```
No Train Service
Use Routes 86, 87, or 91
```
