### PR TITLE
move platform config out of signs.json

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -25,7 +25,7 @@ defmodule Content.Audio.Approaching do
       %__MODULE__{
         destination: message.destination,
         trip_id: message.trip_id,
-        platform: message.platform,
+        platform: Content.Utilities.stop_platform(message.stop_id),
         route_id: message.route_id,
         new_cars?: message.new_cars?,
         crowding_description: if(include_crowding?, do: message.crowding_description)

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -30,7 +30,7 @@ defmodule Content.Audio.NextTrainCountdown do
         minutes: if(message.minutes == :approaching, do: 1, else: message.minutes),
         verb: if(message.terminal?, do: :departs, else: :arrives),
         track_number: Content.Utilities.stop_track_number(message.stop_id),
-        platform: message.platform,
+        platform: Content.Utilities.stop_platform(message.stop_id),
         station_code: message.station_code,
         zone: message.zone
       }

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -23,7 +23,7 @@ defmodule Content.Audio.TrainIsArriving do
       %__MODULE__{
         destination: message.destination,
         trip_id: message.trip_id,
-        platform: message.platform,
+        platform: Content.Utilities.stop_platform(message.stop_id),
         route_id: message.route_id,
         crowding_description: if(include_crowding?, do: message.crowding_description)
       }

--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -29,7 +29,6 @@ defmodule Content.Message.Predictions do
     :direction_id,
     :zone,
     width: 18,
-    platform: nil,
     new_cars?: false,
     terminal?: false,
     certainty: nil,
@@ -49,7 +48,6 @@ defmodule Content.Message.Predictions do
           new_cars?: boolean(),
           station_code: String.t() | nil,
           zone: String.t() | nil,
-          platform: Content.platform() | nil,
           terminal?: boolean(),
           certainty: non_neg_integer() | nil,
           crowding_data_confidence: :high | :low | nil,
@@ -61,12 +59,11 @@ defmodule Content.Message.Predictions do
           String.t(),
           String.t(),
           Signs.Realtime.t(),
-          Content.platform() | nil,
           integer()
         ) :: t() | nil
-  def non_terminal(prediction, station_code, zone, sign, platform \\ nil, width \\ 18)
+  def non_terminal(prediction, station_code, zone, sign, width \\ 18)
 
-  def non_terminal(prediction, station_code, zone, sign, platform, width) do
+  def non_terminal(prediction, station_code, zone, sign, width) do
     # e.g., North Station which is non-terminal but has trips that begin there
     predicted_time = prediction.seconds_until_arrival || prediction.seconds_until_departure
 
@@ -100,7 +97,6 @@ defmodule Content.Message.Predictions do
       new_cars?: sign.location_engine.for_vehicle(prediction.vehicle_id) |> new_cars?(),
       station_code: station_code,
       zone: zone,
-      platform: platform,
       certainty: certainty,
       crowding_data_confidence: crowding_data_confidence,
       crowding_description: crowding_description

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -119,6 +119,11 @@ defmodule Content.Utilities do
   def stop_track_number("Union Square-02"), do: 2
   def stop_track_number(_), do: nil
 
+  @spec stop_platform(String.t()) :: Content.platform() | nil
+  def stop_platform("70086"), do: :ashmont
+  def stop_platform("70096"), do: :braintree
+  def stop_platform(_), do: nil
+
   def stop_platform_name("70086"), do: "Ashmont"
   def stop_platform_name("70096"), do: "Braintree"
 

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -54,13 +54,7 @@ defmodule Signs.Utilities.Predictions do
           Content.Message.Predictions.terminal(prediction, station_code, zone, sign)
 
         true ->
-          Content.Message.Predictions.non_terminal(
-            prediction,
-            station_code,
-            zone,
-            sign,
-            platform(prediction, sources)
-          )
+          Content.Message.Predictions.non_terminal(prediction, station_code, zone, sign)
       end
     end)
     |> Enum.reject(&is_nil(&1))
@@ -199,18 +193,6 @@ defmodule Signs.Utilities.Predictions do
 
   defp allowed_multi_berth_platform?(_, _) do
     false
