### PR TITLE
Revert "Migrate to GTFS-rt predictions and locations feeds"

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -17,6 +17,7 @@ export API_V3_URL=https://api-dev-green.mbtace.com
 #export CHELSEA_BRIDGE_URL=
 #export CHELSEA_BRIDGE_AUTH=
 
-# URLs of the enhanced trip-update and vehicle-position feeds. Required.
-#export TRIP_UPDATE_URL="https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/TripUpdates_enhanced.json"
-#export VEHICLE_POSITIONS_URL="https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/VehiclePositions_enhanced.json"
+# URLs of the enhanced trip-update and vehicle-position feeds. Default to the real feed URLs if
+# not set here.
+#export TRIP_UPDATE_URL=
+#export VEHICLE_POSITIONS_URL=

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,12 +12,12 @@ if config_env() != :test do
     trip_update_url:
       System.get_env(
         "TRIP_UPDATE_URL",
-        "https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/TripUpdates_enhanced.json"
+        "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/TripUpdates_enhanced.json"
       ),
     vehicle_positions_url:
       System.get_env(
         "VEHICLE_POSITIONS_URL",
-        "https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/VehiclePositions_enhanced.json"
+        "https://s3.amazonaws.com/mbta-gtfs-s3/rtr/VehiclePositions_enhanced.json"
       ),
     s3_bucket: System.get_env("SIGNS_S3_BUCKET"),
     s3_path: System.get_env("SIGNS_S3_PATH"),

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -77,17 +77,10 @@ defmodule Content.Message.Predictions do
 
     {minutes, approximate?} =
       cond do
-        prediction.stopped_at_predicted_stop? ->
-          {:boarding, false}
-
-        predicted_time <= 30 ->
-          {:arriving, false}
-
-        predicted_time <= 60 ->
-          {:approaching, false}
-
-        true ->
-          compute_minutes(predicted_time, certainty)
+        prediction.stops_away == 0 -> {:boarding, false}
+        predicted_time <= 30 -> {:arriving, false}
+        predicted_time <= 60 -> {:approaching, false}
+        true -> compute_minutes(predicted_time, certainty)
       end
 
     {crowding_data_confidence, crowding_description} =
@@ -135,16 +128,13 @@ defmodule Content.Message.Predictions do
   def terminal(prediction, station_code, zone, sign, width \\ 18)
 
   def terminal(prediction, station_code, zone, sign, width) do
+    stopped_at? = prediction.stops_away == 0
+
     {minutes, approximate?} =
       case prediction.seconds_until_departure + @terminal_prediction_offset_seconds do
