### PR TITLE
Add GL-NB to North Station concourse signs

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7430,24 +7430,44 @@
       "m"
     ],
     "type": "realtime",
-    "source_config": {
-      "headway_group": "green_trunk",
-      "headway_direction_name": "Inbound",
-      "sources": [
-        {
-          "stop_id": "70206",
-          "direction_id": 0,
-          "routes": [
-            "Green-D",
-            "Green-E"
-          ],
-          "platform": null,
-          "terminal": false,
-          "announce_arriving": false,
-          "announce_boarding": true
-        }
-      ]
-    }
+    "source_config": [
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Outbound",
+        "sources": [
+          {
+            "stop_id": "70205",
+            "direction_id": 1,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      },
+      {
+        "headway_group": "green_trunk",
+        "headway_direction_name": "Inbound",
+        "sources": [
+          {
+            "stop_id": "70206",
+            "direction_id": 0,
+            "routes": [
+              "Green-D",
+              "Green-E"
+            ],
+            "platform": null,
+            "terminal": false,
+            "announce_arriving": false,
+            "announce_boarding": true
+          }
+        ]
+      }
+    ]
   },
   {
     "id": "science_park_eastbound",


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Add GL-NB to North Station concourse signs](https://app.asana.com/0/1185117109217413/1200592856846313/f)

Update the config for `green_north_station_commuter_rail_exit` to be like a mezzanine sign.
![Screenshot 2024-01-23 at 12 39 17 PM](https://github.com/mbta/realtime_signs/assets/16074540/ad618fff-ea56-449a-b8b2-9e154f5084cf)