-  end
-
-  defp platform(prediction, source_list) do
-    source_list
-    |> SourceConfig.get_source_by_stop_and_direction(
-      prediction.stop_id,
-      prediction.direction_id
-    )
-    |> case do
-      nil -> nil
-      source -> source.platform
-    end
   end
 
   # This is a temporary fix for a situation where spotty train sheet data can

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -72,7 +72,6 @@ defmodule Signs.Utilities.SourceConfig do
     "routes": ["Orange"],
     "direction_id": 0,
     "headway_direction_name": "Forest Hills",
-    "platform": null,
     "announce_arriving": true,
     "announce_boarding": false
   }
@@ -80,8 +79,6 @@ defmodule Signs.Utilities.SourceConfig do
   * stop_id: The GTFS stop_id that it uses for prediction data.
   * routes: A list of routes that are relevant to this sign regarding alerts.
   * direction_id: 0 or 1, used in tandem with the stop ID for predictions
-  * platform: mostly null, but :ashmont | :braintree for JFK/UMass, where it's used for the "next
-    train to X is approaching, on the Y platform" audio.
   * announce_arriving: whether to play audio when a sign goes to ARR.
   * announce_boarding: whether to play audio when a sign goes to BRD. Generally we do one or the
     other. Considerations include how noisy the station is, what we've done in the past, how
@@ -96,7 +93,6 @@ defmodule Signs.Utilities.SourceConfig do
     :stop_id,
     :direction_id,
     :routes,
-    :platform,
     :announce_arriving?,
     :announce_boarding?
   ]
@@ -108,7 +104,6 @@ defmodule Signs.Utilities.SourceConfig do
           headway_stop_id: String.t() | nil,
           direction_id: 0 | 1,
           routes: [String.t()] | nil,
-          platform: Content.platform() | nil,
           announce_arriving?: boolean(),
           announce_boarding?: boolean(),
           multi_berth?: boolean()
@@ -146,18 +141,10 @@ defmodule Signs.Utilities.SourceConfig do
          %{
            "stop_id" => stop_id,
            "direction_id" => direction_id,
-           "platform" => platform,
            "announce_arriving" => announce_arriving?,
            "announce_boarding" => announce_boarding?
          } = source
        ) do
-    platform =
-      case platform do
-        nil -> nil
-        "ashmont" -> :ashmont
-        "braintree" -> :braintree
-      end
-
     multi_berth? =
       case source["multi_berth"] do
         true -> true
@@ -168,7 +155,6 @@ defmodule Signs.Utilities.SourceConfig do
       stop_id: stop_id,
       direction_id: direction_id,
       routes: source["routes"],
-      platform: platform,
       announce_arriving?: announce_arriving?,
       announce_boarding?: announce_boarding?,
       multi_berth?: multi_berth?

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -22,7 +22,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -39,7 +38,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -69,7 +67,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -97,7 +94,6 @@
             "Mattapan"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -125,7 +121,6 @@
             "Mattapan"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -154,7 +149,6 @@
               "Mattapan"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -171,7 +165,6 @@
               "Mattapan"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -200,7 +193,6 @@
             "Mattapan"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -228,7 +220,6 @@
             "Mattapan"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -256,7 +247,6 @@
             "Mattapan"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -284,7 +274,6 @@
             "Mattapan"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -312,7 +301,6 @@
             "Mattapan"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -340,7 +328,6 @@
             "Mattapan"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -368,7 +355,6 @@
             "Mattapan"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -396,7 +382,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -424,7 +409,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -452,7 +436,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -481,7 +464,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -498,7 +480,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -527,7 +508,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -555,7 +535,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -583,7 +562,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -611,7 +589,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -639,7 +616,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -667,7 +643,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -696,7 +671,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -713,7 +687,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -742,7 +715,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -770,7 +742,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -799,7 +770,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -816,7 +786,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -845,7 +814,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -873,7 +841,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -901,7 +868,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -929,7 +895,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -957,7 +922,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -985,7 +949,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1014,7 +977,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1031,7 +993,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1060,7 +1021,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1088,7 +1048,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1117,7 +1076,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1134,7 +1092,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1163,7 +1120,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1191,7 +1147,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1220,7 +1175,6 @@
               "Blue"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1237,7 +1191,6 @@
               "Blue"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1266,7 +1219,6 @@
             "Blue"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1294,7 +1246,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -1322,7 +1273,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -1350,7 +1300,6 @@
             "Blue"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -1378,7 +1327,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1388,7 +1336,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1398,7 +1345,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -1426,7 +1372,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1436,7 +1381,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1446,7 +1390,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -1474,7 +1417,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1484,7 +1426,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -1494,7 +1435,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -1523,7 +1463,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1540,7 +1479,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1570,7 +1508,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1587,7 +1524,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1617,7 +1553,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1634,7 +1569,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1663,7 +1597,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1691,7 +1624,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         },
