### PR TITLE
Don't page no service message on MZ signs

### DIFF
--- a/lib/content/message/last_trip/no_service.ex
+++ b/lib/content/message/last_trip/no_service.ex
@@ -1,32 +1,26 @@
 defmodule Content.Message.LastTrip.NoService do
-  @enforce_keys [:destination, :page?]
+  @enforce_keys [:destination, :line]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
-          page?: boolean()
+          line: :top | :bottom
         }
 
   defimpl Content.Message do
     def to_string(%Content.Message.LastTrip.NoService{
           destination: destination,
-          page?: page?
+          line: line
         }) do
       headsign = PaEss.Utilities.destination_to_sign_string(destination)
 
-      if page?,
-        do: [
-          {Content.Utilities.width_padded_string(
-             headsign,
-             "No trains",
-             24
-           ), 6},
-          {Content.Utilities.width_padded_string(
-             headsign,
-             "Svc ended",
-             24
-           ), 6}
-        ],
+      if line == :bottom,
+        do:
+          Content.Utilities.width_padded_string(
+            headsign,
+            "Svc ended",
+            24
+          ),
         else:
           Content.Utilities.width_padded_string(
             headsign,

--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -34,12 +34,12 @@ defmodule Signs.Utilities.LastTrip do
               {unpacked_mz_bottom,
                %Content.Message.LastTrip.NoService{
                  destination: top_source.headway_destination,
-                 page?: true
+                 line: :bottom
                }}
             else
               {%Content.Message.LastTrip.NoService{
                  destination: top_source.headway_destination,
-                 page?: false
+                 line: :top
                }, unpacked_mz_bottom}
             end
 
@@ -49,12 +49,12 @@ defmodule Signs.Utilities.LastTrip do
               {unpacked_mz_top,
                %Content.Message.LastTrip.NoService{
                  destination: bottom_source.headway_destination,
-                 page?: true
+                 line: :bottom
                }}
             else
               {%Content.Message.LastTrip.NoService{
                  destination: bottom_source.headway_destination,
-                 page?: false
+                 line: :top
                }, unpacked_mz_top}
             end
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1426,7 +1426,7 @@ defmodule Signs.RealtimeTest do
 
       expect_messages(
         {[{"Mattapan   Stopped", 6}, {"Mattapan   8 stops", 6}, {"Mattapan      away", 6}],
-         [{"Southbound     No trains", 6}, {"Southbound     Svc ended", 6}]}
+         "Southbound     Svc ended"}
       )
 
       expect_audios([


### PR DESCRIPTION
#### Summary of changes
Ad-hoc

Quick fix to prevent double-line paging on MZ signs during LTOTD treatment. This type of double paging causes a bug to occur in the vendor's software which leads to a crash and the signs going blank for some time.
