### PR TITLE
add TTS audio format

### DIFF
--- a/lib/content/audio.ex
+++ b/lib/content/audio.ex
@@ -19,4 +19,6 @@ defprotocol Content.Audio do
   @doc "Converts an audio struct to the mid/vars params for the PA system"
   @spec to_params(Content.Audio.t()) :: value()
   def to_params(audio)
+  @spec to_tts(Content.Audio.t()) :: String.t()
+  def to_tts(audio)
 end

--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -50,14 +50,7 @@ defmodule Content.Audio.Approaching do
       case {destination_var(audio.destination, audio.platform, audio.route_id),
             crowding_description} do
         {nil, _} ->
-          case Utilities.ad_hoc_trip_description(audio.destination, audio.route_id) do
-            {:ok, trip_description} ->
-              text = "Attention passengers: The next #{trip_description} is now approaching."
-              {:ad_hoc, {text, :audio_visual}}
-
-            {:error, :unknown} ->
-              handle_unknown_destination(audio)
-          end
+          {:ad_hoc, {Content.Audio.to_tts(audio), :audio_visual}}
 
         {var, nil} ->
           Utilities.take_message([var], :audio_visual)
@@ -86,6 +79,20 @@ defmodule Content.Audio.Approaching do
           vars = [@attention_passengers, destination_var, @space, approaching_var]
           {:canned, {PaEss.Utilities.take_message_id(vars), vars, :audio_visual}}
       end
+    end
+
+    def to_tts(%Content.Audio.Approaching{} = audio) do
+      train = Utilities.train_description(audio.destination, audio.route_id)
+      crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+
+      new_cars =
+        if audio.new_cars? && audio.route_id == "Red" do
+          ", with all new Red Line cars."
+        else
+          "."
+        end
+
+      "Attention passengers: The next #{train} is now approaching#{new_cars}#{crowding}"
     end
 
     @spec handle_unknown_destination(Content.Audio.Approaching.t()) :: nil

--- a/lib/content/audio/boarding_button.ex
+++ b/lib/content/audio/boarding_button.ex
@@ -8,5 +8,9 @@ defmodule Content.Audio.BoardingButton do
     def to_params(_audio) do
       Utilities.take_message([@boarding_button_message], :audio_visual)
     end
+
+    def to_tts(%Content.Audio.BoardingButton{}) do
+      "Attention Passengers: To board the next train, please push the button on either side of the door."
+    end
   end
 end

--- a/lib/content/audio/closure.ex
+++ b/lib/content/audio/closure.ex
@@ -53,8 +53,19 @@ defmodule Content.Audio.Closure do
     end
 
     # Hardcoded for Union Square
-    def to_params(%Content.Audio.Closure{alert: :use_routes_alert, routes: []}) do
-      {:ad_hoc, {"No Train Service. Use routes 86, 87, or 91", :audio}}
+    def to_params(%Content.Audio.Closure{alert: :use_routes_alert, routes: []} = audio) do
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
+    end
+
+    def to_tts(%Content.Audio.Closure{} = audio) do
+      if audio.alert == :use_routes_alert do
+        # Hardcoded for Union Square
+        "No Train Service. Use routes 86, 87, or 91"
+      else
+        shuttle = if(audio.alert == :shuttles_closed_station, do: " Use shuttle.", else: "")
+        line = PaEss.Utilities.get_line_from_routes_list(audio.routes)
+        "There is no #{line} service at this station.#{shuttle}"
+      end
     end
   end
 end

--- a/lib/content/audio/custom.ex
+++ b/lib/content/audio/custom.ex
@@ -37,5 +37,9 @@ defmodule Content.Audio.Custom do
     def to_params(%Content.Audio.Custom{message: message}) do
       {:ad_hoc, {message, :audio}}
     end
+
+    def to_tts(%Content.Audio.Custom{} = audio) do
+      audio.message
+    end
   end
 end

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -54,5 +54,11 @@ defmodule Content.Audio.FirstTrainScheduled do
 
       PaEss.Utilities.take_message(vars, :audio)
     end
+
+    def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do
+      train = PaEss.Utilities.train_description(audio.destination, nil)
+      time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
+      "The first #{train} is scheduled to arrive at #{time}"
+    end
   end
 end

--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -82,23 +82,15 @@ defmodule Content.Audio.FollowingTrain do
       end
     end
 
