### PR TITLE
log trip_id for passthrough audios

### DIFF
--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -35,8 +35,9 @@ defmodule Content.Audio.Passthrough do
       {text, PaEss.Utilities.paginate_text(text)}
     end
 
-    def to_logs(%Content.Audio.Passthrough{}) do
-      []
+    def to_logs(%Content.Audio.Passthrough{trip_id: trip_id}) do
+      # trip_id for debugging RTR/Contentrate differences
+      [trip_id: trip_id]
     end
 
     defp tts_text(%Content.Audio.Passthrough{} = audio) do


### PR DESCRIPTION
#### Summary of changes

This restores the trip_id logs for passthrough audios, for the purpose of debugging RTS/Concentrate data.