### PR TITLE
don't display predictions with skipped schedule_relationship

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -41,7 +41,7 @@ defmodule Signs.Utilities.Predictions do
        ) do
     predictions
     |> Enum.filter(fn p ->
-      p.seconds_until_departure
+      p.seconds_until_departure && p.schedule_relationship != :skipped
     end)
     |> Enum.sort_by(fn prediction ->
       {if terminal_prediction?(prediction, sources) do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -249,9 +249,12 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
-    test "ignores predictions with no departure time" do
+    test "ignores predictions with no departure time or skipped schedule_relationship" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :alewife, seconds_until_departure: nil)]
+        [
+          prediction(destination: :alewife, seconds_until_departure: nil),
+          prediction(destination: :alewife, arrival: 1, schedule_relationship: :skipped)
+        ]
       end)
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -1551,7 +1554,7 @@ defmodule Signs.RealtimeTest do
       departure_certainty: Keyword.get(opts, :departure_certainty),
       seconds_until_passthrough: Keyword.get(opts, :seconds_until_passthrough),
       direction_id: Keyword.get(opts, :direction_id, 0),
-      schedule_relationship: nil,
+      schedule_relationship: Keyword.get(opts, :schedule_relationship),
       route_id: Keyword.get(opts, :route_id),
       trip_id: Keyword.get(opts, :trip_id, "123"),
       destination_stop_id: Keyword.get(opts, :destination_stop_id),


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Update RTS filtering for non-revenue trains](https://app.asana.com/0/1185117109217413/1207429871853193/f)

This filters out predictions with `schedule_relationship` set to `SKIPPED`, to avoid displaying non-revenue predictions now that they include a departure time.