-        x when x <= @terminal_brd_seconds and prediction.stopped_at_predicted_stop? ->
-          {:boarding, false}
-
-        x when x <= @terminal_brd_seconds ->
-          {1, false}
-
-        x ->
-          compute_minutes(x, prediction.departure_certainty)
+        x when x <= @terminal_brd_seconds and stopped_at? -> {:boarding, false}
+        x when x <= @terminal_brd_seconds -> {1, false}
+        x -> compute_minutes(x, prediction.departure_certainty)
       end
 
     case Content.Utilities.destination_for_prediction(

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -65,11 +65,15 @@ defmodule Fake.HTTPoison do
       %{
         "entity" => [
           %{
+            "alert" => nil,
             "id" => "1490783458_32568935",
+            "is_deleted" => false,
             "trip_update" => %{
+              "delay" => nil,
               "stop_time_update" => [
                 %{
                   "arrival" => %{
+                    "delay" => nil,
                     "time" => 1_491_570_120,
                     "uncertainty" => nil
                   },
@@ -80,6 +84,7 @@ defmodule Fake.HTTPoison do
                 },
                 %{
                   "arrival" => %{
+                    "delay" => nil,
                     "time" => 1_491_570_180,
                     "uncertainty" => nil
                   },
@@ -238,17 +243,23 @@ defmodule Fake.HTTPoison do
       %{
         "entity" => [
           %{
+            "alert" => nil,
             "id" => "1490783458_32568935",
+            "is_deleted" => false,
             "trip_update" => %{
+              "delay" => nil,
               "stop_time_update" => [
                 %{
                   "arrival" => %{
+                    "delay" => nil,
                     "time" => 1_491_570_180,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "stop_to_update",
-                  "stop_sequence" => 1
+                  "stop_sequence" => 1,
+                  "stops_away" => 0
                 }
               ],
               "timestamp" => nil,
@@ -258,15 +269,15 @@ defmodule Fake.HTTPoison do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "G-10040",
                 "label" => "3260",
                 "license_plate" => nil
               }
-            }
+            },
+            "vehicle" => nil
           }
         ],
         "header" => %{

--- a/lib/predictions/last_trip.ex
+++ b/lib/predictions/last_trip.ex
@@ -1,13 +1,8 @@
 defmodule Predictions.LastTrip do
-  alias Predictions.Predictions
-
   defp get_running_trips(predictions_feed) do
     predictions_feed["entity"]
     |> Stream.map(& &1["trip_update"])
-    |> Stream.filter(
-      &(Predictions.relevant_rail_route?(&1["trip"]["route_id"]) and
-          &1["trip"]["schedule_relationship"] != "CANCELED")
-    )
+    |> Enum.reject(&(&1["trip"]["schedule_relationship"] == "CANCELED"))
   end
 
   def get_last_trips(predictions_feed) do

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -10,7 +10,8 @@ defmodule Predictions.Prediction do
             route_id: nil,
             trip_id: nil,
             destination_stop_id: nil,
-            stopped_at_predicted_stop?: false,
+            stopped?: false,
+            stops_away: 0,
             boarding_status: nil,
             revenue_trip?: true,
             vehicle_id: nil
@@ -29,7 +30,8 @@ defmodule Predictions.Prediction do
           route_id: String.t(),
           trip_id: trip_id() | nil,
           destination_stop_id: String.t(),
-          stopped_at_predicted_stop?: boolean(),
+          stopped?: boolean(),
+          stops_away: integer(),
           boarding_status: String.t() | nil,
           revenue_trip?: boolean(),
           vehicle_id: String.t() | nil

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -47,9 +47,10 @@ defmodule Signs.Utilities.Predictions do
       {if terminal_prediction?(prediction, sources) do
          0
        else
-         if prediction.stopped_at_predicted_stop?,
-           do: 0,
-           else: 1
+         case prediction.stops_away do
+           0 -> 0
+           _ -> 1
+         end
        end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
     |> filter_large_red_line_gaps()

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -17,6 +17,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 0,
         direction_id: 1,
         route_id: "NON-ROUTE",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -33,6 +35,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 0,
         direction_id: 1,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -46,7 +50,8 @@ defmodule Content.Message.PredictionsTest do
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Boarding"
       }
 
@@ -60,6 +65,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 30,
         direction_id: 0,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70275"
       }
 
@@ -73,6 +80,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 31,
         direction_id: 0,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70275"
       }
 
@@ -86,6 +95,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 61,
         direction_id: 0,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70275"
       }
 
@@ -100,6 +111,8 @@ defmodule Content.Message.PredictionsTest do
         arrival_certainty: 360,
         direction_id: 0,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 10,
         destination_stop_id: "70275"
       }
 
@@ -113,6 +126,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 550,
         route_id: "Mattapan",
         direction_id: 0,
+        stopped?: false,
+        stops_away: 3,
         destination_stop_id: "70275"
       }
 
@@ -125,6 +140,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 65,
         direction_id: 1,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -138,6 +155,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 125,
         direction_id: 1,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 2,
         destination_stop_id: "70261"
       }
 
@@ -151,6 +170,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: -5,
         route_id: "Mattapan",
         direction_id: 1,
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -164,7 +185,8 @@ defmodule Content.Message.PredictionsTest do
         route_id: "Mattapan",
         direction_id: 1,
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Boarding"
       }
 
@@ -178,6 +200,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 91,
         route_id: "Mattapan",
         direction_id: 1,
+        stopped?: false,
+        stops_away: 2,
         destination_stop_id: "70261"
       }
 
@@ -191,6 +215,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_arrival: 91,
         route_id: "Mattapan",
         direction_id: 1,
+        stopped?: false,
+        stops_away: 2,
         destination_stop_id: "70261",
         trip_id: "trip1"
       }
