### PR TITLE
remove unused code for spanish headway readouts

### DIFF
--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -6,86 +6,38 @@ defmodule Content.Audio.VehiclesToDestination do
   require Logger
   alias PaEss.Utilities
 
-  @enforce_keys [:language, :destination, :headway_range]
+  @enforce_keys [:destination, :headway_range]
   defstruct @enforce_keys ++ [:routes]
 
   @type t :: %__MODULE__{
-          language: Content.Audio.language(),
           destination: PaEss.destination() | nil,
           headway_range: {non_neg_integer(), non_neg_integer()},
           routes: [String.t()] | nil
         }
 
   def from_headway_message(
-        %Content.Message.Headways.Top{destination: nil, routes: routes},
+        %Content.Message.Headways.Top{destination: destination, routes: routes},
         %Content.Message.Headways.Bottom{range: range}
-      )
-      when not is_nil(routes) do
+      ) do
     [
       %__MODULE__{
-        language: :english,
-        destination: nil,
+        destination: destination,
         headway_range: range,
         routes: routes
       }
     ]
   end
 
-  @spec from_headway_message(Content.Message.t(), Content.Message.t()) :: [t()]
-  def from_headway_message(
-        %Content.Message.Headways.Top{destination: destination},
-        %Content.Message.Headways.Bottom{range: range}
-      ) do
-    create(:english, destination, range) ++ create(:spanish, destination, range)
-  end
-
-  def from_headway_message(top, bottom) do
-    Logger.error(
-      "message_to_audio_error Audio.VehiclesToDestination: #{inspect(top)}, #{inspect(bottom)}"
-    )
-
-    []
-  end
-
   def from_paging_headway_message(%Content.Message.Headways.Paging{
         destination: destination,
         range: range
       }) do
-    create(:english, destination, range)
-  end
-
-  @spec create(
-          Content.Audio.language(),
-          PaEss.destination() | nil,
-          {non_neg_integer(), non_neg_integer()}
-        ) :: [t()]
-
-  defp create(:english, nil, range) do
     [
       %__MODULE__{
-        language: :english,
-        destination: nil,
+        destination: destination,
         headway_range: range
       }
     ]
-  end
-
-  defp create(:spanish, nil, _range) do
-    []
-  end
-
-  defp create(language, destination, headway_range) do
-    if Utilities.valid_destination?(destination, language) do
-      [
-        %__MODULE__{
-          language: language,
-          destination: destination,
-          headway_range: headway_range
-        }
-      ]
-    else
-      []
-    end
   end
 
   defimpl Content.Audio do
@@ -109,7 +61,6 @@ defmodule Content.Audio.VehiclesToDestination do
     end
 
     def to_params(%Content.Audio.VehiclesToDestination{
-          language: :english,
           destination: nil,
           headway_range: {range_low, range_high}
         }) do
@@ -135,47 +86,44 @@ defmodule Content.Audio.VehiclesToDestination do
     def to_params(_audio), do: nil
 
     @spec message_id(Content.Audio.VehiclesToDestination.t()) :: String.t()
