### PR TITLE
fix capitalization of early AM messages

### DIFF
--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -71,21 +71,12 @@ defmodule Content.Audio.ServiceEnded do
 
     defp tts_text(%Content.Audio.ServiceEnded{location: :platform, destination: destination}) do
       {:ok, destination_string} = Utilities.destination_to_ad_hoc_string(destination)
-
-      service_ended =
-        "#{destination_string} service has ended for the night."
-        |> String.trim_leading()
-        |> String.capitalize()
-
-      "This platform is closed. #{service_ended}"
+      "This platform is closed. #{destination_string} service has ended for the night."
     end
 
     defp tts_text(%Content.Audio.ServiceEnded{location: :direction, destination: destination}) do
       {:ok, destination_string} = Utilities.destination_to_ad_hoc_string(destination)
-
       "#{destination_string} service has ended for the night."
-      |> String.trim_leading()
-      |> String.capitalize()
     end
   end
 end

--- a/lib/content/message/early_am/destination_scheduled_time.ex
+++ b/lib/content/message/early_am/destination_scheduled_time.ex
@@ -12,7 +12,8 @@ defmodule Content.Message.EarlyAm.DestinationScheduledTime do
           destination: destination,
           scheduled_time: scheduled_time
         }) do
-      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} due #{Content.Utilities.render_datetime_as_time(scheduled_time)}"
+      destination_string = PaEss.Utilities.destination_to_sign_string(destination)
+      "#{destination_string} due #{Content.Utilities.render_datetime_as_time(scheduled_time)}"
     end
   end
 end

--- a/lib/content/message/early_am/destination_train.ex
+++ b/lib/content/message/early_am/destination_train.ex
@@ -8,7 +8,7 @@ defmodule Content.Message.EarlyAm.DestinationTrain do
 
   defimpl Content.Message do
     def to_string(%Content.Message.EarlyAm.DestinationTrain{destination: destination}) do
-      "#{String.capitalize(PaEss.Utilities.destination_to_sign_string(destination))} train"
+      "#{PaEss.Utilities.destination_to_sign_string(destination)} train"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Lower case "g" in "Oak grove due" should be capitalized](https://app.asana.com/0/1185117109217422/1208591545042708/f)

`String.capitalize` lowercases the remainder of the string, which is usually not what we want. These usages are unnecessary anyway, since the destination names already have the right casing.