@@ -205,7 +231,9 @@ defmodule Content.Message.PredictionsTest do
         stop_id: "70086",
         seconds_until_arrival: 300,
         direction_id: 1,
-        route_id: "Red"
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
       }
 
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
@@ -221,7 +249,9 @@ defmodule Content.Message.PredictionsTest do
         stop_id: "70096",
         seconds_until_arrival: 300,
         direction_id: 1,
-        route_id: "Red"
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
       }
 
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
@@ -237,7 +267,9 @@ defmodule Content.Message.PredictionsTest do
         stop_id: "70096",
         seconds_until_arrival: 360,
         direction_id: 1,
-        route_id: "Red"
+        route_id: "Red",
+        stopped?: false,
+        stops_away: 2
       }
 
       msg = Content.Message.Predictions.non_terminal(prediction, "RJFK", "m", @sign)
@@ -262,7 +294,8 @@ defmodule Content.Message.PredictionsTest do
         direction_id: 1,
         route_id: "NON-ROUTE",
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Boarding"
       }
 
@@ -279,6 +312,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_departure: 0,
         direction_id: 1,
         route_id: "NON-ROUTE",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -290,13 +325,14 @@ defmodule Content.Message.PredictionsTest do
       assert log =~ "no_destination_for_prediction"
     end
 
-    test "puts boarding on the sign when train is supposed to be boarding according to concentrate" do
+    test "puts boarding on the sign when train is supposed to be boarding according to rtr" do
       prediction = %Predictions.Prediction{
         seconds_until_departure: 75,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Stopped at station"
       }
 
@@ -311,7 +347,8 @@ defmodule Content.Message.PredictionsTest do
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Stopped at station"
       }
 
@@ -326,7 +363,8 @@ defmodule Content.Message.PredictionsTest do
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
-        stopped_at_predicted_stop?: true,
+        stopped?: false,
+        stops_away: 0,
         boarding_status: "Stopped at station"
       }
 
@@ -340,6 +378,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_departure: 70,
         direction_id: 1,
         route_id: "Mattapan",
+        stopped?: false,
+        stops_away: 1,
         destination_stop_id: "70261"
       }
 
@@ -354,7 +394,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_departure: 180,
         direction_id: 1,
         route_id: "Orange",
-        stopped_at_predicted_stop?: true
+        stopped?: false,
+        stops_away: 0
       }
 
       msg = Content.Message.Predictions.terminal(prediction, "test", "m", @sign)
@@ -370,6 +411,8 @@ defmodule Content.Message.PredictionsTest do
         seconds_until_departure: 91,
         route_id: "Mattapan",
         direction_id: 1,
