### PR TITLE
fix: use strings for stop and route ids

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -9699,8 +9699,8 @@
       {
         "sources": [
           {
-            "stop_id": 76121,
-            "route_id": 77,
+            "stop_id": "76121",
+            "route_id": "77",
             "direction_id": 0
           }
         ]
@@ -9708,8 +9708,8 @@
       {
         "sources": [
           {
-            "stop_id": 76122,
-            "route_id": 96,
+            "stop_id": "76122",
+            "route_id": "96",
             "direction_id": 0
           }
         ]
@@ -9717,8 +9717,8 @@
       {
         "sources": [
           {
-            "stop_id": 76123,
-            "route_id": 66,
+            "stop_id": "76123",
+            "route_id": "66",
             "direction_id": 0
           }
         ]
@@ -9726,8 +9726,8 @@
       {
         "sources": [
           {
-            "stop_id": 76123,
-            "route_id": 71,
+            "stop_id": "76123",
+            "route_id": "71",
             "direction_id": 0
           }
         ]
@@ -9735,8 +9735,8 @@
       {
         "sources": [
           {
-            "stop_id": 76123,
-            "route_id": 73,
+            "stop_id": "76123",
+            "route_id": "73",
             "direction_id": 0
           }
         ]
@@ -9744,8 +9744,8 @@
       {
         "sources": [
           {
-            "stop_id": 76124,
-            "route_id": 74,
+            "stop_id": "76124",
+            "route_id": "74",
             "direction_id": 0
           }
         ]
@@ -9753,8 +9753,8 @@
       {
         "sources": [
           {
-            "stop_id": 76124,
-            "route_id": 78,
+            "stop_id": "76124",
+            "route_id": "78",
             "direction_id": 0
           }
         ]
@@ -9762,8 +9762,8 @@
       {
         "sources": [
           {
-            "stop_id": 76125,
-            "route_id": 75,
+            "stop_id": "76125",
+            "route_id": "75",
             "direction_id": 0
           }
         ]


### PR DESCRIPTION
![Capture 2024-08-28 at 10 11 53@2x](https://github.com/user-attachments/assets/d7a93863-fb85-417c-bf68-ea4428dc0627)

#### Reviewer Checklist

- [x] `signs.json` changes were also made in [signs_ui](https://github.com/mbta/signs_ui/blob/master/priv/signs.json)
    - https://github.com/mbta/signs_ui/pull/1403
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
