### PR TITLE
pass single route through messages

### DIFF
--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -1,17 +1,17 @@
 defmodule Content.Audio.ServiceEnded do
   alias PaEss.Utilities
   @enforce_keys [:location]
-  defstruct @enforce_keys ++ [:destination, :routes]
+  defstruct @enforce_keys ++ [:destination, :route]
 
   @type location :: :platform | :station | :direction
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
-          routes: [String.t()] | nil,
+          route: String.t() | nil,
           location: location()
         }
 
-  def from_message(%Content.Message.LastTrip.StationClosed{routes: routes}) do
-    [%__MODULE__{location: :station, routes: routes}]
+  def from_message(%Content.Message.LastTrip.StationClosed{route: route}) do
+    [%__MODULE__{location: :station, route: route}]
   end
 
   def from_message(%Content.Message.LastTrip.PlatformClosed{destination: destination}) do
@@ -27,12 +27,8 @@ defmodule Content.Audio.ServiceEnded do
     # @station_closed "883"
     @platform_closed "884"
 
-    def to_params(%Content.Audio.ServiceEnded{location: :station, routes: routes}) do
-      line_var =
-        routes
-        |> Utilities.get_line_from_routes_list()
-        |> Utilities.line_to_var()
-
+    def to_params(%Content.Audio.ServiceEnded{location: :station, route: route}) do
+      line_var = Utilities.line_to_var(route)
       Utilities.take_message([line_var, @service_ended], :audio)
     end
 
@@ -68,8 +64,8 @@ defmodule Content.Audio.ServiceEnded do
       []
     end
 
-    defp tts_text(%Content.Audio.ServiceEnded{location: :station, routes: routes}) do
-      line = Utilities.get_line_from_routes_list(routes) |> String.capitalize()
+    defp tts_text(%Content.Audio.ServiceEnded{location: :station, route: route}) do
+      line = if(route, do: "#{route} line", else: "Train")
       "#{line} service has ended for the night."
     end
 

--- a/lib/content/message/alert/destination_no_service.ex
+++ b/lib/content/message/alert/destination_no_service.ex
@@ -4,9 +4,12 @@ defmodule Content.Message.Alert.DestinationNoService do
   """
 
   @enforce_keys [:destination]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:route]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          destination: PaEss.destination(),
+          route: String.t() | nil
+        }
 
   defimpl Content.Message do
     @default_page_width 24

--- a/lib/content/message/alert/no_service.ex
+++ b/lib/content/message/alert/no_service.ex
@@ -3,18 +3,15 @@ defmodule Content.Message.Alert.NoService do
   A message displayed when a station is closed due to shuttles or a suspension
   """
 
-  defstruct routes: []
+  defstruct [:route]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          route: String.t() | nil
+        }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.Alert.NoService{routes: routes}) do
-      service =
-        case PaEss.Utilities.get_line_from_routes_list(routes) do
-          "train" -> "train service"
-          line -> line
-        end
-
+    def to_string(%Content.Message.Alert.NoService{route: route}) do
+      service = if(route, do: "#{route} Line", else: "train service")
       "No #{service}"
     end
   end