+    def to_tts(%Content.Audio.FollowingTrain{} = audio) do
+      train = Utilities.train_description(audio.destination, audio.route_id)
+      arrives_or_departs = if audio.verb == :arrives, do: "arrives", else: "departs"
+      min_or_mins = if audio.minutes == 1, do: "minute", else: "minutes"
+      "The following #{train} #{arrives_or_departs} in #{audio.minutes} #{min_or_mins}"
+    end
+
     defp do_ad_hoc_message(audio) do
-      case Utilities.ad_hoc_trip_description(audio.destination, audio.route_id) do
-        {:ok, trip_description} ->
-          min_or_mins = if audio.minutes == 1, do: "minute", else: "minutes"
-
-          text =
-            "The following #{trip_description} #{audio.verb} in #{audio.minutes} #{min_or_mins}"
-
-          {:ad_hoc, {text, :audio}}
-
-        {:error, :unknown} ->
-          Logger.error(
-            "FollowingTrain.to_params unknown destination: #{inspect(audio.destination)}"
-          )
-
-          nil
-      end
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
     end
 
     @spec green_line_with_branch_params(

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -93,27 +93,37 @@ defmodule Content.Audio.NextTrainCountdown do
       end
     end
 
-    defp do_ad_hoc_message(audio) do
-      case Utilities.ad_hoc_trip_description(audio.destination, audio.route_id) do
-        {:ok, trip_description} ->
-          min_or_mins = if audio.minutes == 1, do: "minute", else: "minutes"
+    def to_tts(%Content.Audio.NextTrainCountdown{} = audio) do
+      train = Utilities.train_description(audio.destination, audio.route_id)
+      arrives_or_departs = if audio.verb == :arrives, do: "arrives", else: "departs"
+      min_or_mins = if audio.minutes == 1, do: "minute", else: "minutes"
 
-          text = "The next #{trip_description} #{audio.verb} in #{audio.minutes} #{min_or_mins}"
+      suffix =
+        cond do
+          audio.track_number ->
+            " on track #{audio.track_number}."
 
-          text =
-            if audio.track_number do
-              text <> " from track #{audio.track_number}"
-            else
-              text
+          audio.platform ->
+            cond do
+              audio.minutes <= 5 ->
+                " on the #{if(audio.platform == :ashmont, do: "ashmont", else: "braintree")} platform"
+
+              audio.minutes <= 11 ->
+                ". We will announce the platform for boarding soon."
+
+              true ->
+                ". We will announce the platform for boarding when the tran is closer."
             end
 
-          {:ad_hoc, {text, :audio}}
+          true ->
+            "."
+        end
 
-        {:error, :unknown} ->
-          Logger.error("NextTrainCountdown unknown destination: #{inspect(audio.destination)}")
+      "The next #{train} #{arrives_or_departs} in #{audio.minutes} #{min_or_mins}#{suffix}"
+    end
 
-          nil
-      end
+    defp do_ad_hoc_message(audio) do
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
     end
 
     @spec green_line_with_branch_params(

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -112,7 +112,7 @@ defmodule Content.Audio.NextTrainCountdown do
                 ". We will announce the platform for boarding soon."
 
               true ->
-                ". We will announce the platform for boarding when the tran is closer."
+                ". We will announce the platform for boarding when the train is closer."
             end
 
           true ->

--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -5,50 +5,31 @@ defmodule Content.Audio.NoServiceToDestination do
 
   require Logger
 
-  @enforce_keys [:message]
+  @enforce_keys [:destination, :use_shuttle]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
-          message: String.t()
+          destination: PaEss.destination(),
+          use_shuttle: boolean()
         }
 
-  def from_message(
-        %Content.Message.Alert.DestinationNoService{destination: destination} = message
-      ) do
-    case PaEss.Utilities.destination_to_ad_hoc_string(destination) do
-      {:ok, destination} ->
-        audio = "No service to #{destination}"
-
-        [%__MODULE__{message: audio}]
-
-      {:error, :unknown} ->
-        Logger.error(
-          "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
-        )
-
-        []
-    end
+  def from_message(%Content.Message.Alert.DestinationNoService{destination: destination}) do
+    [%__MODULE__{destination: destination, use_shuttle: false}]
   end
 
-  def from_message(%Content.Message.Alert.NoServiceUseShuttle{destination: destination} = message) do
-    case PaEss.Utilities.destination_to_ad_hoc_string(destination) do
-      {:ok, destination} ->
-        audio = "No service to #{destination} use shuttle"
-
-        [%__MODULE__{message: audio}]
-
-      {:error, :unknown} ->
-        Logger.error(
-          "NoServiceToDestination.from_message unknown destination: #{inspect(message)}"
-        )
-
-        []
-    end
+  def from_message(%Content.Message.Alert.NoServiceUseShuttle{destination: destination}) do
+    [%__MODULE__{destination: destination, use_shuttle: true}]
   end
 
   defimpl Content.Audio do
-    def to_params(%Content.Audio.NoServiceToDestination{message: message}) do
-      {:ad_hoc, {message, :audio}}
+    def to_params(%Content.Audio.NoServiceToDestination{} = audio) do
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
+    end
+
+    def to_tts(%Content.Audio.NoServiceToDestination{} = audio) do
+      {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(audio.destination)
+      shuttle = if(audio.use_shuttle, do: " Use shuttle.", else: "")
+      "No service to #{destination_text}.#{shuttle}"
     end
   end
 end

--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -29,7 +29,7 @@ defmodule Content.Audio.NoServiceToDestination do
     def to_tts(%Content.Audio.NoServiceToDestination{} = audio) do
       {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(audio.destination)
       shuttle = if(audio.use_shuttle, do: " Use shuttle.", else: "")
-      "No service to #{destination_text}.#{shuttle}"
+      "No #{destination_text} service.#{shuttle}"
     end
   end
 end

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -23,20 +23,16 @@ defmodule Content.Audio.Passthrough do
     def to_params(audio) do
       case destination_var(audio.destination, audio.route_id) do
         nil ->
-          case PaEss.Utilities.ad_hoc_trip_description(audio.destination, audio.route_id) do
-            {:ok, trip_description} ->
-              text =
-                "The next #{trip_description} does not take customers. Please stand back from the yellow line."
-
-              {:ad_hoc, {text, :audio}}
-
-            {:error, :unknown} ->
-              handle_unknown_destination(audio)
-          end
+          {:ad_hoc, {Content.Audio.to_tts(audio), :audio_visual}}
 
         var ->
           {:canned, {"103", [var], :audio_visual}}
       end
+    end
+
+    def to_tts(%Content.Audio.Passthrough{} = audio) do
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+      "The next #{train} does not take customers. Please stand back from the yellow line."
     end
 
     @spec handle_unknown_destination(Content.Audio.Passthrough.t()) :: nil

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -6,18 +6,23 @@ defmodule Content.Audio.StoppedTrain do
   require Logger
   alias PaEss.Utilities
 
-  @enforce_keys [:destination, :stops_away]
+  @enforce_keys [:destination, :route_id, :stops_away]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
+          route_id: String.t(),
           stops_away: non_neg_integer()
         }
 
   @spec from_message(Content.Message.t()) :: [t()]
-  def from_message(%Content.Message.StoppedTrain{destination: destination, stops_away: stops_away})
+  def from_message(%Content.Message.StoppedTrain{
+        destination: destination,
+        stops_away: stops_away,
+        route_id: route_id
+      })
       when stops_away > 0 do
-    [%__MODULE__{destination: destination, stops_away: stops_away}]
+    [%__MODULE__{destination: destination, route_id: route_id, stops_away: stops_away}]
   end
 
   def from_message(%Content.Message.StoppedTrain{stops_away: 0}) do
@@ -59,23 +64,14 @@ defmodule Content.Audio.StoppedTrain do
       end
     end
 
+    def to_tts(%Content.Audio.StoppedTrain{} = audio) do
+      train = Utilities.train_description(audio.destination, audio.route_id)
+      stop_or_stops = if audio.stops_away == 1, do: "stop", else: "stops"
+      "The next #{train} is stopped #{audio.stops_away} #{stop_or_stops} away"
+    end
+
     defp do_ad_hoc_message(audio) do
-      case Utilities.ad_hoc_trip_description(audio.destination) do
-        {:ok, trip_description} ->
-          stop_or_stops = if audio.stops_away == 1, do: "stop", else: "stops"
-
-          text =
-            "The next #{trip_description} is stopped #{audio.stops_away} #{stop_or_stops} away"
-
-          {:ad_hoc, {text, :audio}}
-
-        {:error, :unknown} ->
-          Logger.error(
-            "StoppedTrain.to_params unknown destination: #{inspect(audio.destination)}"
-          )
-
-          nil
-      end
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
     end
 
     defp stops_away_var(1), do: "535"

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -71,6 +71,20 @@ defmodule Content.Audio.TrackChange do
       end
     end
 
+    def to_tts(%Content.Audio.TrackChange{} = audio) do
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+
+      platform =
+        case audio.berth do
+          "70196" -> "B"
+          "70197" -> "C"
+          "70198" -> "D"
+          "70199" -> "E"
+        end
+
+      "Track change: The next #{train} is now boarding on the #{platform} platform"
+    end
+
     defp track_change_message(msg_id) do
       vars = [@track_change, msg_id]
       PaEss.Utilities.take_message(vars, :audio_visual)

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -36,15 +36,7 @@ defmodule Content.Audio.TrainIsArriving do
         ) do
       case {dest_param(audio), crowding_description} do
         {nil, _} ->
-          case Utilities.ad_hoc_trip_description(audio.destination, audio.route_id) do
-            {:ok, trip_description} ->
-              text = "Attention passengers: The next #{trip_description} is now arriving."
-              {:ad_hoc, {text, :audio_visual}}
-
-            {:error, :unknown} ->
-              Logger.error("TrainIsArriving.to_params unknown params for #{inspect(audio)}")
-              nil
-          end
+          {:ad_hoc, {Content.Audio.to_tts(audio), :audio_visual}}
 
         {var, nil} ->
           Utilities.take_message([var], :audio_visual)
@@ -55,6 +47,12 @@ defmodule Content.Audio.TrainIsArriving do
             :audio_visual
           )
       end
