### PR TITLE
fix several audio issues

### DIFF
--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -64,8 +64,9 @@ defmodule Content.Audio.ServiceEnded do
       {tts_text(audio), nil}
     end
 
-    defp tts_text(%Content.Audio.ServiceEnded{location: :station}) do
-      "This station is closed. Service has ended for the night."
+    defp tts_text(%Content.Audio.ServiceEnded{location: :station, routes: routes}) do
+      line = Utilities.get_line_from_routes_list(routes) |> String.capitalize()
+      "#{line} service has ended for the night."
     end
 
     defp tts_text(%Content.Audio.ServiceEnded{location: :platform, destination: destination}) do

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -46,13 +46,13 @@ defmodule Content.Audio.VehiclesToDestination do
     def to_params(
           %Content.Audio.VehiclesToDestination{
             headway_range: {range_low, range_high},
-            destination: destination
+            routes: routes
           } = audio
         ) do
       low_var = Utilities.number_var(range_low, :english)
       high_var = Utilities.number_var(range_high, :english)
 
-      if low_var && high_var && destination do
+      if low_var && high_var && !routes do
         {:canned, {message_id(audio), [low_var, high_var], :audio}}
       else
         {:ad_hoc, {tts_text(audio), :audio}}
@@ -70,15 +70,15 @@ defmodule Content.Audio.VehiclesToDestination do
          }) do
       trains =
         case {destination, routes} do
-          {destination, nil} ->
-            {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
-            "#{destination_text} trains"
-
-          {nil, [route]} ->
+          {_, [route]} ->
             "#{route} line trains"
 
-          {nil, _} ->
+          {_, routes} when is_list(routes) ->
             "Trains"
+
+          {destination, _} ->
+            {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
+            "#{destination_text} trains"
         end
 
       "#{trains} every #{range_low} to #{range_high} minutes."

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1369,9 +1369,14 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Red line trains", "Every 9 to 13 min"})
 
+      expect_audios([{:ad_hoc, {"Red line trains every 9 to 13 minutes.", :audio}}], [
+        {"Red line trains every 9 to 13 minutes.", nil}
+      ])
+
       Signs.Realtime.handle_info(:run_loop, %{
         @mezzanine_sign
-        | current_time_fn: fn -> datetime(~T[04:50:00]) end
+        | current_time_fn: fn -> datetime(~T[04:50:00]) end,
+          tick_read: 0
       })
     end
 
@@ -1638,7 +1643,7 @@ defmodule Signs.RealtimeTest do
       expect_messages({"Station closed", "Service ended for night"})
 
       expect_audios([{:canned, {"105", ["864", "21000", "882"], :audio}}], [
-        {"This station is closed. Service has ended for the night.", nil}
+        {"Train service has ended for the night.", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, %{@multi_route_mezzanine_sign | tick_read: 0})
@@ -1653,7 +1658,7 @@ defmodule Signs.RealtimeTest do
       expect_messages({"No Red Line", "Service ended for night"})
 
       expect_audios([{:canned, {"105", ["3005", "21000", "882"], :audio}}], [
-        {"This station is closed. Service has ended for the night.", nil}
+        {"Red line service has ended for the night.", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, sign)


### PR DESCRIPTION
#### Summary of changes

This fixes three audio issues:
1. When partial early AM suppression on a mezzanine sign results in two headway messages, the resulting combined message ends up with both a `destination` and `routes`. The headway TTS audio code wasn't accounting for that possibility, resulting in a crash.
2. In the same case as above, the non-TTS audio code was using a slightly different algorithm than the text code, resulting in a headway readout using the top line's destination, instead of the route name.
3. The TTS audio code for station-level service ended messages was still saying "This station is closed" instead of using the line name.