### PR TITLE
reorder process startup to avoid race condition

### DIFF
--- a/lib/realtime_signs.ex
+++ b/lib/realtime_signs.ex
@@ -25,6 +25,8 @@ defmodule RealtimeSigns do
         :hackney_pool.child_spec(:arinc_pool, []),
         Engine.Health,
         Engine.Config,
+        Engine.Locations,
+        Engine.LastTrip,
         Engine.Predictions,
         Engine.ScheduledHeadways,
         Engine.Static,
@@ -32,11 +34,9 @@ defmodule RealtimeSigns do
         Engine.BusPredictions,
         Engine.ChelseaBridge,
         Engine.Routes,
-        Engine.LastTrip,
         MessageQueue,
         RealtimeSigns.Scheduler,
         RealtimeSignsWeb.Endpoint,
-        Engine.Locations,
         HeadwayAnalysis.Supervisor
       ] ++
         http_updater_children() ++


### PR DESCRIPTION
#### Summary of changes

This fixes an intermittent crash on app startup. `Engine.Predictions` tries to access an ETS table controlled by `Engine.Locations`, and sometimes crashes one time if the process hasn't been initialized yet. By starting `Engine.Locations` first, it should avoid this problem. A similar situation applies to `Engine.LastTrip`.