+    end
+
+    def to_tts(%Content.Audio.TrainIsArriving{} = audio) do
+      train = Utilities.train_description(audio.destination, audio.route_id)
+      crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+      "Attention passengers: The next #{train} is now arriving.#{crowding}"
     end
 
     @spec dest_param(Content.Audio.TrainIsArriving.t()) :: String.t() | nil

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -64,22 +64,14 @@ defmodule Content.Audio.TrainIsBoarding do
       end
     end
 
+    def to_tts(audio) do
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+      track = if(audio.track_number, do: " on track #{audio.track_number}", else: ".")
+      "The next #{train} is now boarding#{track}"
+    end
+
     defp do_ad_hoc_message(audio) do
-      case PaEss.Utilities.ad_hoc_trip_description(audio.destination) do
-        {:ok, trip_description} ->
-          text =
-            if audio.track_number do
-              "The next #{trip_description} is now boarding, on track #{audio.track_number}"
-            else
-              "The next #{trip_description} is now boarding"
-            end
-
-          {:ad_hoc, {text, :audio}}
-
-        {:error, :unknown} ->
-          Logger.error("TrainIsBoarding.to_params unknown destination: #{audio.destination}")
-          nil
-      end
+      {:ad_hoc, {Content.Audio.to_tts(audio), :audio}}
     end
 
     defp do_to_params(%{destination: destination, route_id: "Green-" <> _branch}, destination_var)

