### PR TITLE
chore: refactor function application over `source_config` values

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -150,39 +150,21 @@ defmodule Signs.Realtime do
     current_time = sign.current_time_fn.()
 
     alert_status =
-      case sign.source_config do
-        {top, bottom} ->
-          top_alert_status = get_alert_status_for_source_config(top, sign.alerts_engine)
-          bottom_alert_status = get_alert_status_for_source_config(bottom, sign.alerts_engine)
-
-          {top_alert_status, bottom_alert_status}
-
-        source_config ->
-          alert_status = get_alert_status_for_source_config(source_config, sign.alerts_engine)
-
-          alert_status
-      end
+      sign.source_config
+      |> map_source_config(&get_alert_status_for_source_config(&1, sign.alerts_engine))
       |> then(fn
         {alert_status, alert_status} -> alert_status
         alert_status -> alert_status
       end)
 
     first_scheduled_departures =
-      case sign.source_config do
-        {top, bottom} ->
-          {
-            {sign.headway_engine.get_first_scheduled_departure(SourceConfig.sign_stop_ids(top)),
-             top.headway_destination},
-            {sign.headway_engine.get_first_scheduled_departure(
-               SourceConfig.sign_stop_ids(bottom)
-             ), bottom.headway_destination}
-          }
-
-        source ->
-          {sign.headway_engine.get_first_scheduled_departure(
-             SourceConfig.sign_stop_ids(sign.source_config)
-           ), source.headway_destination}
-      end
+      sign.source_config
+      |> map_source_config(
+        &{
+          sign.headway_engine.get_first_scheduled_departure(SourceConfig.sign_stop_ids(&1)),
+          &1.headway_destination
+        }
+      )
 
     prev_predictions_lookup =
       for prediction <- sign.prev_predictions, into: %{} do
@@ -202,14 +184,10 @@ defmodule Signs.Realtime do
       end
 
     service_end_statuses_per_source =
-      case sign.source_config do
-        {top_source, bottom_source} ->
-          {has_service_ended_for_source?(sign, top_source, current_time),
-           has_service_ended_for_source?(sign, bottom_source, current_time)}
-
-        source ->
-          has_service_ended_for_source?(sign, source, current_time)
-      end
+      map_source_config(
+        sign.source_config,
+        &has_service_ended_for_source?(sign, &1, current_time)
+      )
 
     {new_top, new_bottom} =
       Utilities.Messages.get_messages(
@@ -314,4 +292,7 @@ defmodule Signs.Realtime do
 
     alert_status
   end
+
+  defp map_source_config({top, bottom}, fun), do: {fun.(top), fun.(bottom)}
+  defp map_source_config(config, fun), do: fun.(config)
 end


### PR DESCRIPTION
#### Summary of changes

Defines `map_source_config/2`, a function for applying a function to SourceConfig values (both single and top/bottom--tuple).             
                                                                                     
Uses the new `map_source_config/2` function to calculate `alert_status`, `first_scheduled_departures`, and `service_end_statuses_per_source`.


#### Reviewer Checklist
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