@@ -1701,7 +1633,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1730,7 +1661,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1747,7 +1677,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1776,7 +1705,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1804,7 +1732,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1833,7 +1760,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1850,7 +1776,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1879,7 +1804,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1907,7 +1831,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -1936,7 +1859,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1953,7 +1875,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -1982,7 +1903,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2010,7 +1930,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2038,7 +1957,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2066,7 +1984,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2095,7 +2012,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2112,7 +2028,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2142,7 +2057,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2159,7 +2073,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2189,7 +2102,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2206,7 +2118,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2235,7 +2146,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2263,7 +2173,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2292,7 +2201,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2309,7 +2217,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2338,7 +2245,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2366,7 +2272,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2394,7 +2299,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2422,7 +2326,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2450,7 +2353,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2478,7 +2380,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2506,7 +2407,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2534,7 +2434,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2563,7 +2462,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2580,7 +2478,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2609,7 +2506,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2637,7 +2533,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2666,7 +2561,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2683,7 +2577,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2712,7 +2605,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2740,7 +2632,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2769,7 +2660,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2786,7 +2676,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2815,7 +2704,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2843,7 +2731,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2871,7 +2758,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2899,7 +2785,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -2928,7 +2813,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2945,7 +2829,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2975,7 +2858,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -2992,7 +2874,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3022,7 +2903,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3039,7 +2919,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3068,7 +2947,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3096,7 +2974,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3125,7 +3002,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3142,7 +3018,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3171,7 +3046,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3199,7 +3073,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3228,7 +3101,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3245,7 +3117,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3274,7 +3145,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3302,7 +3172,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3331,7 +3200,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3348,7 +3216,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3377,7 +3244,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3405,7 +3271,6 @@
             "Orange"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3433,7 +3298,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3443,7 +3307,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3453,7 +3316,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -3481,7 +3343,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3491,7 +3352,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3501,7 +3361,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -3529,7 +3388,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3539,7 +3397,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3549,7 +3406,6 @@
             "Orange"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -3578,7 +3434,6 @@
               "Orange"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3595,7 +3450,6 @@
               "Orange"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3624,7 +3478,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3634,7 +3487,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3644,7 +3496,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -3672,7 +3523,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3682,7 +3532,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -3692,7 +3541,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -3721,7 +3569,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3738,7 +3585,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3767,7 +3613,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3795,7 +3640,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3824,7 +3668,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3841,7 +3684,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3870,7 +3712,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3898,7 +3739,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -3927,7 +3767,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3944,7 +3783,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -3973,7 +3811,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4001,7 +3838,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4029,7 +3865,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4057,7 +3892,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4085,7 +3919,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4113,7 +3946,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4141,7 +3973,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4169,7 +4000,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4198,7 +4028,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4227,7 +4056,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4254,7 +4082,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4271,7 +4098,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4300,7 +4126,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4328,7 +4153,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4357,7 +4181,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4374,7 +4197,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4403,7 +4225,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4431,7 +4252,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4460,7 +4280,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4477,7 +4296,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4507,7 +4325,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4524,7 +4341,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4553,7 +4369,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4581,7 +4396,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4610,7 +4424,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4627,7 +4440,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4656,7 +4468,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4684,7 +4495,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4713,7 +4523,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4730,7 +4539,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4759,7 +4567,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4787,7 +4594,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4816,7 +4622,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4833,7 +4638,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4862,7 +4666,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4890,7 +4693,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4919,7 +4721,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4936,7 +4737,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -4965,7 +4765,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -4993,7 +4792,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5022,7 +4820,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": false,
             "announce_boarding": true
           }
