### PR TITLE
fix custom mode not overriding last trip message

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -70,7 +70,7 @@ defmodule Signs.Utilities.Messages do
       end
 
     messages =
-      if sign_config in [:off, :static_text],
+      if sign_config == :off or match?({:static_text, _}, sign_config),
         do: messages,
         else:
           Signs.Utilities.LastTrip.get_last_trip_messages(


### PR DESCRIPTION
#### Summary of changes
This fixes a bug that was preventing custom mode from taking priority over LTOTD messages.