--- a/lib/content/message/alert/no_service.ex
+++ b/lib/content/message/alert/no_service.ex
@@ -9,7 +9,13 @@ defmodule Content.Message.Alert.NoService do
 
   defimpl Content.Message do
     def to_string(%Content.Message.Alert.NoService{routes: routes}) do
-      "No #{PaEss.Utilities.get_line_from_routes_list(routes)}"
+      service =
+        case PaEss.Utilities.get_line_from_routes_list(routes) do
+          "train" -> "train service"
+          line -> line
+        end
+
+      "No #{service}"
     end
   end
 end

--- a/lib/fake/unknown_audio.ex
+++ b/lib/fake/unknown_audio.ex
@@ -1,9 +1,0 @@
-defmodule Fake.UnknownAudio do
-  defstruct []
-
-  defimpl Content.Audio do
-    def to_params(_) do
-      nil
-    end
-  end
-end

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -14,15 +14,6 @@ defmodule Content.Audio.ApproachingTest do
       assert Content.Audio.to_params(audio) == {:canned, {"103", ["32122"], :audio_visual}}
     end
 
-    test "Returns ad-hoc audio for valid destinations" do
-      audio = %Approaching{destination: :northbound, route_id: "Orange"}
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc,
-                {"Attention passengers: The next Northbound Orange Line train is now approaching.",
-                 :audio_visual}}
-    end
-
     test "Returns nil for Green Line trips" do
       audio = %Approaching{destination: :riverside, route_id: "Green-D"}
       assert Content.Audio.to_params(audio) == nil
@@ -30,11 +21,6 @@ defmodule Content.Audio.ApproachingTest do
 
     test "Returns nil when destination is Ashmont on the Mattapan line" do
       audio = %Approaching{destination: :ashmont, route_id: "Mattapan"}
-      assert Content.Audio.to_params(audio) == nil
-    end
-
-    test "Returns nil when destination for which we don't have audio" do
-      audio = %Approaching{destination: :unknown, route_id: "Red"}
       assert Content.Audio.to_params(audio) == nil
     end
 