--- a/lib/content/message/alert/no_service_use_shuttle.ex
+++ b/lib/content/message/alert/no_service_use_shuttle.ex
@@ -4,10 +4,11 @@ defmodule Content.Message.Alert.NoServiceUseShuttle do
   """
 
   @enforce_keys [:destination]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:route]
 
   @type t :: %__MODULE__{
-          destination: PaEss.destination()
+          destination: PaEss.destination(),
+          route: String.t() | nil
         }
 
   defimpl Content.Message do

--- a/lib/content/message/headways/paging.ex
+++ b/lib/content/message/headways/paging.ex
@@ -1,9 +1,11 @@
 defmodule Content.Message.Headways.Paging do
-  defstruct [:destination, :range]
+  @enforce_keys [:destination, :range]
+  defstruct @enforce_keys ++ [:route]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
-          range: {non_neg_integer(), non_neg_integer()}
+          range: {non_neg_integer(), non_neg_integer()},
+          route: String.t() | nil
         }
 
   defimpl Content.Message do

--- a/lib/content/message/headways/top.ex
+++ b/lib/content/message/headways/top.ex
@@ -1,22 +1,22 @@
 defmodule Content.Message.Headways.Top do
-  defstruct [:destination, :routes]
+  defstruct [:destination, :route]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination() | nil,
-          routes: [String.t()] | nil
+          route: String.t() | nil
         }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.Headways.Top{destination: nil, routes: ["Mattapan"]}) do
+    def to_string(%Content.Message.Headways.Top{destination: nil, route: nil}) do
+      "Trains"
+    end
+
+    def to_string(%Content.Message.Headways.Top{destination: nil, route: "Mattapan"}) do
       "Mattapan trains"
     end
 
-    def to_string(%Content.Message.Headways.Top{destination: nil, routes: [route]}) do
+    def to_string(%Content.Message.Headways.Top{destination: nil, route: route}) do
       "#{route} line trains"
-    end
-
-    def to_string(%Content.Message.Headways.Top{destination: nil}) do
-      "Trains"
     end
 
     def to_string(%Content.Message.Headways.Top{destination: destination}) do

--- a/lib/content/message/last_trip/no_service.ex
+++ b/lib/content/message/last_trip/no_service.ex
@@ -1,9 +1,10 @@
 defmodule Content.Message.LastTrip.NoService do
   @enforce_keys [:destination, :line]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:route]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
+          route: String.t() | nil,
           line: :top | :bottom
         }
 

--- a/lib/content/message/last_trip/station_closed.ex
+++ b/lib/content/message/last_trip/station_closed.ex
@@ -3,16 +3,13 @@ defmodule Content.Message.LastTrip.StationClosed do
   A message displayed when a station is closed
   """
   @enforce_keys []
-  defstruct @enforce_keys ++ [routes: []]
+  defstruct @enforce_keys ++ [:route]
 
   @type t :: %__MODULE__{}
 
   defimpl Content.Message do
-    def to_string(%Content.Message.LastTrip.StationClosed{routes: routes}) do
-      case PaEss.Utilities.get_line_from_routes_list(routes) do
-        "train" -> "Station closed"
-        line -> "No #{line}"
-      end
+    def to_string(%Content.Message.LastTrip.StationClosed{route: route}) do
+      if(route, do: "No #{route} Line", else: "Station closed")
     end
   end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -307,32 +307,12 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:medford_tufts), do: {:ok, "Medford/Tufts"}
   def destination_to_ad_hoc_string(_unknown), do: {:error, :unknown}
 
-  def line_to_var("Red Line"), do: "3005"
-  def line_to_var("Orange Line"), do: "3006"
-  def line_to_var("Blue Line"), do: "3007"
-  def line_to_var("Green Line"), do: "3008"
-  def line_to_var("Mattapan Line"), do: "3009"
+  def line_to_var("Red"), do: "3005"
+  def line_to_var("Orange"), do: "3006"
+  def line_to_var("Blue"), do: "3007"
+  def line_to_var("Green"), do: "3008"
+  def line_to_var("Mattapan"), do: "3009"
   def line_to_var(_), do: "864"
-
-  def get_unique_routes(routes) do
-    routes
-    |> Enum.map(fn route -> route |> String.split("-") |> List.first() end)
-    |> Enum.uniq()
-  end
-
-  def get_line_from_routes_list(routes) do
-    case get_unique_routes(routes) do
-      [route] ->
-        "#{route} Line"
-
-      _ ->
-        # Currently, the only case where there would be two fully distinct
-        # routes (disregarding GL Branches) is the Ashmont Mezzanine.
-        # Even in the Ashmont Mezzanine case though, we would page the Mattapan-specific
-        # shuttle alert on the second line and show Red line predictions on top.
-        "train"
-    end
-  end
 
   def directional_destination?(destination),
     do: destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound]

--- a/lib/signs/utilities/early_am_suppression.ex
+++ b/lib/signs/utilities/early_am_suppression.ex
@@ -98,12 +98,9 @@ defmodule Signs.Utilities.EarlyAmSuppression do
             {top, bottom}
 
           match?({{%Headways.Top{}, _}, {%Headways.Top{}, _}}, {top_content, bottom_content}) ->
-            routes =
-              Signs.Utilities.SourceConfig.sign_routes(sign.source_config)
-              |> PaEss.Utilities.get_unique_routes()
-
+            route = Signs.Utilities.SourceConfig.single_route(sign.source_config)
             {t1, t2} = top_content
-            {%{t1 | routes: routes, destination: nil}, t2}
+            {%{t1 | route: route, destination: nil}, t2}
 
           true ->
             paginate(top_content, bottom_content)
