### PR TITLE
Log headend server stats

### DIFF
--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -16,6 +16,42 @@ defmodule Monitoring.Uptime do
   end
 
   defp log_node_status(
+         %{
+           "IPAddress" => ip_address,
+           "Uptime" => uptime,
+           "TotalMemory" => total_memory,
+           "Total_C_Space" => total_c_space,
+           "Total_D_Space" => total_d_space,
+           "AvailableMemory" => available_memory,
+           "Available_C_Space" => available_c_space,
+           "Available_D_Space" => available_d_space
+         },
+         date_time
+       ) do
+    Logger.info([
+      "headend_server_stats: ",
+      "date_time=",
+      DateTime.to_string(date_time),
+      " ip_address=",
+      ip_address,
+      " uptime=",
+      uptime,
+      " total_memory=",
+      total_memory,
+      " total_c_space=",
+      total_c_space,
+      " total_d_space=",
+      total_d_space,
+      " available_memory=",
+      available_memory,
+      " available_c_space=",
+      available_c_space,
+      " available_d_space=",
+      available_d_space
+    ])
+  end
+
+  defp log_node_status(
          %{"sw_component" => _, "is_online" => is_online, "status" => status} = node,
          date_time
        ) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Implement JSON Splunk logging of Wabtec server health](https://app.asana.com/0/1185117109217422/1206547676849854/f)

This PR adds handling for POSTs that we will receive from Wabtec containing server stats for the PAESS headend servers. The plan is to have this sent once per day. 

Example JSON payload from Wabtec:
```
{
    "time":  1707329422,
    "data":  {
                 "nodes":  {
                               "Available_D_Space":  54.16,
                               "Available_C_Space":  54.16,
                               "AvailableMemory":  13.12,
                               "Total_D_Space":  80,
                               "TotalMemory":  16,
                               "Total_C_Space":  80,
                               "Uptime":  "109 days, 7 hours, 52 minutes",
                               "IPAddress":  "172.20.145.20"
                           }
             }
}
```

