### PR TITLE
chore: update lab sign definitions

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1,14 +1,14 @@
 [
   {
-    "id": "lab_test",
+    "id": "lab_test_1",
     "type": "realtime",
     "pa_ess_loc": "201",
     "scu_id": "TBR01",
     "default_mode": "auto",
     "read_loop_offset": 120,
-    "text_zone": "m",
+    "text_zone": "n",
     "audio_zones": [
-      "m"
+      "n"
     ],
     "source_config": [
       {
@@ -46,6 +46,35 @@
         ]
       }
     ]
+  },
+  {
+    "id": "lab_test_2",
+    "type": "realtime",
+    "pa_ess_loc": "201",
+    "scu_id": "TBR01",
+    "default_mode": "auto",
+    "read_loop_offset": 30,
+    "text_zone": "s",
+    "audio_zones": [
+      "s"
+    ],
+    "source_config": {
+      "headway_group": "blue_trunk",
+      "headway_direction_name": "Wonderland",
+      "sources": [
+        {
+          "stop_id": "70042",
+          "routes": [
+            "Blue"
+          ],
+          "direction_id": 1,
+          "platform": null,
+          "terminal": false,
+          "announce_arriving": true,
+          "announce_boarding": false
+        }
+      ]
+    }
   },
   {
     "id": "cedar_grove_outbound",


### PR DESCRIPTION
The zone code that was actually set up for this sign turned out to be `n` rather than `m`. The second daisy-chained sign is also separately addressable as zone `s`, so we add a configuration for it too.

* `n` is a copy of `state_blue_mezzanine`
* `s` is a copy of `state_blue_eastbound`

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on Codecov)~~
- [ ] `signs.json` changes were also made in [signs_ui](https://github.com/mbta/signs_ui/blob/master/priv/signs.json)
  - **Note:** I don't think these particular changes should actually be mirrored in Signs UI, since we don't want these signs to show up there.
- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207993019127452