### PR TITLE
Modify "End of service" text to specify routes and/or directions

### DIFF
--- a/lib/content/message/last_trip/platform_closed.ex
+++ b/lib/content/message/last_trip/platform_closed.ex
@@ -11,7 +11,7 @@ defmodule Content.Message.LastTrip.PlatformClosed do
 
   defimpl Content.Message do
     def to_string(%Content.Message.LastTrip.PlatformClosed{}) do
-      "Platform closed"
+      "Service ended"
     end
   end
 end

--- a/lib/content/message/last_trip/service_ended.ex
+++ b/lib/content/message/last_trip/service_ended.ex
@@ -11,7 +11,7 @@ defmodule Content.Message.LastTrip.ServiceEnded do
 
   defimpl Content.Message do
     def to_string(%Content.Message.LastTrip.ServiceEnded{destination: nil}) do
-      "Service ended for the night"
+      "Service ended for night"
     end
 
     def to_string(%Content.Message.LastTrip.ServiceEnded{destination: destination}) do

--- a/lib/content/message/last_trip/service_ended.ex
+++ b/lib/content/message/last_trip/service_ended.ex
@@ -3,13 +3,20 @@ defmodule Content.Message.LastTrip.ServiceEnded do
   A message displayed when a station is closed
   """
   @enforce_keys []
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:destination]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          destination: PaEss.destination()
+        }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.LastTrip.ServiceEnded{}) do
-      "Service ended for night"
+    def to_string(%Content.Message.LastTrip.ServiceEnded{destination: nil}) do
+      "Service ended for the night"
+    end
+
+    def to_string(%Content.Message.LastTrip.ServiceEnded{destination: destination}) do
+      headsign = PaEss.Utilities.destination_to_sign_string(destination)
+      "No #{headsign} trains"
     end
   end
 end

--- a/lib/content/message/last_trip/station_closed.ex
+++ b/lib/content/message/last_trip/station_closed.ex
@@ -3,13 +3,16 @@ defmodule Content.Message.LastTrip.StationClosed do
   A message displayed when a station is closed
   """
   @enforce_keys []
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [routes: []]
 
   @type t :: %__MODULE__{}
 
   defimpl Content.Message do
-    def to_string(%Content.Message.LastTrip.StationClosed{}) do
-      "Station closed"
+    def to_string(%Content.Message.LastTrip.StationClosed{routes: routes}) do
+      case PaEss.Utilities.get_line_from_routes_list(routes) do
+        "train" -> "Station closed"
+        line -> "No #{line}"
+      end
     end
   end
 end

--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -67,7 +67,7 @@ defmodule Signs.Utilities.LastTrip do
              not (is_prediction?(top_message) or is_prediction?(bottom_message)),
            do:
              {%LastTrip.PlatformClosed{destination: source.headway_destination},
-              %LastTrip.ServiceEnded{}},
+              %LastTrip.ServiceEnded{destination: source.headway_destination}},
            else: messages
     end
   end

--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -12,11 +12,7 @@ defmodule Signs.Utilities.LastTrip do
         {unpacked_mz_top, unpacked_mz_bottom} = unpack_mezzanine_content(messages, source)
         {top_source_config, bottom_source_config} = source
 
-        routes =
-          Enum.flat_map(
-            top_source_config.sources ++ bottom_source_config.sources,
-            &List.wrap(&1.routes)
-          )
+        routes = Signs.Utilities.SourceConfig.sign_routes(source)
 
         cond do
           # If combined alert status, only switch to Last Trip messaging once service has fully ended.

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1390,7 +1390,7 @@ defmodule Signs.RealtimeTest do
         | tick_read: 0
       }
 
-      expect_messages({"Platform closed", "Service ended for night"})
+      expect_messages({"Service ended", "No Southbound trains"})
       expect_audios(canned: {"107", ["884", "21000", "787", "21000", "882"], :audio})
       Signs.Realtime.handle_info(:run_loop, sign)
     end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1420,7 +1420,7 @@ defmodule Signs.RealtimeTest do
       }
 
       expect_messages({"Station closed", "Service ended for night"})
-      expect_audios(canned: {"103", ["883"], :audio})
+      expect_audios(canned: {"105", ["864", "21000", "882"], :audio})
       Signs.Realtime.handle_info(:run_loop, sign)
     end
 
@@ -1431,7 +1431,7 @@ defmodule Signs.RealtimeTest do
       }
 
       expect_messages({"No Orange Line", "Service ended for night"})
-      expect_audios(canned: {"103", ["883"], :audio})
+      expect_audios(canned: {"105", ["3006", "21000", "882"], :audio})
       Signs.Realtime.handle_info(:run_loop, sign)
     end
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -62,6 +62,24 @@ defmodule Signs.RealtimeTest do
       current_content_bottom: "Every 11 to 13 min"
   }
 
+  @mezzanine_sign_with_routes %{
+    @mezzanine_sign
+    | source_config: {
+        %{
+          sources: [%{@src | routes: ["Orange"]}],
+          headway_group: "group",
+          headway_destination: :northbound
+        },
+        %{
+          sources: [%{@src_2 | routes: ["Orange"]}],
+          headway_group: "group",
+          headway_destination: :southbound
+        }
+      },
+      current_content_top: "Orange line trains",
+      current_content_bottom: "Every 11 to 13 min"
+  }
+
   @jfk_mezzanine_sign %{
     @sign
     | pa_ess_loc: "RJFK",
@@ -1406,9 +1424,20 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, sign)
     end
 
+    test "Station with routes is closed" do
+      sign = %{
+        @mezzanine_sign_with_routes
+        | tick_read: 0
+      }
+
+      expect_messages({"No Orange Line", "Service ended for night"})
+      expect_audios(canned: {"103", ["883"], :audio})
+      Signs.Realtime.handle_info(:run_loop, sign)
+    end
+
     test "No service goes on bottom line when top line fits in 18 chars or less" do
       sign = %{
-        @mezzanine_sign
+        @mezzanine_sign_with_routes
         | tick_read: 0,
           announced_stalls: [{"a", 8}]
       }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Modify "End of service" text to specify routes and/or directions](https://app.asana.com/0/1185117109217422/1207279074432055/f)

Updates Last Trip messages to add additional context w/r/t route or direction when possible.

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [x] ~~Any new or changed functions have typespecs~~ No changes to functions
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