@@ -5039,7 +4836,6 @@
               "Mattapan"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": true
           }
@@ -5068,7 +4864,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -5096,7 +4891,6 @@
             "Mattapan"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": true
         }
@@ -5125,7 +4919,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5142,7 +4935,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5171,7 +4963,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5199,7 +4990,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5228,7 +5018,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5245,7 +5034,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5274,7 +5062,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5302,7 +5089,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5331,7 +5117,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5348,7 +5133,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5377,7 +5161,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5405,7 +5188,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5434,7 +5216,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5451,7 +5232,6 @@
               "Red"
             ],
             "direction_id": 0,
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5480,7 +5260,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5508,7 +5287,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5536,7 +5314,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -5546,7 +5323,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -5556,7 +5332,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -5584,7 +5359,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -5594,7 +5368,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -5604,7 +5377,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -5632,7 +5404,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5660,7 +5431,6 @@
             "Red"
           ],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5688,7 +5458,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": "ashmont",
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5716,7 +5485,6 @@
             "Red"
           ],
           "direction_id": 1,
-          "platform": "braintree",
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5745,14 +5513,12 @@
             "routes": [
               "Red"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           },
           {
             "stop_id": "70095",
             "direction_id": 0,
-            "platform": null,
             "routes": [
               "Red"
             ],
@@ -5772,7 +5538,6 @@
               "Red"
             ],
             "direction_id": 1,
-            "platform": "ashmont",
             "announce_arriving": true,
             "announce_boarding": false
           },
@@ -5782,7 +5547,6 @@
             "routes": [
               "Red"
             ],
-            "platform": "braintree",
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -5811,7 +5575,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -5839,7 +5602,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5867,7 +5629,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5895,7 +5656,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5923,7 +5683,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5951,7 +5710,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -5979,7 +5737,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6007,7 +5764,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6035,7 +5791,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6063,7 +5818,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6091,7 +5845,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6119,7 +5872,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6147,7 +5899,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6175,7 +5926,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6203,7 +5953,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6232,7 +5981,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6261,7 +6009,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6289,7 +6036,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6317,7 +6063,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6345,7 +6090,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6373,7 +6117,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6401,7 +6144,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6429,7 +6171,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6457,7 +6198,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6485,7 +6225,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6513,7 +6252,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6541,7 +6279,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6569,7 +6306,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6597,7 +6333,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6625,7 +6360,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6653,7 +6387,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6682,7 +6415,6 @@
             "Green-C",
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6711,7 +6443,6 @@
             "Green-C",
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6741,7 +6472,6 @@
               "Green-C",
               "Green-D"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           },
@@ -6751,7 +6481,6 @@
             "routes": [
               "Green-B"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -6769,7 +6498,6 @@
               "Green-C",
               "Green-D"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           },
@@ -6779,7 +6507,6 @@
             "routes": [
               "Green-B"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -6810,7 +6537,6 @@
             "Green-C",
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6840,7 +6566,6 @@
             "Green-C",
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6871,7 +6596,6 @@
               "Green-C",
               "Green-D"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -6890,7 +6614,6 @@
               "Green-C",
               "Green-D"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -6922,7 +6645,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6953,7 +6675,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -6984,7 +6705,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7015,7 +6735,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7047,7 +6766,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7067,7 +6785,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7099,7 +6816,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7130,7 +6846,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7158,7 +6873,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7186,7 +6900,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7214,7 +6927,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7242,7 +6954,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7271,7 +6982,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7288,7 +6998,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7320,7 +7029,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         },