@@ -55,15 +41,6 @@ defmodule Content.Audio.ApproachingTest do
     test "Falls back on audio without new cars message if needed" do
       audio = %Approaching{destination: :bowdoin, route_id: "Blue", new_cars?: true}
       assert Content.Audio.to_params(audio) == {:canned, {"103", ["32121"], :audio_visual}}
-    end
-
-    test "Returns params when destination is 'southbound'" do
-      audio = %Approaching{destination: :southbound, route_id: "Red"}
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc,
-                {"Attention passengers: The next Southbound Red Line train is now approaching.",
-                 :audio_visual}}
     end
 
     test "Returns crowding info" do

--- a/test/content/audio/following_train_test.exs
+++ b/test/content/audio/following_train_test.exs
@@ -1,6 +1,5 @@
 defmodule Content.Audio.FollowingTrainTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "Content.Audio.to_params protocol" do
     test "Following train to Ashmont" do
@@ -153,46 +152,6 @@ defmodule Content.Audio.FollowingTrainTest do
                    "21000",
                    "505"
                  ], :audio}}
-    end
-
-    test "returns ad_hoc audio when the destination is 'southbound'" do
-      audio = %Content.Audio.FollowingTrain{
-        destination: :southbound,
-        route_id: "Red",
-        verb: :arrives,
-        minutes: 3
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The following Southbound Red Line train arrives in 3 minutes", :audio}}
-    end
-
-    test "Returns ad_hoc audio for valid destinations" do
-      audio = %Content.Audio.FollowingTrain{
-        destination: :eastbound,
-        route_id: "Green-D",
-        verb: :arrives,
-        minutes: 3
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The following Eastbound train arrives in 3 minutes", :audio}}
-    end
-
-    test "Handles unknown destination gracefully" do
-      audio = %Content.Audio.FollowingTrain{
-        destination: :unknown,
-        route_id: "Foo",
-        verb: :arrives,
-        minutes: 3
-      }
-
-      log =
-        capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) == nil
-        end)
-
-      assert log =~ "unknown destination"
     end
   end
 end

--- a/test/content/audio/next_train_countdown_test.exs
+++ b/test/content/audio/next_train_countdown_test.exs
@@ -1,6 +1,5 @@
 defmodule Content.Audio.NextTrainCountdownTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "Content.Audio.to_params protocol" do
     test "Next train to Ashmont" do
@@ -401,81 +400,5 @@ defmodule Content.Audio.NextTrainCountdownTest do
                    "541"
                  ], :audio}}
     end
-  end
-
-  test "The next southbound train in 1 minute" do
-    audio = %Content.Audio.NextTrainCountdown{
-      destination: :southbound,
-      route_id: "Red",
-      verb: :arrives,
-      minutes: 1,
-      track_number: nil,
-      platform: nil
-    }
-
-    assert Content.Audio.to_params(audio) ==
-             {:ad_hoc, {"The next Southbound Red Line train arrives in 1 minute", :audio}}
-  end
-
-  test "The next Southbound train in multiple minutes" do
-    audio = %Content.Audio.NextTrainCountdown{
-      destination: :southbound,
-      route_id: "Red",
-      verb: :arrives,
-      minutes: 5,
-      track_number: nil,
-      platform: nil
-    }
-
-    assert Content.Audio.to_params(audio) ==
-             {:ad_hoc, {"The next Southbound Red Line train arrives in 5 minutes", :audio}}
-  end
-
-  test "The next southbound train on track 1" do
-    audio = %Content.Audio.NextTrainCountdown{
-      destination: :southbound,
-      route_id: "Red",
-      verb: :departs,
-      minutes: 5,
-      track_number: 1,
-      platform: nil
-    }
-
-    assert Content.Audio.to_params(audio) ==
-             {:ad_hoc,
-              {"The next Southbound Red Line train departs in 5 minutes from track 1", :audio}}
-  end
-
-  test "Returns ad_hoc audio for valid destinations" do
-    audio = %Content.Audio.NextTrainCountdown{
-      destination: :southbound,
-      route_id: "Orange",
-      verb: :departs,
-      minutes: 5,
-      track_number: 1,
-      platform: nil
-    }
-
-    assert Content.Audio.to_params(audio) ==
-             {:ad_hoc,
-              {"The next Southbound Orange Line train departs in 5 minutes from track 1", :audio}}
-  end
-
-  test "Handles unknown destination gracefully" do
-    audio = %Content.Audio.NextTrainCountdown{
-      destination: :unknown,
-      route_id: "Red",
-      verb: :departs,
-      minutes: 5,
-      track_number: 1,
-      platform: nil
-    }
-
-    log =
-      capture_log([level: :error], fn ->
-        assert Content.Audio.to_params(audio) == nil
-      end)
-
-    assert log =~ "unknown destination"
   end
 end

