### PR TITLE
fix: handle split alert statuses for signs in headway mode

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -205,14 +205,24 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
+  @spec get_alert_messages(
+          Engine.Alerts.Fetcher.stop_status()
+          | {Engine.Alerts.Fetcher.stop_status(), Engine.Alerts.Fetcher.stop_status()},
+          Signs.Realtime.t()
+        ) ::
+          Signs.Realtime.sign_messages() | nil
+  defp get_alert_messages({top_alert_status, bottom_alert_status}, sign) do
+    top_alert_status
+    |> Engine.Alerts.Fetcher.higher_priority_status(bottom_alert_status)
+    |> get_alert_messages(sign)
+  end
+
   defp get_alert_messages(alert_status, %{pa_ess_loc: "GUNS"}) do
     if alert_status in [:none, :alert_along_route],
       do: nil,
       else: {%Alert.NoService{}, %Alert.UseRoutes{}}
   end
 
-  @spec get_alert_messages(Engine.Alerts.Fetcher.stop_status(), Signs.Realtime.t()) ::
-          Signs.Realtime.sign_messages() | nil
   defp get_alert_messages(alert_status, sign) do
     sign_routes = Signs.Utilities.SourceConfig.sign_routes(sign.source_config)
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1573,6 +1573,20 @@ defmodule Signs.RealtimeTest do
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
+
+    test "signs in headway mode with split alert_status will show the first alert" do
+      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+
+      expect_messages({"No train service", "Use shuttle bus"})
+
+      expect_audios([{:canned, {"199", ["864"], :audio}}], [
+        {"There is no train service at this station. Use shuttle.", nil}
+      ])
+
+      Signs.Realtime.handle_info(:run_loop, @multi_route_mezzanine_sign)
+    end
   end
 
   describe "decrement_ticks/1" do


### PR DESCRIPTION
@PaulJKim pointed out that mezzanine signs when set to `:headway` mode check alert status but that code hadn't been updated to handle when alert statuses are different between `top` and `bottom` source configurations.

This change intercepts split alert status values passed to `get_alert_messages/2` and gets the highest priority alert status of the two using `Engine.Alerts.higher_priority_status/2` before continuing on to the existing implementation.