### PR TITLE
RTS update_signs: logs include message_type for custom or headway modes

### DIFF
--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -83,7 +83,13 @@ defmodule PaEss.HttpUpdater do
       signs_ui_ms: signs_ui_ms,
       top_line: inspect(top_line),
       bottom_line: inspect(bottom_line),
-      sign_id: sign_id
+      sign_id: sign_id,
+      message_type:
+        case Engine.Config.sign_config(sign_id) do
+          type when is_atom(type) -> type
+          tuple when is_tuple(tuple) -> elem(tuple, 0)
+          _ -> nil
+        end
     )
 
     result

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -84,7 +84,7 @@ defmodule PaEss.HttpUpdater do
       top_line: inspect(top_line),
       bottom_line: inspect(bottom_line),
       sign_id: sign_id,
-      message_type:
+      current_config:
         case Engine.Config.sign_config(sign_id) do
           type when is_atom(type) -> type
           tuple when is_tuple(tuple) -> elem(tuple, 0)


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [RTS update_signs: logs include message_type for custom or headway modes](https://app.asana.com/0/1185117109217413/1204643930705430/f)

- fetches sign config and includes message_type in `update_sign` logging

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