+        stopped?: false,
+        stops_away: 2,
         destination_stop_id: "70261",
         trip_id: "trip1"
       }

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -7,32 +7,47 @@ defmodule Predictions.PredictionsTest do
   @feed_message %{
     "entity" => [
       %{
+        "alert" => nil,
         "id" => "1490783458_32568935",
+        "is_deleted" => false,
         "trip_update" => %{
+          "delay" => nil,
           "stop_time_update" => [
             %{
               "arrival" => nil,
               "departure" => nil,
+              "schedule_relationship" => "SKIPPED",
               "stop_id" => "70265",
-              "stop_sequence" => 1
+              "stop_sequence" => 1,
+              "stops_away" => nil,
+              "stopped?" => false,
+              "passthrough_time" => 1_491_570_110
             },
             %{
               "arrival" => nil,
               "departure" => %{
+                "delay" => nil,
                 "time" => 1_491_570_120,
-                "uncertainty" => 60
+                "uncertainty" => nil
               },
+              "schedule_relationship" => "SCHEDULED",
               "stop_id" => "70263",
               "stop_sequence" => 1,
+              "stops_away" => 1,
+              "stopped?" => true,
               "boarding_status" => "Stopped 1 stop away"
             },
             %{
               "arrival" => %{
+                "delay" => nil,
                 "time" => 1_491_570_180,
-                "uncertainty" => 60
+                "uncertainty" => nil
               },
               "departure" => nil,
+              "schedule_relationship" => "SCHEDULED",
               "stop_id" => "70261",
+              "stops_away" => 1,
+              "stopped?" => false,
               "stop_sequence" => 1
             }
           ],
@@ -43,8 +58,7 @@ defmodule Predictions.PredictionsTest do
             "schedule_relationship" => "SCHEDULED",
             "start_date" => "20170329",
             "start_time" => nil,
-            "trip_id" => "32568935",
-            "revenue" => true
+            "trip_id" => "32568935"
           },
           "vehicle" => %{
             "id" => "G-10040",
@@ -69,10 +83,11 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70261",
             seconds_until_arrival: 180,
-            arrival_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
+            stops_away: 1,
+            stopped?: false,
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
@@ -83,12 +98,28 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70263",
             seconds_until_departure: 120,
-            departure_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
             destination_stop_id: "70261",
+            stops_away: 1,
+            stopped?: true,
             boarding_status: "Stopped 1 stop away",
+            trip_id: "32568935",
+            revenue_trip?: true,
+            vehicle_id: "G-10040"
+          }
+        ],
+        {"70265", 0} => [
+          %Predictions.Prediction{
+            stop_id: "70265",
+            seconds_until_passthrough: 110,
+            direction_id: 0,
+            schedule_relationship: :skipped,
+            route_id: "Mattapan",
+            destination_stop_id: "70261",
+            stops_away: nil,
+            stopped?: false,
             trip_id: "32568935",
             revenue_trip?: true,
             vehicle_id: "G-10040"
@@ -113,9 +144,10 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => %{
                     "delay" => nil,
                     "time" => 1_491_570_120,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70263",
                   "stopped?" => false,
                   "stops_away" => 1,
@@ -125,9 +157,10 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => %{
                     "delay" => nil,
                     "time" => 1_491_570_180,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70261",
                   "stopped?" => false,
                   "stops_away" => 1,
@@ -136,6 +169,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => nil,
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70261",
                   "stopped?" => false,
                   "stops_away" => 1,
@@ -149,8 +183,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "G-10040",
@@ -171,9 +204,10 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => %{
                     "delay" => nil,
                     "time" => 1_491_570_200,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70038",
                   "stopped?" => false,
                   "stops_away" => 1,
@@ -183,9 +217,10 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => %{
                     "delay" => nil,
                     "time" => 1_491_570_400,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
+                  "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70060",
                   "stopped?" => false,
                   "stops_away" => 1,
@@ -199,8 +234,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "trip_2",
-                "revenue" => true
+                "trip_id" => "trip_2"
               },
               "vehicle" => %{
                 "id" => "vehicle_2",
@@ -224,8 +258,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "CANCELED",
                 "start_date" => "20190821",
                 "start_time" => nil,
-                "trip_id" => "40826503",
-                "revenue" => true
+                "trip_id" => "40826503"
               },
               "vehicle" => %{
                 "id" => nil,
@@ -248,10 +281,11 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70261",
             seconds_until_arrival: 180,
-            arrival_certainty: 60,
             schedule_relationship: :scheduled,
             direction_id: 0,
             route_id: "Mattapan",
+            stopped?: false,
+            stops_away: 1,
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
@@ -262,10 +296,11 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70263",
             seconds_until_arrival: 120,
-            arrival_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
+            stopped?: false,
+            stops_away: 1,
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
@@ -276,10 +311,11 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70038",
             seconds_until_arrival: 200,
-            arrival_certainty: 60,
             direction_id: 1,
             schedule_relationship: :scheduled,
             route_id: "Blue",
+            stopped?: false,
+            stops_away: 1,
             destination_stop_id: "70060",
             trip_id: "trip_2",
             revenue_trip?: true,
@@ -290,10 +326,11 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70060",
             seconds_until_arrival: 400,
-            arrival_certainty: 60,
             direction_id: 1,
             schedule_relationship: :scheduled,
             route_id: "Blue",
+            stopped?: false,
+            stops_away: 1,
             destination_stop_id: "70060",
             trip_id: "trip_2",
             revenue_trip?: true,
@@ -319,7 +356,7 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => %{
                     "delay" => nil,
                     "time" => Timex.to_unix(@current_time) - 100,
-                    "uncertainty" => 60
+                    "uncertainty" => nil
                   },
                   "departure" => nil,
                   "schedule_relationship" => "SCHEDULED",
@@ -336,8 +373,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "G-10040",
@@ -363,6 +399,8 @@ defmodule Predictions.PredictionsTest do
                     direction_id: 0,
                     schedule_relationship: :scheduled,
                     route_id: "Mattapan",
+                    stopped?: false,
+                    stops_away: 1,
                     destination_stop_id: "70263",
                     trip_id: "32568935",
                     revenue_trip?: true,
@@ -370,6 +408,109 @@ defmodule Predictions.PredictionsTest do
                   }
                 ]
               }, _} = get_all(feed_message, @current_time)
+    end
+
+    test "filters stop_time_updates where stops_away == nil" do
+      feed_message = %{
+        "entity" => [
+          %{
+            "alert" => nil,
+            "id" => "1490783458_32568935",
+            "is_deleted" => false,
+            "trip_update" => %{
+              "delay" => nil,
+              "stop_time_update" => [
+                %{
+                  "arrival" => %{
+                    "delay" => nil,
+                    "time" => Timex.to_unix(@current_time) - 100,
+                    "uncertainty" => nil
+                  },
+                  "departure" => %{
+                    "delay" => nil,
+                    "time" => Timex.to_unix(@current_time) - 100,
+                    "uncertainty" => nil
+                  },
+                  "schedule_relationship" => "SCHEDULED",
+                  "stop_id" => "70262",
+                  "stopped?" => false,
+                  "stops_away" => nil,
+                  "stop_sequence" => 1
+                },
+                %{
+                  "arrival" => nil,
+                  "departure" => %{
+                    "delay" => nil,
+                    "time" => Timex.to_unix(@current_time) - 100,
+                    "uncertainty" => nil
+                  },
+                  "schedule_relationship" => "SCHEDULED",
+                  "stop_id" => "70263",
+                  "stopped?" => false,
+                  "stops_away" => nil,
+                  "stop_sequence" => 1
+                },
+                %{
+                  "arrival" => nil,
+                  "departure" => %{
+                    "delay" => nil,
+                    "time" => Timex.to_unix(@current_time) + 100,
+                    "uncertainty" => nil
+                  },
+                  "schedule_relationship" => "SCHEDULED",
+                  "stop_id" => "70264",
+                  "stopped?" => false,
+                  "stops_away" => 1,
+                  "stop_sequence" => 2
+                }
+              ],
+              "timestamp" => nil,
+              "trip" => %{
+                "direction_id" => 0,
+                "route_id" => "Mattapan",
+                "schedule_relationship" => "SCHEDULED",
+                "start_date" => "20170329",
+                "start_time" => nil,
+                "trip_id" => "32568935"
+              },
+              "vehicle" => %{
+                "id" => "G-10040",
+                "label" => "3260",
+                "license_plate" => nil
+              }
+            },
+            "vehicle" => nil
+          }
+        ],
+        "header" => %{
+          "gtfs_realtime_version" => "1.0",
+          "incrementality" => "FULL_DATASET",
+          "timestamp" => 1_490_783_458
+        }
+      }
+
+      {predictions_map, _} = get_all(feed_message, @current_time)
+
+      assert predictions_map == %{
+               {"70264", 0} => [
+                 %Predictions.Prediction{
+                   boarding_status: nil,
+                   destination_stop_id: "70262",
+                   direction_id: 0,
+                   revenue_trip?: true,
+                   route_id: "Mattapan",
+                   schedule_relationship: :scheduled,
+                   seconds_until_arrival: nil,
+                   seconds_until_departure: 100,
+                   seconds_until_passthrough: nil,
+                   stop_id: "70264",
+                   stopped?: false,
+                   stops_away: 1,
+                   trip_id: "32568935",
+                   vehicle_id: "G-10040"
+                 }
+               ]
+             }
     end
 
     test "include predictions with low uncertainty" do
@@ -406,8 +547,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "R-54639F6C",
@@ -472,8 +612,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "R-54639F6C",
@@ -534,8 +673,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "R-54639F6C",
@@ -601,8 +739,7 @@ defmodule Predictions.PredictionsTest do
                 "schedule_relationship" => "SCHEDULED",
                 "start_date" => "20170329",
                 "start_time" => nil,
-                "trip_id" => "32568935",
-                "revenue" => true
+                "trip_id" => "32568935"
               },
               "vehicle" => %{
                 "id" => "G-10040",

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -481,8 +481,8 @@ defmodule Signs.RealtimeTest do
     test "only the first prediction in a source list can be BRD" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
-          prediction(destination: :mattapan, arrival: 0, stopped: 0, trip_id: "1"),
-          prediction(destination: :mattapan, arrival: 100)
+          prediction(destination: :mattapan, arrival: 0, stops_away: 0, trip_id: "1"),
+          prediction(destination: :mattapan, arrival: 100, stops_away: 1)
         ]
       end)
 
@@ -502,7 +502,7 @@ defmodule Signs.RealtimeTest do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
           prediction(destination: :boston_college, arrival: 200),
-          prediction(destination: :cleveland_circle, arrival: 250, stopped: 0)
+          prediction(destination: :cleveland_circle, arrival: 250, stops_away: 0)
         ]
       end)
 
