### PR TITLE
Consider stopped trains as a prediction

### DIFF
--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -101,7 +101,8 @@ defmodule Signs.Utilities.LastTrip do
   end
 
   defp is_prediction?(message) do
-    match?(%Content.Message.Predictions{}, message)
+    match?(%Content.Message.Predictions{}, message) or
+      match?(%Content.Message.StoppedTrain{}, message)
   end
 
   defp is_empty?(message) do


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Investigate: weird LTOTD behavior on BL](https://app.asana.com/0/1205101743911491/1207509052653329/f)

We are seeing some weirdness on BL EB stops where we sometimes show "service ended" instead of "stopped away" for a train that is in the predictions feed as holding at an upstream station. While this change doesn't address the underlying problem with the data and trains potentially being mis-tagged (see ticket for more details on the investigation), we can mitigate the issue by making sure that stopped train messages don't get masked by LTOTD logic.
