### PR TITLE
Don't deploy to dev-green on push to main

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -1,9 +1,6 @@
 name: Deploy to Dev Green
 
-on:
-  workflow_dispatch:
-  push:
-    branches: [main]
+on: workflow_dispatch
 
 jobs:
   deploy:


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] remove auto-deploy for RTS dev-green](https://app.asana.com/0/1185117109217413/1208381515035004/f)

Automatic deploys to dev-green upon pushing to main can cause unintentional hindrances when using dev-green to test branches. This change to the workflow makes it so that we can only manually deploy to dev-green.