@@ -608,21 +608,21 @@ defmodule Signs.RealtimeTest do
         [
           prediction(
             destination: :riverside,
-            stopped: 0,
+            stops_away: 0,
             seconds_until_arrival: -30,
             seconds_until_departure: 60,
             trip_id: "1"
           ),
           prediction(
             destination: :riverside,
-            stopped: 0,
+            stops_away: 0,
             seconds_until_arrival: -15,
             seconds_until_departure: 75,
             trip_id: "2"
           ),
           prediction(
             destination: :boston_college,
-            stopped: 0,
+            stops_away: 0,
             seconds_until_arrival: nil,
             seconds_until_departure: 60,
             trip_id: "3"
@@ -678,7 +678,7 @@ defmodule Signs.RealtimeTest do
 
     test "reads special boarding button announcement at Bowdoin" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(arrival: 0, destination: :wonderland, stopped: 0)]
+        [prediction(arrival: 0, destination: :wonderland, stops_away: 0)]
       end)
 
       expect_audios(
@@ -1053,7 +1053,7 @@ defmodule Signs.RealtimeTest do
       # special case.
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
-          prediction(destination: :ashmont, arrival: 0, stopped: 0, trip_id: "1"),
+          prediction(destination: :ashmont, arrival: 0, stops_away: 0, trip_id: "1"),
           prediction(destination: :braintree, arrival: 45, trip_id: "2")
         ]
       end)
