### PR TITLE
simplify headway message code

### DIFF
--- a/lib/content/message/headways/top.ex
+++ b/lib/content/message/headways/top.ex
@@ -1,68 +1,26 @@
 defmodule Content.Message.Headways.Top do
-  require Logger
-  defstruct [:destination, :vehicle_type, :routes]
+  defstruct [:destination, :routes]
 
-  @type vehicle_type :: :bus | :trolley | :train
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
-          vehicle_type: vehicle_type,
           routes: [String.t()] | nil
         }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.Headways.Top{
-          vehicle_type: type,
-          routes: routes
-        })
-        when not is_nil(routes) do
-      case routes do
-        ["Mattapan"] ->
-          "Mattapan #{signify_vehicle_type(type)}"
-
-        [route] ->
-          "#{route} line #{signify_vehicle_type(type)}"
-
-        _ ->
-          Content.Message.to_string(%Content.Message.Headways.Top{
-            destination: nil,
-            vehicle_type: :train
-          })
-      end
+    def to_string(%Content.Message.Headways.Top{destination: nil, routes: ["Mattapan"]}) do
+      "Mattapan trains"
     end
 
-    def to_string(%Content.Message.Headways.Top{
-          destination: nil,
-          vehicle_type: type
-        }) do
-      type |> signify_vehicle_type |> String.capitalize()
+    def to_string(%Content.Message.Headways.Top{destination: nil, routes: [route]}) do
+      "#{route} line trains"
     end
 
-    def to_string(%Content.Message.Headways.Top{
-          destination: destination,
-          vehicle_type: type
-        })
-        when type in [:bus] do
-      "#{type |> signify_vehicle_type() |> String.capitalize()} to #{PaEss.Utilities.destination_to_sign_string(destination)}"
+    def to_string(%Content.Message.Headways.Top{destination: nil}) do
+      "Trains"
     end
 
-    def to_string(%Content.Message.Headways.Top{
-          destination: destination,
-          vehicle_type: type
-        }) do
-      "#{PaEss.Utilities.destination_to_sign_string(destination)} #{signify_vehicle_type(type)}"
-    end
-
-    @spec signify_vehicle_type(Content.Message.Headways.Top.vehicle_type()) :: String.t()
-    defp signify_vehicle_type(:train) do
-      "trains"
-    end
-
-    defp signify_vehicle_type(:bus) do
-      "buses"
-    end
-
-    defp signify_vehicle_type(:trolley) do
-      "trolleys"
+    def to_string(%Content.Message.Headways.Top{destination: destination}) do
+      "#{PaEss.Utilities.destination_to_sign_string(destination)} trains"
     end
   end
 end

--- a/lib/signs/utilities/early_am_suppression.ex
+++ b/lib/signs/utilities/early_am_suppression.ex
@@ -103,7 +103,7 @@ defmodule Signs.Utilities.EarlyAmSuppression do
               |> PaEss.Utilities.get_unique_routes()
 
             {t1, t2} = top_content
-            {%{t1 | routes: routes}, t2}
+            {%{t1 | routes: routes, destination: nil}, t2}
 
           true ->
             paginate(top_content, bottom_content)
@@ -163,8 +163,7 @@ defmodule Signs.Utilities.EarlyAmSuppression do
         |> case do
           # If line has status :none, then it could be a paging headway message
           {%Headways.Paging{destination: destination, range: range}, _} ->
-            {%Headways.Top{destination: destination, vehicle_type: :train},
-             %Headways.Bottom{range: range}}
+            {%Headways.Top{destination: destination}, %Headways.Bottom{range: range}}
 
           # If we get one half of a headway message, it means the mz sign was showing headways in the original content generation
           # but that one or the other mz lines has an early am status of :none.

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -23,14 +23,13 @@ defmodule Signs.Utilities.Headways do
           {%Content.Message.Headways.Top{
              routes:
                SourceConfig.sign_routes(sign.source_config)
-               |> PaEss.Utilities.get_unique_routes(),
-             vehicle_type: :train
+               |> PaEss.Utilities.get_unique_routes()
            },
            %Content.Message.Headways.Bottom{
              range: {headways.range_low, headways.range_high}
            }}
         else
