### PR TITLE
chore: correct lab sign location IDs

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -2,8 +2,8 @@
   {
     "id": "lab_test_1",
     "type": "realtime",
-    "pa_ess_loc": "201",
-    "scu_id": "TBR01",
+    "pa_ess_loc": "TBR01",
+    "scu_id": "TBR01SCU001",
     "default_mode": "auto",
     "read_loop_offset": 120,
     "text_zone": "n",
@@ -50,8 +50,8 @@
   {
     "id": "lab_test_2",
     "type": "realtime",
-    "pa_ess_loc": "201",
-    "scu_id": "TBR01",
+    "pa_ess_loc": "TBR01",
+    "scu_id": "TBR01SCU001",
     "default_mode": "auto",
     "read_loop_offset": 30,
     "text_zone": "s",


### PR DESCRIPTION
The SCU IDs here are a guess based on the apparent pattern for real signs. This value seems to only be used when an SCU has been migrated to the new system, so in any case we shouldn't need it yet.

[Relevant Slack thread](https://mbta.slack.com/archives/C039ARUM48H/p1724170794694359).

#### Reviewer Checklist

- [ ] ~~Meets ticket's acceptance criteria~~
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on Codecov)~~
- [ ] ~~`signs.json` changes were also made in [signs_ui](https://github.com/mbta/signs_ui/blob/master/priv/signs.json)~~
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