--- a/test/content/audio/no_service_to_destination_test.exs
+++ b/test/content/audio/no_service_to_destination_test.exs
@@ -2,24 +2,19 @@ defmodule Content.Audio.NoServiceToDestinationTest do
   use ExUnit.Case, async: true
 
   test "Inserts destination into audio for no service" do
-    message = %Content.Message.Alert.DestinationNoService{
-      destination: :medford_tufts
-    }
+    [audio] =
+      %Content.Message.Alert.DestinationNoService{destination: :medford_tufts}
+      |> Content.Audio.NoServiceToDestination.from_message()
 
-    assert Content.Audio.NoServiceToDestination.from_message(message) ==
-             [%Content.Audio.NoServiceToDestination{message: "No service to Medford/Tufts"}]
+    assert Content.Audio.to_params(audio) == {:ad_hoc, {"No service to Medford/Tufts.", :audio}}
   end
 
   test "Inserts destination into audio for paging shuttle alert" do
-    message = %Content.Message.Alert.NoServiceUseShuttle{
-      destination: :medford_tufts
-    }
+    [audio] =
+      %Content.Message.Alert.NoServiceUseShuttle{destination: :medford_tufts}
+      |> Content.Audio.NoServiceToDestination.from_message()
 
-    assert Content.Audio.NoServiceToDestination.from_message(message) ==
-             [
-               %Content.Audio.NoServiceToDestination{
-                 message: "No service to Medford/Tufts use shuttle"
-               }
-             ]
+    assert Content.Audio.to_params(audio) ==
+             {:ad_hoc, {"No service to Medford/Tufts. Use shuttle.", :audio}}
   end
 end

--- a/test/content/audio/no_service_to_destination_test.exs
+++ b/test/content/audio/no_service_to_destination_test.exs
@@ -6,7 +6,7 @@ defmodule Content.Audio.NoServiceToDestinationTest do
       %Content.Message.Alert.DestinationNoService{destination: :medford_tufts}
       |> Content.Audio.NoServiceToDestination.from_message()
 
-    assert Content.Audio.to_params(audio) == {:ad_hoc, {"No service to Medford/Tufts.", :audio}}
+    assert Content.Audio.to_params(audio) == {:ad_hoc, {"No Medford/Tufts service.", :audio}}
   end
 
   test "Inserts destination into audio for paging shuttle alert" do
@@ -15,6 +15,6 @@ defmodule Content.Audio.NoServiceToDestinationTest do
       |> Content.Audio.NoServiceToDestination.from_message()
 
     assert Content.Audio.to_params(audio) ==
-             {:ad_hoc, {"No service to Medford/Tufts. Use shuttle.", :audio}}
+             {:ad_hoc, {"No Medford/Tufts service. Use shuttle.", :audio}}
   end
 end

--- a/test/content/audio/passthrough_test.exs
+++ b/test/content/audio/passthrough_test.exs
@@ -10,23 +10,8 @@ defmodule Content.Audio.PassthroughTest do
       assert Content.Audio.to_params(audio) == {:canned, {"103", ["32114"], :audio_visual}}
     end
 
-    test "Returns ad-hoc audio for valid destinations" do
-      audio = %Passthrough{destination: :southbound, route_id: "Orange"}
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc,
-                {"The next Southbound Orange Line train does not take customers. Please stand back from the yellow line.",
-                 :audio}}
-    end
-
     test "Returns nil for Green Line trips" do
       audio = %Passthrough{destination: :riverside, route_id: "Green-D"}
-      log = capture_log([level: :info], fn -> assert Content.Audio.to_params(audio) == nil end)
-      assert log =~ "unknown_passthrough_audio"
-    end
-
-    test "Returns nil when destination for which we don't have audio" do
-      audio = %Passthrough{destination: :unknown, route_id: "Red"}
       log = capture_log([level: :info], fn -> assert Content.Audio.to_params(audio) == nil end)
       assert log =~ "unknown_passthrough_audio"
     end

--- a/test/content/audio/stopped_train_test.exs
+++ b/test/content/audio/stopped_train_test.exs
@@ -1,10 +1,9 @@
 defmodule Content.Audio.StoppedTrainTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "to_params/1" do
     test "Serializes correctly" do
-      audio = %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 2}
+      audio = %Content.Audio.StoppedTrain{destination: :alewife, route_id: "Red", stops_away: 2}
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
@@ -27,7 +26,7 @@ defmodule Content.Audio.StoppedTrainTest do
     end
 
     test "Uses singular 'stop' if 1 stop away" do