@@ -213,8 +210,8 @@ defmodule Signs.Utilities.EarlyAmSuppression do
               {headway_top, %Headways.Bottom{range: {_, high}} = headway_bottom} ->
                 # Check against schedule to account for mezzanine sources having different first scheduled arrivals
                 if DateTime.add(current_time, high, :minute) |> DateTime.compare(scheduled) == :gt do
-                  # Make sure routes is nil so that destination is used as headsign
-                  {%{headway_top | destination: destination, routes: nil}, headway_bottom}
+                  # Make sure route is nil so that destination is used as headsign
+                  {%{headway_top | destination: destination, route: nil}, headway_bottom}
                 else
                   {%EarlyAm.DestinationTrain{
                      destination: destination

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -20,11 +20,7 @@ defmodule Signs.Utilities.Headways do
 
       headways ->
         if Signs.Utilities.SourceConfig.multi_source?(sign.source_config) do
-          {%Content.Message.Headways.Top{
-             routes:
-               SourceConfig.sign_routes(sign.source_config)
-               |> PaEss.Utilities.get_unique_routes()
-           },
+          {%Content.Message.Headways.Top{route: SourceConfig.single_route(sign.source_config)},
            %Content.Message.Headways.Bottom{
              range: {headways.range_low, headways.range_high}
            }}

--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -12,7 +12,7 @@ defmodule Signs.Utilities.LastTrip do
         {unpacked_mz_top, unpacked_mz_bottom} = unpack_mezzanine_content(messages, source)
         {top_source_config, bottom_source_config} = source
 
-        routes = Signs.Utilities.SourceConfig.sign_routes(source)
+        route = Signs.Utilities.SourceConfig.single_route(source)
 
         cond do
           # If combined alert status, only switch to Last Trip messaging once service has fully ended.
@@ -21,14 +21,14 @@ defmodule Signs.Utilities.LastTrip do
           match?(%Message.Alert.NoService{}, unpacked_mz_top) ->
             if has_top_service_ended? and has_bottom_service_ended?,
               do:
-                {%Content.Message.LastTrip.StationClosed{routes: routes},
+                {%Content.Message.LastTrip.StationClosed{route: route},
                  %Content.Message.LastTrip.ServiceEnded{}},
               else: messages
 
           has_top_service_ended? and has_bottom_service_ended? and
             not is_prediction?(unpacked_mz_top) and
               not is_prediction?(unpacked_mz_bottom) ->
-            {%Content.Message.LastTrip.StationClosed{routes: routes},
+            {%Content.Message.LastTrip.StationClosed{route: route},
              %Content.Message.LastTrip.ServiceEnded{}}
 
           has_top_service_ended? and not is_prediction?(unpacked_mz_top) and

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -221,26 +221,26 @@ defmodule Signs.Utilities.Messages do
   end
 
   defp get_alert_messages(alert_status, sign) do
-    sign_routes = Signs.Utilities.SourceConfig.sign_routes(sign.source_config)
+    route = Signs.Utilities.SourceConfig.single_route(sign.source_config)
 
     case {alert_status, sign.uses_shuttles} do
       {:shuttles_transfer_station, _} ->
         {Content.Message.Empty.new(), Content.Message.Empty.new()}
 
       {:shuttles_closed_station, true} ->
-        {%Alert.NoService{routes: sign_routes}, %Alert.UseShuttleBus{}}
+        {%Alert.NoService{route: route}, %Alert.UseShuttleBus{}}
 
       {:shuttles_closed_station, false} ->
-        {%Alert.NoService{routes: sign_routes}, Content.Message.Empty.new()}
+        {%Alert.NoService{route: route}, Content.Message.Empty.new()}
 
       {:suspension_transfer_station, _} ->
         {Content.Message.Empty.new(), Content.Message.Empty.new()}
 
       {:suspension_closed_station, _} ->
-        {%Alert.NoService{routes: sign_routes}, Content.Message.Empty.new()}
+        {%Alert.NoService{route: route}, Content.Message.Empty.new()}
 
       {:station_closure, _} ->
-        {%Alert.NoService{routes: sign_routes}, Content.Message.Empty.new()}
+        {%Alert.NoService{route: route}, Content.Message.Empty.new()}
 
       _ ->
         nil

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -76,10 +76,7 @@ defmodule Signs.Utilities.Predictions do
     # Take next two predictions, but if the list has multiple destinations, prefer showing
     # distinct ones. This helps e.g. the red line trunk where people may need to know about
     # a particular branch.
-    |> get_unique_destination_predictions(
-      SourceConfig.sign_routes(sign.source_config)
-      |> PaEss.Utilities.get_unique_routes()
-    )
+    |> get_unique_destination_predictions(SourceConfig.single_route(sign.source_config))
     |> case do
       [] ->
         {Content.Message.Empty.new(), Content.Message.Empty.new()}
@@ -102,8 +99,7 @@ defmodule Signs.Utilities.Predictions do
     end
   end
 
-  defp get_unique_destination_predictions(predictions, sign_routes)
-       when sign_routes == ["Green"] do
+  defp get_unique_destination_predictions(predictions, "Green") do
     Enum.take(predictions, 2)
   end
 

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -199,6 +199,17 @@ defmodule Signs.Utilities.SourceConfig do
     Enum.flat_map(sources, &(&1.routes || []))
   end
 
+  @spec single_route(config() | {config(), config()}) :: String.t() | nil
+  def single_route(config) do
+    sign_routes(config)
+    |> Enum.map(fn route -> route |> String.split("-") |> List.first() end)
+    |> Enum.uniq()
+    |> case do
+      [single] -> single
+      _ -> nil
+    end
+  end
+
   def get_source_by_stop_and_direction(
         {%{sources: top_source_list}, %{sources: bottom_source_list}},
         stop_id,

--- a/test/content/audio/closure_test.exs
+++ b/test/content/audio/closure_test.exs
@@ -39,42 +39,42 @@ defmodule Content.Audio.ClosureTest do
     test "There is no [single line] service at this station, use shuttle bus" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :shuttles_closed_station,
-               routes: ["Orange"]
+               route: "Orange"
              }) == {:canned, {"199", ["3006"], :audio}}
     end
 
     test "There is no [single line] service at this station" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :suspension_closed_station,
-               routes: ["Orange"]
+               route: "Orange"
              }) == {:canned, {"107", ["861", "21000", "3006", "21000", "863"], :audio}}
     end
 
     test "Default to train service when different lines for shuttle alert" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :shuttles_closed_station,
-               routes: ["Red", "Mattapan"]
+               route: nil
              }) == {:canned, {"199", ["864"], :audio}}
     end
 
     test "Default to train service when different lines for suspension alert" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :suspension_closed_station,
