### PR TITLE
streamline message logging

### DIFF
--- a/lib/content/audio.ex
+++ b/lib/content/audio.ex
@@ -22,4 +22,6 @@ defprotocol Content.Audio do
   def to_params(audio)
   @spec to_tts(Content.Audio.t()) :: tts_value()
   def to_tts(audio)
+  @spec to_logs(Content.Audio.t()) :: keyword()
+  def to_logs(audio)
 end

--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -86,6 +86,10 @@ defmodule Content.Audio.Approaching do
       {text, PaEss.Utilities.paginate_text(text)}
     end
 
+    def to_logs(%Content.Audio.Approaching{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.Approaching{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)

--- a/lib/content/audio/boarding_button.ex
+++ b/lib/content/audio/boarding_button.ex
@@ -15,5 +15,9 @@ defmodule Content.Audio.BoardingButton do
 
       {text, PaEss.Utilities.paginate_text(text)}
     end
+
+    def to_logs(%Content.Audio.BoardingButton{}) do
+      []
+    end
   end
 end

--- a/lib/content/audio/closure.ex
+++ b/lib/content/audio/closure.ex
@@ -61,6 +61,10 @@ defmodule Content.Audio.Closure do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.Closure{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.Closure{} = audio) do
       if audio.alert == :use_routes_alert do
         # Hardcoded for Union Square

--- a/lib/content/audio/custom.ex
+++ b/lib/content/audio/custom.ex
@@ -41,5 +41,9 @@ defmodule Content.Audio.Custom do
     def to_tts(%Content.Audio.Custom{} = audio) do
       {audio.message, nil}
     end
+
+    def to_logs(%Content.Audio.Custom{}) do
+      []
+    end
   end
 end

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -60,5 +60,9 @@ defmodule Content.Audio.FirstTrainScheduled do
       time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
       {"The first #{train} is scheduled to arrive at #{time}", nil}
     end
+
+    def to_logs(%Content.Audio.FirstTrainScheduled{}) do
+      []
+    end
   end
 end

--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -86,6 +86,10 @@ defmodule Content.Audio.FollowingTrain do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.FollowingTrain{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.FollowingTrain{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       arrives_or_departs = if audio.verb == :arrives, do: "arrives", else: "departs"

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -97,6 +97,10 @@ defmodule Content.Audio.NextTrainCountdown do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.NextTrainCountdown{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.NextTrainCountdown{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       arrives_or_departs = if audio.verb == :arrives, do: "arrives", else: "departs"

--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -30,6 +30,10 @@ defmodule Content.Audio.NoServiceToDestination do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.NoServiceToDestination{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.NoServiceToDestination{} = audio) do
       {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(audio.destination)
       shuttle = if(audio.use_shuttle, do: " Use shuttle.", else: "")

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -35,6 +35,10 @@ defmodule Content.Audio.Passthrough do
       {text, PaEss.Utilities.paginate_text(text)}
     end
 
+    def to_logs(%Content.Audio.Passthrough{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.Passthrough{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
       "The next #{train} does not take customers. Please stand back from the yellow line."

--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -64,6 +64,10 @@ defmodule Content.Audio.ServiceEnded do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.ServiceEnded{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.ServiceEnded{location: :station, routes: routes}) do
       line = Utilities.get_line_from_routes_list(routes) |> String.capitalize()
       "#{line} service has ended for the night."

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -68,6 +68,10 @@ defmodule Content.Audio.StoppedTrain do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.StoppedTrain{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.StoppedTrain{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       stop_or_stops = if audio.stops_away == 1, do: "stop", else: "stops"

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -86,6 +86,10 @@ defmodule Content.Audio.TrackChange do
       {text, PaEss.Utilities.paginate_text(text)}
     end
 
+    def to_logs(%Content.Audio.TrackChange{}) do
+      []
+    end
+
     defp track_change_message(msg_id) do
       vars = [@track_change, msg_id]
       PaEss.Utilities.take_message(vars, :audio_visual)

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -54,6 +54,10 @@ defmodule Content.Audio.TrainIsArriving do
       {text, PaEss.Utilities.paginate_text(text)}
     end
 
+    def to_logs(%Content.Audio.TrainIsArriving{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.TrainIsArriving{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -68,6 +68,10 @@ defmodule Content.Audio.TrainIsBoarding do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.TrainIsBoarding{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.TrainIsBoarding{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
       track = if(audio.track_number, do: " on track #{audio.track_number}", else: ".")

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -63,6 +63,10 @@ defmodule Content.Audio.VehiclesToDestination do
       {tts_text(audio), nil}
     end
 
+    def to_logs(%Content.Audio.VehiclesToDestination{}) do
+      []
+    end
+
     defp tts_text(%Content.Audio.VehiclesToDestination{
            headway_range: {range_low, range_high},
            destination: destination,

--- a/lib/pa_messages/pa_message.ex
+++ b/lib/pa_messages/pa_message.ex
@@ -23,5 +23,9 @@ defmodule PaMessages.PaMessage do
     def to_tts(%PaMessages.PaMessage{visual_text: visual_text, audio_text: audio_text}) do
       {audio_text, PaEss.Utilities.paginate_text(visual_text)}
     end
+
+    def to_logs(%PaMessages.PaMessage{id: id, priority: priority, interval_in_ms: interval_in_ms}) do
+      [pa_message_id: id, pa_message_priority: priority, pa_message_interval: interval_in_ms]
+    end
   end
 end

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -132,16 +132,7 @@ defmodule Signs.Bus do
 
   @impl true
   def handle_info({:play_pa_message, pa_message}, sign) do
-    pa_message_plays =
-      Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign, fn ->
-        send_audio(
-          [Content.Audio.to_params(pa_message)],
-          [Content.Audio.to_tts(pa_message)],
-          sign
-        )
-      end)
-
-    {:noreply, %{sign | pa_message_plays: pa_message_plays}}
+    {:noreply, Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)}
   end
 
   @impl true

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -137,12 +137,7 @@ defmodule Signs.Realtime do
   end
 
   def handle_info({:play_pa_message, pa_message}, sign) do
-    pa_message_plays =
-      Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign, fn ->
-        Signs.Utilities.Audio.send_audio(sign, [pa_message])
-      end)
-
-    {:noreply, %{sign | pa_message_plays: pa_message_plays}}
+    {:noreply, Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)}
   end
 
   def handle_info(:run_loop, sign) do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Improve RTS and SCU message logging](https://app.asana.com/0/1185117109217413/1208067121004443/f)

* Switches to explicit logging of extra message metadata, instead of dumping the raw struct. This effectively removes a lot of fields that were initially intended for debugging, but now that we're including visual and audio strings with every message, most of them should be unnecessary. This approach will let us add additional metadata easily, if desired.
* Keeps the PA message metadata needed for the playback dashboard, but renames them `pa_message_id`, `pa_message_priority`, and `pa_message_interval` to avoid confusion
* Unifies the PA message playback code, for simplicity and to allow bus sign logs to inherit the same rich log output.