### PR TITLE
Track recent departure for 90 minutes

### DIFF
--- a/lib/engine/last_trip.ex
+++ b/lib/engine/last_trip.ex
@@ -114,7 +114,8 @@ defmodule Engine.LastTrip do
     |> Enum.each(fn {key, departures} ->
       departures_within_last_hour =
         Map.filter(departures, fn {_, departed_time} ->
-          DateTime.to_unix(current_time) - DateTime.to_unix(departed_time) <= @hour_in_seconds
+          DateTime.to_unix(current_time) - DateTime.to_unix(departed_time) <=
+            @hour_in_seconds * 1.5
         end)
 
       :ets.insert(state.recent_departures, {key, departures_within_last_hour})


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Read in the "last train" information from transit data feed and display "end of service" information](https://app.asana.com/0/1185117109217413/1206605275887005/f)

Ad-hoc
Small tweak to track recent departures for 90 minutes instead of 60. This means that "Platform closed" will show for 90 minutes instead of 60. This is to help make sure that there is enough time for trips to pass through each stop so that MZ signs have a chance to show "Station closed".

60 minutes was too short so some stations at the ends of the OL and BL would never have their MZ signs show "Station closed" because the service ended status for one direction would be forgotten before the last trip in the other direciton reaches the station.