@@ -1907,14 +1907,8 @@ defmodule Signs.RealtimeTest do
     opts =
       opts ++
         case Keyword.get(opts, :stopped) do
-          nil ->
-            []
-
-          0 ->
-            [stopped_at_predicted_stop: true]
-
-          stops ->
-            [stopped_at_predicted_stop: false, boarding_status: "Stopped #{stops} stop away"]
+          nil -> []
+          stops -> [stops_away: stops, boarding_status: "Stopped #{stops} stop away"]
         end
 
     %Predictions.Prediction{
@@ -1929,7 +1923,8 @@ defmodule Signs.RealtimeTest do
       route_id: Keyword.get(opts, :route_id),
       trip_id: Keyword.get(opts, :trip_id, "123"),
       destination_stop_id: Keyword.get(opts, :destination_stop_id),
-      stopped_at_predicted_stop?: Keyword.get(opts, :stopped_at_predicted_stop, false),
+      stopped?: false,
+      stops_away: Keyword.get(opts, :stops_away, 1),
       boarding_status: Keyword.get(opts, :boarding_status),
       revenue_trip?: true,
       vehicle_id: "v1"


### PR DESCRIPTION
Reverts mbta/realtime_signs#743

Unfortunately after deploying this migration last week, we started seeing some erroneous changes in predictions particularly with `BRD` predictions at terminals and passthrough announcements.

We should revert the migration for now to reduce the rider impact and to give us some space to do a deeper investigation into what could be causing the discrepancies in predictions when consuming the concentrate feeds vs the RTR feeds.