### PR TITLE
add alert message variants

### DIFF
--- a/lib/content/audio/no_service_to_destination.ex
+++ b/lib/content/audio/no_service_to_destination.ex
@@ -21,6 +21,20 @@ defmodule Content.Audio.NoServiceToDestination do
     [%__MODULE__{destination: destination, use_shuttle: true}]
   end
 
+  def from_messages(
+        %Content.Message.Alert.NoService{destination: destination},
+        %Content.Message.Alert.UseShuttleBus{}
+      ) do
+    [%__MODULE__{destination: destination, use_shuttle: true}]
+  end
+
+  def from_messages(
+        %Content.Message.Alert.NoService{destination: destination},
+        %Content.Message.Empty{}
+      ) do
+    [%__MODULE__{destination: destination, use_shuttle: false}]
+  end
+
   defimpl Content.Audio do
     def to_params(%Content.Audio.NoServiceToDestination{} = audio) do
       {:ad_hoc, {tts_text(audio), :audio}}

--- a/lib/content/message/alert/destination_no_service.ex
+++ b/lib/content/message/alert/destination_no_service.ex
@@ -4,20 +4,34 @@ defmodule Content.Message.Alert.DestinationNoService do
   """
 
   @enforce_keys [:destination]
-  defstruct @enforce_keys ++ [:route]
+  defstruct @enforce_keys ++ [:route, variant: :long]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
-          route: String.t() | nil
+          route: String.t() | nil,
+          variant: :long | :short
         }
 
   defimpl Content.Message do
-    @default_page_width 24
-    def to_string(%Content.Message.Alert.DestinationNoService{destination: destination}) do
+    def to_string(%Content.Message.Alert.DestinationNoService{
+          destination: destination,
+          variant: :long
+        }) do
       Content.Utilities.width_padded_string(
         PaEss.Utilities.destination_to_sign_string(destination),
         "no service",
-        @default_page_width
+        24
+      )
+    end
+
+    def to_string(%Content.Message.Alert.DestinationNoService{
+          destination: destination,
+          variant: :short
+        }) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        "no svc",
+        18
       )
     end
   end

--- a/lib/content/message/alert/no_service.ex
+++ b/lib/content/message/alert/no_service.ex
@@ -3,16 +3,21 @@ defmodule Content.Message.Alert.NoService do
   A message displayed when a station is closed due to shuttles or a suspension
   """
 
-  defstruct [:route]
+  defstruct [:route, :destination]
 
   @type t :: %__MODULE__{
-          route: String.t() | nil
+          route: String.t() | nil,
+          destination: PaEss.destination() | nil
         }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.Alert.NoService{route: route}) do
+    def to_string(%Content.Message.Alert.NoService{destination: nil, route: route}) do
       service = if(route, do: "#{route} Line", else: "train service")
       "No #{service}"
+    end
+
+    def to_string(%Content.Message.Alert.NoService{destination: destination}) do
+      "No #{PaEss.Utilities.destination_to_sign_string(destination)} svc"
     end
   end
 end

--- a/lib/content/message/last_trip/no_service.ex
+++ b/lib/content/message/last_trip/no_service.ex
@@ -1,33 +1,28 @@
 defmodule Content.Message.LastTrip.NoService do
-  @enforce_keys [:destination, :line]
-  defstruct @enforce_keys ++ [:route]
+  @enforce_keys [:destination]
+  defstruct @enforce_keys ++ [:route, variant: :long]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           route: String.t() | nil,
-          line: :top | :bottom
+          variant: :long | :short
         }
 
   defimpl Content.Message do
-    def to_string(%Content.Message.LastTrip.NoService{
-          destination: destination,
-          line: line
-        }) do
-      headsign = PaEss.Utilities.destination_to_sign_string(destination)
+    def to_string(%Content.Message.LastTrip.NoService{destination: destination, variant: :long}) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        "Svc ended",
+        24
+      )
+    end
 
-      if line == :bottom,
-        do:
-          Content.Utilities.width_padded_string(
-            headsign,
-            "Svc ended",
-            24
-          ),
-        else:
-          Content.Utilities.width_padded_string(
-            headsign,
-            "No Svc",
-            18
-          )
+    def to_string(%Content.Message.LastTrip.NoService{destination: destination, variant: :short}) do
+      Content.Utilities.width_padded_string(
+        PaEss.Utilities.destination_to_sign_string(destination),
+        "No Svc",
+        18
+      )
     end
   end
 end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -47,8 +47,11 @@ defmodule Signs.Utilities.Audio do
 
   defp get_passive_readout({:alert, top, bottom}) do
     case top do
-      %Message.Alert.NoService{} ->
+      %Message.Alert.NoService{destination: nil} ->
         Audio.Closure.from_messages(top, bottom)
+
+      %Message.Alert.NoService{} ->
+        Audio.NoServiceToDestination.from_messages(top, bottom)
 
       %Message.Alert.DestinationNoService{} ->
         Audio.NoServiceToDestination.from_message(top)
@@ -150,8 +153,11 @@ defmodule Signs.Utilities.Audio do
       {:alert, top, bottom} ->
         new_audios =
           case top do
-            %Message.Alert.NoService{} ->
+            %Message.Alert.NoService{destination: nil} ->
               Audio.Closure.from_messages(top, bottom)
+
+            %Message.Alert.NoService{} ->
+              Audio.NoServiceToDestination.from_messages(top, bottom)
 
             %Message.Alert.DestinationNoService{} ->
               Audio.NoServiceToDestination.from_message(top)
@@ -322,6 +328,9 @@ defmodule Signs.Utilities.Audio do
 
       {%Message.Headways.Top{}, %Message.Headways.Bottom{}} ->
         [{:headway, top, bottom}]
+
+      {%Message.Alert.NoService{}, _} ->
+        [{:alert, top, bottom}]
 
       {%Message.EarlyAm.DestinationTrain{}, %Message.EarlyAm.ScheduledTime{}} ->
         [{:scheduled_train, top, bottom}]

--- a/lib/signs/utilities/last_trip.ex
+++ b/lib/signs/utilities/last_trip.ex
@@ -37,12 +37,12 @@ defmodule Signs.Utilities.LastTrip do
               {unpacked_mz_bottom,
                %Content.Message.LastTrip.NoService{
                  destination: top_source_config.headway_destination,
-                 line: :bottom
+                 variant: :long
                }}
             else
               {%Content.Message.LastTrip.NoService{
                  destination: top_source_config.headway_destination,
-                 line: :top
+                 variant: :short
                }, unpacked_mz_bottom}
             end
 
@@ -52,12 +52,12 @@ defmodule Signs.Utilities.LastTrip do
               {unpacked_mz_top,
                %Content.Message.LastTrip.NoService{
                  destination: bottom_source_config.headway_destination,
-                 line: :bottom
+                 variant: :long
                }}
             else
               {%Content.Message.LastTrip.NoService{
                  destination: bottom_source_config.headway_destination,
-                 line: :top
+                 variant: :short
                }, unpacked_mz_top}
             end
 


### PR DESCRIPTION
#### Summary of changes

This is a small refactor in advance of a larger one. Adds two new message variants:
* A short version of the single-line destination-specific "no service" message, which can fit on the top line.
* A destination-specific version of the full-page "no service" message.
Note that neither of these messages are used yet, but they will be in a followup PR. The language has been ok'd by product.

Also reworks the `line` field in the "service ended" message as `variant`, to make it more general.