-    defp message_id(%{language: :english, destination: :alewife}), do: "175"
-    defp message_id(%{language: :english, destination: :ashmont}), do: "173"
-    defp message_id(%{language: :english, destination: :braintree}), do: "174"
-    defp message_id(%{language: :english, destination: :mattapan}), do: "180"
-    defp message_id(%{language: :english, destination: :bowdoin}), do: "178"
-    defp message_id(%{language: :english, destination: :wonderland}), do: "179"
-    defp message_id(%{language: :english, destination: :forest_hills}), do: "176"
-    defp message_id(%{language: :english, destination: :oak_grove}), do: "177"
-    defp message_id(%{language: :english, destination: :lechmere}), do: "170"
-    defp message_id(%{language: :english, destination: :union_square}), do: "194"
-    defp message_id(%{language: :english, destination: :north_station}), do: "169"
-    defp message_id(%{language: :english, destination: :government_center}), do: "167"
-    defp message_id(%{language: :english, destination: :park_street}), do: "168"
-    defp message_id(%{language: :english, destination: :kenmore}), do: "166"
-    defp message_id(%{language: :english, destination: :boston_college}), do: "161"
-    defp message_id(%{language: :english, destination: :cleveland_circle}), do: "162"
-    defp message_id(%{language: :english, destination: :reservoir}), do: "165"
-    defp message_id(%{language: :english, destination: :riverside}), do: "163"
-    defp message_id(%{language: :english, destination: :heath_street}), do: "164"
-    defp message_id(%{language: :english, destination: :medford_tufts}), do: "196"
-    defp message_id(%{language: :english, destination: :northbound}), do: "183"
-    defp message_id(%{language: :english, destination: :southbound}), do: "184"
-    defp message_id(%{language: :english, destination: :eastbound}), do: "181"
-    defp message_id(%{language: :english, destination: :westbound}), do: "182"
-    defp message_id(%{language: :english, destination: :inbound}), do: "197"
-    defp message_id(%{language: :english, destination: :outbound}), do: "198"
-
-    defp message_id(%{language: :english, destination: :chelsea}), do: "133"
-    defp message_id(%{language: :english, destination: :south_station}), do: "134"
-    defp message_id(%{language: :spanish, destination: :chelsea}), do: "150"
-    defp message_id(%{language: :spanish, destination: :south_station}), do: "151"
+    defp message_id(%{destination: :alewife}), do: "175"
+    defp message_id(%{destination: :ashmont}), do: "173"
+    defp message_id(%{destination: :braintree}), do: "174"
+    defp message_id(%{destination: :mattapan}), do: "180"
+    defp message_id(%{destination: :bowdoin}), do: "178"
+    defp message_id(%{destination: :wonderland}), do: "179"
+    defp message_id(%{destination: :forest_hills}), do: "176"
+    defp message_id(%{destination: :oak_grove}), do: "177"
+    defp message_id(%{destination: :lechmere}), do: "170"
+    defp message_id(%{destination: :union_square}), do: "194"
+    defp message_id(%{destination: :north_station}), do: "169"
+    defp message_id(%{destination: :government_center}), do: "167"
+    defp message_id(%{destination: :park_street}), do: "168"
+    defp message_id(%{destination: :kenmore}), do: "166"
+    defp message_id(%{destination: :boston_college}), do: "161"
+    defp message_id(%{destination: :cleveland_circle}), do: "162"
+    defp message_id(%{destination: :reservoir}), do: "165"
+    defp message_id(%{destination: :riverside}), do: "163"
+    defp message_id(%{destination: :heath_street}), do: "164"
+    defp message_id(%{destination: :medford_tufts}), do: "196"
+    defp message_id(%{destination: :northbound}), do: "183"
+    defp message_id(%{destination: :southbound}), do: "184"
+    defp message_id(%{destination: :eastbound}), do: "181"
+    defp message_id(%{destination: :westbound}), do: "182"
+    defp message_id(%{destination: :inbound}), do: "197"
+    defp message_id(%{destination: :outbound}), do: "198"
+    defp message_id(%{destination: :chelsea}), do: "133"
+    defp message_id(%{destination: :south_station}), do: "134"
 
     @spec vars(Content.Audio.VehiclesToDestination.t()) :: [String.t()] | nil
-    defp vars(%{language: language, headway_range: headway_range}) do
+    defp vars(%{headway_range: headway_range}) do
       case headway_range do
         {lower_mins, higher_mins} when is_integer(lower_mins) and is_integer(higher_mins) ->
-          if Utilities.valid_range?(lower_mins, language) and
-               Utilities.valid_range?(higher_mins, language) do
+          if Utilities.valid_range?(lower_mins, :english) and
+               Utilities.valid_range?(higher_mins, :english) do
             [
-              Utilities.number_var(lower_mins, language),
-              Utilities.number_var(higher_mins, language)
+              Utilities.number_var(lower_mins, :english),
+              Utilities.number_var(higher_mins, :english)
             ]
           else
             nil

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -126,11 +126,6 @@ defmodule PaEss.Utilities do
     n > 0 and n < 21
   end
 
-  @spec valid_destination?(PaEss.destination(), Content.Audio.language()) :: boolean()
-  def valid_destination?(destination, language) when not is_nil(destination) do
-    language == :english or destination in [:chelsea, :south_station]
-  end
-
   @spec number_var(integer(), Content.Audio.language()) :: String.t() | nil
   def number_var(n, :english) do
     if valid_range?(n, :english) do