-          {%Content.Message.Headways.Top{destination: destination, vehicle_type: :train},
+          {%Content.Message.Headways.Top{destination: destination},
            %Content.Message.Headways.Bottom{
              range: {headways.range_low, headways.range_high}
            }}

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -148,10 +148,7 @@ defmodule Signs.Utilities.Messages do
            messages: [
              # Make zone nil in order to prevent the usual paging platform message
              %{prediction | zone: nil},
-             %Content.Message.Headways.Top{
-               destination: destination,
-               vehicle_type: :train
-             }
+             %Content.Message.Headways.Top{destination: destination}
            ]
          },
          %Content.Message.GenericPaging{

--- a/test/content/audio/vehicles_to_destination_test.exs
+++ b/test/content/audio/vehicles_to_destination_test.exs
@@ -161,7 +161,7 @@ defmodule Content.Audio.VehiclesToDestinationTest do
                }
              ] =
                from_headway_message(
-                 %Content.Message.Headways.Top{destination: nil, vehicle_type: :train},
+                 %Content.Message.Headways.Top{destination: nil},
                  %Content.Message.Headways.Bottom{range: {8, 10}}
                )
     end

--- a/test/content/messages/headways/top_test.exs
+++ b/test/content/messages/headways/top_test.exs
@@ -2,54 +2,30 @@ defmodule Content.Message.Headways.TopTest do
   use ExUnit.Case, async: true
 
   describe "to_string/1" do
-    test "when the message has a headsign and a vehicle type, displays a top line message" do
+    test "works" do
       assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :mattapan,
-               vehicle_type: :bus
-             }) == "Buses to Mattapan"
-    end
+               destination: :alewife,
+               routes: ["Red"]
+             }) ==
+               "Alewife trains"
 
-    test "correctly makes a message for trolleys" do
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :mattapan,
-               vehicle_type: :trolley
-             }) == "Mattapan trolleys"
-    end
-
-    test "Shows directionbound headsigns in a way that makes sense in english" do
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :northbound,
-               vehicle_type: :trolley
-             }) == "Northbound trolleys"
-
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :southbound,
-               vehicle_type: :trolley
-             }) == "Southbound trolleys"
-
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :eastbound,
-               vehicle_type: :trolley
-             }) == "Eastbound trolleys"
-
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :westbound,
-               vehicle_type: :trolley
-             }) == "Westbound trolleys"
-    end
-
-    test "Forest Hills trains are displayed as Frst Hills trains" do
-      assert Content.Message.to_string(%Content.Message.Headways.Top{
-               destination: :forest_hills,
-               vehicle_type: :train
-             }) == "Frst Hills trains"
-    end
-
-    test "Shows the right message when no destination" do
       assert Content.Message.to_string(%Content.Message.Headways.Top{
                destination: nil,
-               vehicle_type: :train
-             }) == "Trains"
+               routes: ["Mattapan"]
+             }) ==
+               "Mattapan trains"
+
+      assert Content.Message.to_string(%Content.Message.Headways.Top{
+               destination: nil,
+               routes: ["Red"]
+             }) ==
+               "Red line trains"
+
+      assert Content.Message.to_string(%Content.Message.Headways.Top{
+               destination: nil,
+               routes: ["Red", "Green"]
+             }) ==
+               "Trains"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

This is a small refactor in advance of a larger one. It cleans up some unused abstraction around vehicle types in the headway message code, since we only ever generate messages about trains. Also flips the display logic around so the `destination` field controls which primary code path is used, rather than `routes`. This should result in no user-facing changes.

Note: Regarding the recent discussion about adding SL headways, the bus logic doesn't use this code, so that doesn't impact the decision to clean up this code.