-      audio = %Content.Audio.StoppedTrain{destination: :alewife, stops_away: 1}
+      audio = %Content.Audio.StoppedTrain{destination: :alewife, route_id: "Red", stops_away: 1}
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
@@ -48,42 +47,24 @@ defmodule Content.Audio.StoppedTrainTest do
                    "535"
                  ], :audio}}
     end
-
-    test "Returns :ad_hoc params for southbound destination" do
-      audio = %Content.Audio.StoppedTrain{destination: :southbound, stops_away: 2}
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The next Southbound train is stopped 2 stops away", :audio}}
-    end
-
-    test "Returns ad_hoc audio for valid destinations" do
-      audio = %Content.Audio.StoppedTrain{
-        destination: :westbound,
-        stops_away: 2
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The next Westbound train is stopped 2 stops away", :audio}}
-    end
-
-    test "Handles unknown destinations gracefully" do
-      audio = %Content.Audio.StoppedTrain{destination: :unknown, stops_away: 2}
-
-      log =
-        capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) == nil
-        end)
-
-      assert log =~ "unknown destination"
-    end
   end
 
   describe "from_message/1" do
     test "Converts a stopped train message with known headsign" do
-      msg = %Content.Message.StoppedTrain{destination: :forest_hills, stops_away: 1}
+      msg = %Content.Message.StoppedTrain{
+        destination: :forest_hills,
+        route_id: "Orange",
+        stops_away: 1
+      }
 
       assert Content.Audio.StoppedTrain.from_message(msg) ==
-               [%Content.Audio.StoppedTrain{destination: :forest_hills, stops_away: 1}]
+               [
+                 %Content.Audio.StoppedTrain{
+                   destination: :forest_hills,
+                   route_id: "Orange",
+                   stops_away: 1
+                 }
+               ]
     end
 
     test "Returns nil for irrelevant message" do

--- a/test/content/audio/train_is_arriving_test.exs
+++ b/test/content/audio/train_is_arriving_test.exs
@@ -1,6 +1,5 @@
 defmodule Content.Audio.TrainIsArrivingTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "Content.Audio.to_params protocol" do
     test "Next train to Ashmont is now arriving" do
@@ -46,38 +45,6 @@ defmodule Content.Audio.TrainIsArrivingTest do
       }
 
       assert Content.Audio.to_params(audio) == {:canned, {"103", ["32106"], :audio_visual}}
-    end
-
-    test "Southbound train" do
-      audio = %Content.Audio.TrainIsArriving{destination: :southbound, route_id: "Red"}
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc,
-                {"Attention passengers: The next Southbound Red Line train is now arriving.",
-                 :audio_visual}}
-    end
-
-    test "Returns ad_hoc audio for valid destinations" do
-      audio = %Content.Audio.TrainIsArriving{
-        destination: :westbound,
-        route_id: "Green-B"
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc,
-                {"Attention passengers: The next Westbound B train is now arriving.",
-                 :audio_visual}}
-    end
-
-    test "Handles unknown destination gracefully" do
-      audio = %Content.Audio.TrainIsArriving{destination: :unknown, route_id: "Red"}
-
-      log =
-        capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) == nil
-        end)
-
-      assert log =~ "unknown params"
     end
 
     test "Returns crowding info" do

--- a/test/content/audio/train_is_boarding_test.exs
+++ b/test/content/audio/train_is_boarding_test.exs
@@ -1,6 +1,5 @@
 defmodule Content.Audio.TrainIsBoardingTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "Content.Audio.to_params protocol" do
     test "Next D train to Riverside is now boarding" do
@@ -51,58 +50,6 @@ defmodule Content.Audio.TrainIsBoardingTest do
                {:canned,
                 {"111", ["501", "21000", "507", "21000", "4016", "21000", "544", "21000", "542"],
                  :audio}}
-    end
-
-    test "Returns :ad_hoc params when destination is 'southbound'" do
-      audio = %Content.Audio.TrainIsBoarding{
-        destination: :southbound,
-        trip_id: nil,
-        route_id: "Red",
-        track_number: nil
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The next Southbound train is now boarding", :audio}}
-    end
-
-    test "Returns :ad_hoc params when destination is 'southbound', and says track #" do
-      audio = %Content.Audio.TrainIsBoarding{
-        destination: :southbound,
-        trip_id: nil,
-        route_id: "Red",
-        track_number: 2
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The next Southbound train is now boarding, on track 2", :audio}}
-    end
-
-    test "Returns ad_hoc audio for valid destinations" do
-      audio = %Content.Audio.TrainIsBoarding{
-        destination: :westbound,
-        route_id: "Green-B",
-        trip_id: nil,
-        track_number: 1
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"The next Westbound train is now boarding, on track 1", :audio}}
-    end
-
-    test "Handles unknown destination gracefully" do
-      audio = %Content.Audio.TrainIsBoarding{
-        destination: :unknown,
-        trip_id: nil,
-        route_id: "Red",
-        track_number: 2
-      }
-
-      log =
-        capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) == nil
-        end)
-
-      assert log =~ "unknown destination"
     end
   end
 end