--- a/test/content/audio/vehicles_to_destination_test.exs
+++ b/test/content/audio/vehicles_to_destination_test.exs
@@ -8,62 +8,24 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     test "Buses to Chelsea in English" do
       audio = %Content.Audio.VehiclesToDestination{
         destination: :chelsea,
-        language: :english,
         headway_range: {7, 10}
       }
 
       assert Content.Audio.to_params(audio) == {:canned, {"133", ["5507", "5510"], :audio}}
     end
 
-    test "Buses to Chelsea in Spanish" do
-      audio = %Content.Audio.VehiclesToDestination{
-        destination: :chelsea,
-        language: :spanish,
-        headway_range: {7, 10}
-      }
-
-      assert Content.Audio.to_params(audio) == {:canned, {"150", ["37007", "37010"], :audio}}
-    end
-
     test "Buses to South Station in English" do
       audio = %Content.Audio.VehiclesToDestination{
         destination: :south_station,
-        language: :english,
         headway_range: {7, 10}
       }
 
       assert Content.Audio.to_params(audio) == {:canned, {"134", ["5507", "5510"], :audio}}
     end
 
-    test "Buses to South Station in Spanish" do
-      audio = %Content.Audio.VehiclesToDestination{
-        destination: :south_station,
-        language: :spanish,
-        headway_range: {7, 10}
-      }
-
-      assert Content.Audio.to_params(audio) == {:canned, {"151", ["37007", "37010"], :audio}}
-    end
-
-    test "Buses to South Station in Spanish, headway out of range" do
-      audio = %Content.Audio.VehiclesToDestination{
-        destination: :south_station,
-        language: :spanish,
-        headway_range: {19, 21}
-      }
-
-      log =
-        capture_log([level: :warn], fn ->
-          assert Content.Audio.to_params(audio) == nil
-        end)
-
-      assert log =~ "no_audio_for_headway_range"
-    end
-
     test "returns correct audio for cardinal direction, rather than terminal, headways" do
       audio = %Content.Audio.VehiclesToDestination{
         destination: :southbound,
-        language: :english,
         headway_range: {5, 7}
       }
 
@@ -73,7 +35,6 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     test "returns nil when range is unexpected" do
       audio = %Content.Audio.VehiclesToDestination{
         destination: :lechmere,
-        language: :english,
         headway_range: {:a, :b, :c}
       }
 
@@ -83,7 +44,6 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     test "Returns ad-hoc audio when no destination" do
       audio = %Content.Audio.VehiclesToDestination{
         destination: nil,
-        language: :english,
         headway_range: {8, 10}
       }
 
@@ -97,32 +57,22 @@ defmodule Content.Audio.VehiclesToDestinationTest do
 
     test "returns an audio message from a headway message to chelsea" do
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :chelsea},
-               %Content.Audio.VehiclesToDestination{language: :spanish, destination: :chelsea}
+               %Content.Audio.VehiclesToDestination{destination: :chelsea}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :chelsea}, @msg)
     end
 
     test "returns an audio message from a headway message to red/orange/blue/green line terminals" do
       # green line
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :lechmere
-               }
+               %Content.Audio.VehiclesToDestination{destination: :lechmere}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :lechmere}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :union_sq
-               }
+               %Content.Audio.VehiclesToDestination{destination: :union_sq}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :union_sq}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :government_center
-               }
+               %Content.Audio.VehiclesToDestination{destination: :government_center}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :government_center},
@@ -130,10 +80,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :north_station
-               }
+               %Content.Audio.VehiclesToDestination{destination: :north_station}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :north_station},
@@ -141,10 +88,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :park_street
-               }
+               %Content.Audio.VehiclesToDestination{destination: :park_street}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :park_street},
@@ -152,10 +96,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :heath_street
-               }
+               %Content.Audio.VehiclesToDestination{destination: :heath_street}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :heath_street},
@@ -163,18 +104,12 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :riverside
-               }
+               %Content.Audio.VehiclesToDestination{destination: :riverside}
              ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :riverside}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :boston_college
