### PR TITLE
adjust approaching and arriving visual messages

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -82,8 +82,17 @@ defmodule Content.Audio.Approaching do
     end
 
     def to_tts(%Content.Audio.Approaching{} = audio) do
-      text = tts_text(audio)
-      {text, PaEss.Utilities.paginate_text(text)}
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
+      crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+
+      new_cars =
+        if(audio.new_cars? && audio.route_id == "Red", do: "with all new Red Line cars", else: "")
+
+      pages =
+        [{train, "now approaching", 6}] ++
+          PaEss.Utilities.paginate_text(new_cars) ++ PaEss.Utilities.paginate_text(crowding)
+
+      {tts_text(audio), pages}
     end
 
     def to_logs(%Content.Audio.Approaching{}) do

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -50,8 +50,10 @@ defmodule Content.Audio.TrainIsArriving do
     end
 
     def to_tts(%Content.Audio.TrainIsArriving{} = audio) do
-      text = tts_text(audio)
-      {text, PaEss.Utilities.paginate_text(text)}
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
+      crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+      pages = [{train, "now arriving", 6}] ++ PaEss.Utilities.paginate_text(crowding)
+      {tts_text(audio), pages}
     end
 
     def to_logs(%Content.Audio.TrainIsArriving{}) do

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -116,5 +116,6 @@ defmodule Content.Audio.UtilitiesTest do
 
     assert [{"too-long", "word", 3}] = paginate_text(" too-long   word ", 5)
     assert [{"fits", "", 3}] = paginate_text("fits", 24)
+    assert [] = paginate_text("")
   end
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -554,10 +554,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["90007"], :audio_visual}}], [
         {"Attention passengers: The next C train to Cleveland Circle is now arriving.",
-         [
-           {"Attention passengers:", "The next C train to", 3},
-           {"Cleveland Circle is now", "arriving.", 3}
-         ]}
+         [{"C train to Clvlnd Cir", "now arriving", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -581,15 +578,9 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Attention passengers: The next C train to Cleveland Circle is now arriving.",
-           [
-             {"Attention passengers:", "The next C train to", 3},
-             {"Cleveland Circle is now", "arriving.", 3}
-           ]},
+           [{"C train to Clvlnd Cir", "now arriving", 6}]},
           {"Attention passengers: The next D train to Riverside is now arriving.",
-           [
-             {"Attention passengers:", "The next D train to", 3},
-             {"Riverside is now", "arriving.", 3}
-           ]}
+           [{"D train to Riverside", "now arriving", 6}]}
         ]
       )
 
@@ -739,7 +730,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Attention passengers:", "The next Ashmont train", 3}, {"is now approaching.", "", 3}]}
+         [{"Ashmont train", "now approaching", 6}]}
       ])
 
       assert {_, %{announced_approachings: ["1"]}} = Signs.Realtime.handle_info(:run_loop, @sign)
@@ -798,7 +789,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Attention passengers:", "The next Ashmont train", 3}, {"is now approaching.", "", 3}]}
+         [{"Ashmont train", "now approaching", 6}]}
       ])
 
       assert {_, %{tick_read: 119}} =
@@ -818,10 +809,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32123"], :audio_visual}}], [
         {"Attention passengers: The next Forest Hills train is now approaching.",
-         [
-           {"Attention passengers:", "The next Forest Hills", 3},
-           {"train is now", "approaching.", 3}
-         ]}
+         [{"Frst Hills train", "now approaching", 6}]}
       ])
 
       assert {_, %{announced_approachings_with_crowding: ["1"]}} =
@@ -841,10 +829,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32123"], :audio_visual}}], [
         {"Attention passengers: The next Forest Hills train is now approaching.",
-         [
-           {"Attention passengers:", "The next Forest Hills", 3},
-           {"train is now", "approaching.", 3}
-         ]}
+         [{"Frst Hills train", "now approaching", 6}]}
       ])
 
       assert {_, %{announced_approachings_with_crowding: []}} =
@@ -864,10 +849,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32103"], :audio_visual}}], [
         {"Attention passengers: The next Forest Hills train is now arriving.",
-         [
-           {"Attention passengers:", "The next Forest Hills", 3},
-           {"train is now arriving.", "", 3}
-         ]}
+         [{"Frst Hills train", "now arriving", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -886,10 +868,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32103"], :audio_visual}}], [
         {"Attention passengers: The next Forest Hills train is now arriving.",
-         [
-           {"Attention passengers:", "The next Forest Hills", 3},
-           {"train is now arriving.", "", 3}
-         ]}
+         [{"Frst Hills train", "now arriving", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -908,10 +887,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32103"], :audio_visual}}], [
         {"Attention passengers: The next Forest Hills train is now arriving.",
-         [
-           {"Attention passengers:", "The next Forest Hills", 3},
-           {"train is now arriving.", "", 3}
-         ]}
+         [{"Frst Hills train", "now arriving", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | announced_approachings_with_crowding: ["1"]})
@@ -1038,7 +1014,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32107"], :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now arriving.",
-         [{"Attention passengers:", "The next Ashmont train", 3}, {"is now arriving.", "", 3}]}
+         [{"Ashmont train", "now arriving", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, %{
@@ -1097,7 +1073,7 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Attention passengers: The next Ashmont train is now arriving.",
-           [{"Attention passengers:", "The next Ashmont train", 3}, {"is now arriving.", "", 3}]},
+           [{"Ashmont train", "now arriving", 6}]},
           {"The following Ashmont train arrives in 2 minutes", nil}
         ]
       )
@@ -1124,7 +1100,7 @@ defmodule Signs.RealtimeTest do
         [
           {"The next Ashmont train arrives in 2 minutes.", nil},
           {"Attention passengers: The next Alewife train is now arriving.",
-           [{"Attention passengers:", "The next Alewife train", 3}, {"is now arriving.", "", 3}]}
+           [{"Alewife train", "now arriving", 6}]}
         ]
       )
 
@@ -1548,10 +1524,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"106", ["783", "4016", "21000", "786"], :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now approaching, with all new Red Line cars.",
-         [
-           {"Attention passengers:", "The next Ashmont train", 3},
-           {"is now approaching, with", "all new Red Line cars.", 3}
-         ]}
+         [{"Ashmont train", "now approaching", 6}, {"with all new Red Line", "cars", 3}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -1580,7 +1553,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Attention passengers:", "The next Ashmont train", 3}, {"is now approaching.", "", 3}]}
+         [{"Ashmont train", "now approaching", 6}]}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Adjust Approaching/Arriving messages](https://app.asana.com/0/1207660975981504/1208551608056344/f)

This adjusts the visual component of the post-migration approaching and arriving messages to a more compact form that fits one one page. This should provide a close match for what currently plays pre-migration.