-               routes: ["Red", "Mattapan"]
+               route: nil
              }) == {:canned, {"107", ["861", "21000", "864", "21000", "863"], :audio}}
     end
 
     test "Handle Green Line branches for shuttle alert" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :shuttles_closed_station,
-               routes: ["Green-B", "Green-C", "Green-D", "Green-E"]
+               route: "Green"
              }) == {:canned, {"199", ["3008"], :audio}}
     end
 
     test "Handle Green Line branches for suspension alert" do
       assert Content.Audio.to_params(%Content.Audio.Closure{
                alert: :suspension_closed_station,
-               routes: ["Green-B", "Green-C", "Green-D", "Green-E"]
+               route: "Green"
              }) == {:canned, {"107", ["861", "21000", "3008", "21000", "863"], :audio}}
     end
   end

--- a/test/content/messages/headways/top_test.exs
+++ b/test/content/messages/headways/top_test.exs
@@ -5,25 +5,25 @@ defmodule Content.Message.Headways.TopTest do
     test "works" do
       assert Content.Message.to_string(%Content.Message.Headways.Top{
                destination: :alewife,
-               routes: ["Red"]
+               route: "Red"
              }) ==
                "Alewife trains"
 
       assert Content.Message.to_string(%Content.Message.Headways.Top{
                destination: nil,
-               routes: ["Mattapan"]
+               route: "Mattapan"
              }) ==
                "Mattapan trains"
 
       assert Content.Message.to_string(%Content.Message.Headways.Top{
                destination: nil,
-               routes: ["Red"]
+               route: "Red"
              }) ==
                "Red line trains"
 
       assert Content.Message.to_string(%Content.Message.Headways.Top{
                destination: nil,
-               routes: ["Red", "Green"]
+               route: nil
              }) ==
                "Trains"
     end


### PR DESCRIPTION
#### Summary of changes

This is a small refactor in advance of a larger one. Several of the `Message` structs carry a `routes` field which holds the list of routes from the config used to generate it. However, at the end of the computation, the only thing we care about is whether there was a single unique route. This changes the fields to hold a single `route`, or nil if there were multiple, which simplifies downstream calculations. It also adds a `route` field to a few additional messages, which will be used by later changes.