### PR TITLE
remove unused process options

### DIFF
--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -65,7 +65,7 @@ defmodule Signs.Bus do
           last_read_time: DateTime.t()
         }
 
-  def start_link(sign, opts \\ []) do
+  def start_link(sign) do
     state = %__MODULE__{
       id: Map.fetch!(sign, "id"),
       pa_ess_loc: Map.fetch!(sign, "pa_ess_loc"),
@@ -80,10 +80,10 @@ defmodule Signs.Bus do
       chelsea_bridge: sign["chelsea_bridge"],
       read_loop_interval: Map.fetch!(sign, "read_loop_interval"),
       read_loop_offset: Map.fetch!(sign, "read_loop_offset"),
-      config_engine: opts[:config_engine] || Engine.Config,
-      prediction_engine: opts[:prediction_engine] || Engine.BusPredictions,
-      bridge_engine: opts[:bridge_engine] || Engine.ChelseaBridge,
-      alerts_engine: opts[:alerts_engine] || Engine.Alerts,
+      config_engine: Engine.Config,
+      prediction_engine: Engine.BusPredictions,
+      bridge_engine: Engine.ChelseaBridge,
+      alerts_engine: Engine.Alerts,
       routes_engine: Engine.Routes,
       sign_updater: PaEss.Updater,
       prev_predictions: [],

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -89,14 +89,8 @@ defmodule Signs.Realtime do
           uses_shuttles: boolean()
         }
 
-  def start_link(%{"type" => "realtime"} = config, opts \\ []) do
+  def start_link(%{"type" => "realtime"} = config) do
     source_config = config |> Map.fetch!("source_config") |> SourceConfig.parse!()
-
-    prediction_engine = opts[:prediction_engine] || Engine.Predictions
-    headway_engine = opts[:headway_engine] || Engine.ScheduledHeadways
-    config_engine = opts[:config_engine] || Engine.Config
-    alerts_engine = opts[:alerts_engine] || Engine.Alerts
-    last_trip_engine = opts[:last_trip_engine] || Engine.LastTrip
 
     sign = %__MODULE__{
       id: Map.fetch!(config, "id"),
@@ -107,18 +101,16 @@ defmodule Signs.Realtime do
       source_config: source_config,
       current_content_top: "",
       current_content_bottom: "",
-      prediction_engine: prediction_engine,
-      location_engine: opts[:location_engine] || Engine.Locations,
-      headway_engine: headway_engine,
-      config_engine: config_engine,
-      alerts_engine: alerts_engine,
-      last_trip_engine: last_trip_engine,
-      current_time_fn:
-        opts[:current_time_fn] ||
-          fn ->
-            time_zone = Application.get_env(:realtime_signs, :time_zone)
-            DateTime.utc_now() |> DateTime.shift_zone!(time_zone)
-          end,
+      prediction_engine: Engine.Predictions,
+      location_engine: Engine.Locations,
+      headway_engine: Engine.ScheduledHeadways,
+      config_engine: Engine.Config,
+      alerts_engine: Engine.Alerts,
+      last_trip_engine: Engine.LastTrip,
+      current_time_fn: fn ->
+        time_zone = Application.get_env(:realtime_signs, :time_zone)
+        DateTime.utc_now() |> DateTime.shift_zone!(time_zone)
+      end,
       sign_updater: PaEss.Updater,
       last_update: nil,
       tick_read: 240 + Map.fetch!(config, "read_loop_offset"),


### PR DESCRIPTION
#### Summary of changes

This removes some unused `opts` parameters that were originally intended to be used in test cases. In practice, we just set the state directly, so these extra arguments are not used.