-               }
+               %Content.Audio.VehiclesToDestination{destination: :boston_college}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :boston_college},
@@ -182,10 +117,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :cleveland_circle
-               }
+               %Content.Audio.VehiclesToDestination{destination: :cleveland_circle}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :cleveland_circle},
@@ -194,23 +126,17 @@ defmodule Content.Audio.VehiclesToDestinationTest do
 
       # blue line
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :bowdoin
-               }
+               %Content.Audio.VehiclesToDestination{destination: :bowdoin}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :bowdoin}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :wonderland}
+               %Content.Audio.VehiclesToDestination{destination: :wonderland}
              ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :wonderland}, @msg)
 
       # orange line
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :forest_hills
-               }
+               %Content.Audio.VehiclesToDestination{destination: :forest_hills}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :forest_hills},
@@ -218,35 +144,28 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                )
 
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :oak_grove}
+               %Content.Audio.VehiclesToDestination{destination: :oak_grove}
              ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :oak_grove}, @msg)
 
       # red line
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :alewife}
+               %Content.Audio.VehiclesToDestination{destination: :alewife}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :alewife}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :ashmont}
+               %Content.Audio.VehiclesToDestination{destination: :ashmont}
              ] = from_headway_message(%Content.Message.Headways.Top{destination: :ashmont}, @msg)
 
       assert [
-               %Content.Audio.VehiclesToDestination{language: :english, destination: :braintree}
+               %Content.Audio.VehiclesToDestination{destination: :braintree}
              ] =
                from_headway_message(%Content.Message.Headways.Top{destination: :braintree}, @msg)
     end
 
     test "returns an audio message from a headway message to south station" do
       assert [
-               %Content.Audio.VehiclesToDestination{
-                 language: :english,
-                 destination: :south_station
-               },
-               %Content.Audio.VehiclesToDestination{
-                 language: :spanish,
-                 destination: :south_station
-               }
+               %Content.Audio.VehiclesToDestination{destination: :south_station}
              ] =
                from_headway_message(
                  %Content.Message.Headways.Top{destination: :south_station},
@@ -257,7 +176,6 @@ defmodule Content.Audio.VehiclesToDestinationTest do
     test "handles a nil destination in English" do
       assert [
                %Content.Audio.VehiclesToDestination{
-                 language: :english,
                  destination: nil,
                  headway_range: {8, 10}
                }
@@ -266,15 +184,6 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                  %Content.Message.Headways.Top{destination: nil, vehicle_type: :train},
                  %Content.Message.Headways.Bottom{range: {8, 10}}
                )
-    end
-
-    test "returns nils for an unknown destination" do
-      log =
-        capture_log([level: :warn], fn ->
-          assert from_headway_message(:foo, :bar) == []
-        end)
-
-      assert log =~ "message_to_audio_error"
     end
   end
 end

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -10,12 +10,6 @@ defmodule Content.Audio.UtilitiesTest do
     refute valid_range?(100, :spanish)
   end
 
-  test "valid_destination?" do
-    assert valid_destination?(:chelsea, :spanish)
-    assert valid_destination?(:south_station, :english)
-    refute valid_destination?(:cleveland_circle, :spanish)
-  end
-
   test "number_var/2" do
     assert number_var(10, :english) == "5510"
     assert number_var(10, :spanish) == "37010"

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -747,21 +747,6 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0})
     end
 
-    test "reads headways in spanish, if available" do
-      expect_messages({"Chelsea trains", "Every 11 to 13 min"})
-
-      expect_audios([
-        {:canned, {"133", ["5511", "5513"], :audio}},
-        {:canned, {"150", ["37011", "37013"], :audio}}
-      ])
-
-      Signs.Realtime.handle_info(:run_loop, %{
-        @sign
-        | tick_read: 0,
-          source_config: %{@sign.source_config | headway_destination: :chelsea}
-      })
-    end
-
     test "reads mixed predictions and headways" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :ashmont, arrival: 130)]


### PR DESCRIPTION
#### Summary of changes

This removes some old code for reading headways in Spanish, which is never called in practice. It's only active for Chelsea and South Station destinations, neither of which can come up in the rail code.