### PR TITLE
fix: expand handling of alert status on signs with top/bottom configs

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -176,48 +176,33 @@ defmodule Signs.Utilities.Messages do
           Engine.Alerts.Fetcher.stop_status(),
           :top | :bottom
         ) :: Signs.Realtime.line_content()
-  defp get_paging_headway_or_alert_messages(
-         %Signs.Realtime{source_config: {config, _bottom}} = sign,
-         current_time,
-         {alert_status, _},
-         :top
-       ) do
-    get_paging_alert_message(alert_status, sign.uses_shuttles, config.headway_destination) ||
-      Signs.Utilities.Headways.get_paging_message(sign, config, current_time)
-  end
+  defp get_paging_headway_or_alert_messages(sign, current_time, alert_status, pos) do
+    config_and_alert_status =
+      case {sign, alert_status, pos} do
+        {%Signs.Realtime{source_config: {config, _bottom}}, {alert_status, _}, :top} ->
+          {config, alert_status}
 
-  defp get_paging_headway_or_alert_messages(
-         %Signs.Realtime{source_config: {_top, config}} = sign,
-         current_time,
-         {_, alert_status},
-         :bottom
-       ) do
-    get_paging_alert_message(alert_status, sign.uses_shuttles, config.headway_destination) ||
-      Signs.Utilities.Headways.get_paging_message(sign, config, current_time)
-  end
+        {%Signs.Realtime{source_config: {config, _bottom}}, alert_status, :top} ->
+          {config, alert_status}
 
-  defp get_paging_headway_or_alert_messages(
-         %Signs.Realtime{source_config: {config, _bottom}} = sign,
-         current_time,
-         alert_status,
-         :top
-       ) do
-    get_paging_alert_message(alert_status, sign.uses_shuttles, config.headway_destination) ||
-      Signs.Utilities.Headways.get_paging_message(sign, config, current_time)
-  end
+        {%Signs.Realtime{source_config: {_top, config}}, {_, alert_status}, :bottom} ->
+          {config, alert_status}
 
-  defp get_paging_headway_or_alert_messages(
-         %Signs.Realtime{source_config: {_top, config}} = sign,
-         current_time,
-         alert_status,
-         :bottom
-       ) do
-    get_paging_alert_message(alert_status, sign.uses_shuttles, config.headway_destination) ||
-      Signs.Utilities.Headways.get_paging_message(sign, config, current_time)
-  end
+        {%Signs.Realtime{source_config: {_top, config}}, alert_status, :bottom} ->
+          {config, alert_status}
 
-  defp get_paging_headway_or_alert_messages(_, _, _, _) do
-    Content.Message.Empty.new()
+        _ ->
+          nil
+      end
+
+    case config_and_alert_status do
+      {config, alert_status} ->
+        get_paging_alert_message(alert_status, sign.uses_shuttles, config.headway_destination) ||
+          Signs.Utilities.Headways.get_paging_message(sign, config, current_time)
+
+      _ ->
+        Content.Message.Empty.new()
+    end
   end
 
   defp get_alert_messages(alert_status, %{pa_ess_loc: "GUNS"}) do

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -205,14 +205,24 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
+  @spec get_alert_messages(
+          Engine.Alerts.Fetcher.stop_status()
+          | {Engine.Alerts.Fetcher.stop_status(), Engine.Alerts.Fetcher.stop_status()},
+          Signs.Realtime.t()
+        ) ::
+          Signs.Realtime.sign_messages() | nil
+  defp get_alert_messages({top_alert_status, bottom_alert_status}, sign) do
+    top_alert_status
+    |> Engine.Alerts.Fetcher.higher_priority_status(bottom_alert_status)
+    |> get_alert_messages(sign)
+  end
+
   defp get_alert_messages(alert_status, %{pa_ess_loc: "GUNS"}) do
     if alert_status in [:none, :alert_along_route],
       do: nil,
       else: {%Alert.NoService{}, %Alert.UseRoutes{}}
   end
 
-  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
-          Signs.Realtime.sign_messages() | nil
   defp get_alert_messages(alert_status, sign) do
     sign_routes = Signs.Utilities.SourceConfig.sign_routes(sign.source_config)
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1573,6 +1573,20 @@ defmodule Signs.RealtimeTest do
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
+
+    test "signs in headway mode with split alert_status will show the first alert" do
+      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+
+      expect_messages({"No train service", "Use shuttle bus"})
+
+      expect_audios([{:canned, {"199", ["864"], :audio}}], [
+        {"There is no train service at this station. Use shuttle.", nil}
+      ])
+
+      Signs.Realtime.handle_info(:run_loop, @multi_route_mezzanine_sign)
+    end
   end
 
   describe "decrement_ticks/1" do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -287,6 +287,7 @@ defmodule Signs.RealtimeTest do
 
     test "multi-route mezzanine sign with alert" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
       expect_messages({"No train service", ""})
 
       expect_audios([{:canned, {"107", ["861", "21000", "864", "21000", "863"], :audio}}], [


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Ashmont MZ sign shows headway mode for Mattapan Trolley when it's shuttling](https://app.asana.com/0/1185117109217413/1207563461018208/f)

different alert status per top/bottom config are needed to support showing an alert status based message on a single source config. this is most common when top and bottom source configs are for different lines/routes.

previously the alert_status for a sign was reduced down to a single value which could cause weird behavior when an alert was only effecting one of the two source configs.

https://github.com/user-attachments/assets/1ab76a7d-fe2e-4884-b0df-a1feb070402e

#### Reviewer Checklist
- [x] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