@@ -7333,7 +7041,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7364,7 +7071,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         },
@@ -7377,7 +7083,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7402,7 +7107,6 @@
         {
           "stop_id": "70198",
           "direction_id": 0,
-          "platform": null,
           "routes": [
             "Green-D"
           ],
@@ -7413,7 +7117,6 @@
         {
           "stop_id": "70199",
           "direction_id": 0,
-          "platform": null,
           "routes": [
             "Green-E"
           ],
@@ -7445,7 +7148,6 @@
           "routes": [
             "Green-B"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true,
           "multi_berth": true
@@ -7456,7 +7158,6 @@
           "routes": [
             "Green-C"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true,
           "multi_berth": true
@@ -7488,7 +7189,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -7519,7 +7219,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -7551,7 +7250,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7571,7 +7269,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7601,7 +7298,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7630,7 +7326,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7659,7 +7354,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -7688,7 +7382,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -7718,7 +7411,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": false,
             "announce_boarding": true
           }
@@ -7736,7 +7428,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": false,
             "announce_boarding": true
           }
@@ -7766,7 +7457,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7795,7 +7485,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7825,7 +7514,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7843,7 +7531,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7873,7 +7560,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7902,7 +7588,6 @@
             "Green-D",
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -7932,7 +7617,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7950,7 +7634,6 @@
               "Green-D",
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -7977,7 +7660,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -7987,7 +7669,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -7997,7 +7678,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -8023,7 +7703,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -8033,7 +7712,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -8043,7 +7721,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -8073,7 +7750,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -8083,7 +7759,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         },
@@ -8093,7 +7768,6 @@
           "routes": [
             "Green-D"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }
@@ -8121,7 +7795,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8149,7 +7822,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8176,7 +7848,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8193,7 +7864,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8222,7 +7892,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8250,7 +7919,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8279,7 +7947,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8296,7 +7963,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8325,7 +7991,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8353,7 +8018,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8382,7 +8046,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8399,7 +8062,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8428,7 +8090,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8456,7 +8117,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": true,
           "announce_boarding": false
         }
@@ -8485,7 +8145,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8502,7 +8161,6 @@
             "routes": [
               "Green-E"
             ],
-            "platform": null,
             "announce_arriving": true,
             "announce_boarding": false
           }
@@ -8529,7 +8187,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -8555,7 +8212,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -8585,7 +8241,6 @@
           "routes": [
             "Green-E"
           ],
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": true
         }

--- a/scripts/one_offs/platform_config.exs
+++ b/scripts/one_offs/platform_config.exs
@@ -1,0 +1,28 @@
+Mix.install([{:jason, "~> 1.4.0"}])
+
+signs =
+  File.read!("priv/signs.json")
+  |> Jason.decode!(keys: :atoms, objects: :ordered_objects)
+
+transform_config = fn config ->
+  Enum.map(config, fn
+    {:sources, sources} ->
+      {:sources,
+       Enum.map(sources, fn source ->
+         Enum.reject(source, &match?({:platform, _}, &1)) |> Jason.OrderedObject.new()
+       end)}
+
+    x ->
+      x
+  end)
+  |> Jason.OrderedObject.new()
+end
+
+signs_json =
+  update_in(signs, [Access.filter(&(&1[:type] == "realtime")), :source_config], fn
+    [top, bottom] -> [transform_config.(top), transform_config.(bottom)]
+    config -> transform_config.(config)
+  end)
+  |> Jason.encode!(pretty: true)
+
+File.write!("priv/signs.json", signs_json <> "\n")

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -113,7 +113,7 @@ defmodule Content.Message.PredictionsTest do
         destination_stop_id: "70275"
       }
 
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign, nil, 15)
+      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign, 15)
       assert Content.Message.to_string(msg) == "Mattapan  9 min"
     end
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -9,7 +9,6 @@ defmodule Signs.RealtimeTest do
     stop_id: "1",
     direction_id: 0,
     routes: ["Red"],
-    platform: nil,
     announce_arriving?: true,
     announce_boarding?: false
   }
@@ -18,7 +17,6 @@ defmodule Signs.RealtimeTest do
     stop_id: "2",
     direction_id: 0,
     routes: ["Red"],