--- a/test/content/audio/vehicles_to_destination_test.exs
+++ b/test/content/audio/vehicles_to_destination_test.exs
@@ -1,6 +1,5 @@
 defmodule Content.Audio.VehiclesToDestinationTest do
   use ExUnit.Case
-  import ExUnit.CaptureLog
 
   import Content.Audio.VehiclesToDestination
 
@@ -30,25 +29,6 @@ defmodule Content.Audio.VehiclesToDestinationTest do
       }
 
       assert Content.Audio.to_params(audio) == {:canned, {"184", ["5505", "5507"], :audio}}
-    end
-
-    test "returns nil when range is unexpected" do
-      audio = %Content.Audio.VehiclesToDestination{
-        destination: :lechmere,
-        headway_range: {:a, :b, :c}
-      }
-
-      assert Content.Audio.to_params(audio) == nil
-    end
-
-    test "Returns ad-hoc audio when no destination" do
-      audio = %Content.Audio.VehiclesToDestination{
-        destination: nil,
-        headway_range: {8, 10}
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:ad_hoc, {"Trains every 8 to 10 minutes.", :audio}}
     end
   end
 

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -92,54 +92,6 @@ defmodule Content.Audio.UtilitiesTest do
     assert destination_to_ad_hoc_string(:southbound) == {:ok, "Southbound"}
   end
 
-  describe "ad_hoc_trip_description/2" do
-    test "handles locations as destinations" do
-      assert ad_hoc_trip_description(:forest_hills) == {:ok, "train to Forest Hills"}
-
-      assert ad_hoc_trip_description(:forest_hills, "Orange") ==
-               {:ok, "Orange Line train to Forest Hills"}
-
-      assert ad_hoc_trip_description(:forest_hills, "An-Unexpected-Route") ==
-               {:ok, "train to Forest Hills"}
-
-      assert ad_hoc_trip_description(:unknown) == {:error, :unknown}
-      assert ad_hoc_trip_description(:unknown, "Green-D") == {:error, :unknown}
-    end
-
-    test "handles cardinal directions as destinations" do
-      assert ad_hoc_trip_description(:northbound) == {:ok, "Northbound train"}
-
-      assert ad_hoc_trip_description(:northbound, "Orange") ==
-               {:ok, "Northbound Orange Line train"}
-
-      assert ad_hoc_trip_description(:eastbound, "An-Unexpected-Route") ==
-               {:ok, "Eastbound train"}
-    end
-
-    test "does not include branch letter for eastbound Green Line trips" do
-      Enum.each(["Green-B", "Green-C", "Green-D", "Green-E"], fn route ->
-        assert ad_hoc_trip_description(:eastbound, route) == {:ok, "Eastbound train"}
-
-        Enum.each(
-          [
-            :lechmere,
-            :north_station,
-            :government_center,
-            :park_street,
-            :kenmore,
-            :union_square,
-            :medford_tufts
-          ],
-          fn destination ->
-            assert ad_hoc_trip_description(destination, route) ==
-                     {:ok,
-                      "train to #{Kernel.elem(destination_to_ad_hoc_string(destination), 1)}"}
-          end
-        )
-      end)
-    end
-  end
-
   describe "replace_abbreviations/1" do
     test "replaces multiple times, including binary start and end" do
       assert replace_abbreviations("RL and RL and OL") == "Red Line and Red Line and Orange Line"


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [RTS: Refactor audio messages to support TTS](https://app.asana.com/0/1185117109217413/1206141631184123/f)

Adds a new function to the Audio protocol to transform messages into TTS strings. This serves to formalize the various TTS fallback code that currently exists, and provides a unified interface that can be used with the new TTS system.

Notes:
* Most of these code paths won't be called currently, even the existing fallback ones, because we never generate the conditions that would cause them to be called.
* This implements the new simplified "train description" language via a common helper.
* Updates the fallback TTS with some newer features, like OL crowding.
* Fixes a small language bug in the station closure message.
* Cleans up some low-level tests for cases that don't actually happen in practice.