### PR TITLE
fix: mark riverside as a terminal station

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -5757,7 +5757,7 @@
             "Green-D"
           ],
           "platform": null,
-          "terminal": false,
+          "terminal": true,
           "announce_arriving": false,
           "announce_boarding": true
         }


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** ["BRD" showing on GL terminals too early](https://app.asana.com/0/1185117109217413/1207563461018197/f)

Sets `terminal: true` for  Riverside so when a prediction is 0 stops away `BRD` is not shown until within the predicted departure time.

Note: I still haven't reproduced the original issue locally. Any help verifying before merging is much appreciated.

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