-    platform: nil,
     announce_arriving?: true,
     announce_boarding?: false
   }
@@ -106,7 +104,7 @@ defmodule Signs.RealtimeTest do
           terminal?: false
         },
         %{
-          sources: [%{@src | stop_id: "70086", direction_id: 1, platform: :ashmont}],
+          sources: [%{@src | stop_id: "70086", direction_id: 1}],
           headway_group: "group",
           headway_destination: :alewife,
           terminal?: false

--- a/test/signs/utilities/source_config_test.exs
+++ b/test/signs/utilities/source_config_test.exs
@@ -13,7 +13,6 @@ defmodule Signs.Utilities.SourceConfigTest do
         "stop_id": "123",
         "routes": ["Foo"],
         "direction_id": 0,
-        "platform": null,
         "announce_arriving": false,
         "announce_boarding": false
       },
@@ -21,7 +20,6 @@ defmodule Signs.Utilities.SourceConfigTest do
         "stop_id": "234",
         "routes": ["Bar"],
         "direction_id": 1,
-        "platform": "ashmont",
         "announce_arriving": true,
         "announce_boarding": false,
         "multi_berth": true
@@ -41,7 +39,6 @@ defmodule Signs.Utilities.SourceConfigTest do
           "stop_id": "123",
           "routes": ["Foo"],
           "direction_id": 0,
-          "platform": null,
           "announce_arriving": false,
           "announce_boarding": false
         }
@@ -57,7 +54,6 @@ defmodule Signs.Utilities.SourceConfigTest do
           "headway_direction_name": "Southbound",
           "routes": ["Bar"],
           "direction_id": 1,
-          "platform": "braintree",
           "announce_arriving": true,
           "announce_boarding": true
         }
@@ -76,7 +72,6 @@ defmodule Signs.Utilities.SourceConfigTest do
         "stop_id": "123",
         "routes": ["Foo"],
         "direction_id": 0,
-        "platform": null,
         "announce_arriving": false,
         "announce_boarding": false
       },
@@ -84,7 +79,6 @@ defmodule Signs.Utilities.SourceConfigTest do
         "stop_id": "234",
         "routes": ["Bar"],
         "direction_id": 1,
-        "platform": "ashmont",
         "announce_arriving": true,
         "announce_boarding": false,
         "multi_berth": true
@@ -105,7 +99,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                      stop_id: "123",
                      routes: ["Foo"],
                      direction_id: 0,
-                     platform: nil,
                      announce_arriving?: false,
                      announce_boarding?: false,
                      multi_berth?: false
@@ -114,7 +107,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                      stop_id: "234",
                      routes: ["Bar"],
                      direction_id: 1,
-                     platform: :ashmont,
                      announce_arriving?: true,
                      announce_boarding?: false,
                      multi_berth?: true
@@ -135,7 +127,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                        stop_id: "123",
                        routes: ["Foo"],
                        direction_id: 0,
-                       platform: nil,
                        announce_arriving?: false,
                        announce_boarding?: false
                      }
@@ -150,7 +141,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                        stop_id: "234",
                        routes: ["Bar"],
                        direction_id: 1,
-                       platform: :braintree,
                        announce_arriving?: true,
                        announce_boarding?: true
                      }
@@ -171,7 +161,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                 stop_id: "123",
                 routes: ["Foo"],
                 direction_id: 0,
-                platform: nil,
                 announce_arriving?: false,
                 announce_boarding?: false,
                 multi_berth?: false
@@ -180,7 +169,6 @@ defmodule Signs.Utilities.SourceConfigTest do
                 stop_id: "234",
                 routes: ["Bar"],
                 direction_id: 1,
-                platform: :ashmont,
                 announce_arriving?: true,
                 announce_boarding?: false,
                 multi_berth?: true


### PR DESCRIPTION
#### Summary of changes

This moves the `platform` field out of the sign configuration and into code. The platform is only non-nil in two specific cases, and can be straightforwardly computed from the stop id, so there's no reason to store it separately.

The `signs.json` change was made programmatically, and the script is included for review.