### PR TITLE
don't modify predictions when both lines ARR

### DIFF
--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -27,7 +27,7 @@ defmodule Signs.Utilities.Predictions do
         ) :: Signs.Realtime.sign_messages() | nil
   def prediction_messages(
         predictions,
-        %{sources: sources, terminal?: terminal?},
+        %{terminal?: terminal?},
         %{pa_ess_loc: station_code, text_zone: zone} = sign
       ) do
     predictions
@@ -68,16 +68,6 @@ defmodule Signs.Utilities.Predictions do
 
       [msg] ->
         {msg, Content.Message.Empty.new()}
-
-      [
-        %Content.Message.Predictions{minutes: :arriving} = p1,
-        %Content.Message.Predictions{minutes: :arriving} = p2
-      ] ->
-        if allowed_multi_berth_platform?(sources, p1, p2) do
-          {p1, p2}
-        else
-          {p1, %{p2 | minutes: 1}}
-        end
 
       [msg1, msg2] ->
         {msg1, msg2}
@@ -166,33 +156,6 @@ defmodule Signs.Utilities.Predictions do
 
     boarding_status && String.starts_with?(boarding_status, "Stopped") &&
       boarding_status != "Stopped at station" && !approximate_arrival? && !approximate_departure?
-  end
-
-  defp allowed_multi_berth_platform?(source_list, p1, p2) do
-    allowed_multi_berth_platform?(
-      SourceConfig.get_source_by_stop_and_direction(
-        source_list,
-        p1.stop_id,
-        p1.direction_id
-      ),
-      SourceConfig.get_source_by_stop_and_direction(
-        source_list,
-        p2.stop_id,
-        p2.direction_id
-      )
-    )
-  end
-
-  defp allowed_multi_berth_platform?(
-         %SourceConfig{multi_berth?: true} = s1,
-         %SourceConfig{multi_berth?: true} = s2
-       )
-       when s1 != s2 do
-    true
-  end
-
-  defp allowed_multi_berth_platform?(_, _) do
-    false
   end
 
   # This is a temporary fix for a situation where spotty train sheet data can

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -96,8 +96,7 @@ defmodule Signs.Utilities.SourceConfig do
     :announce_arriving?,
     :announce_boarding?
   ]
-  defstruct @enforce_keys ++
-              [:headway_stop_id, multi_berth?: false]
+  defstruct @enforce_keys ++ [:headway_stop_id]
 
   @type source :: %__MODULE__{
           stop_id: String.t(),
@@ -105,8 +104,7 @@ defmodule Signs.Utilities.SourceConfig do
           direction_id: 0 | 1,
           routes: [String.t()] | nil,
           announce_arriving?: boolean(),
-          announce_boarding?: boolean(),
-          multi_berth?: boolean()
+          announce_boarding?: boolean()
         }
 
   @type config :: %{
@@ -145,19 +143,12 @@ defmodule Signs.Utilities.SourceConfig do
            "announce_boarding" => announce_boarding?
          } = source
        ) do
-    multi_berth? =
-      case source["multi_berth"] do
-        true -> true
-        _ -> false
-      end
-
     %__MODULE__{
       stop_id: stop_id,
       direction_id: direction_id,
       routes: source["routes"],
       announce_arriving?: announce_arriving?,
-      announce_boarding?: announce_boarding?,
-      multi_berth?: multi_berth?
+      announce_boarding?: announce_boarding?
     }
   end
 

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7111,8 +7111,7 @@
             "Green-D"
           ],
           "announce_arriving": false,
-          "announce_boarding": true,
-          "multi_berth": true
+          "announce_boarding": true
         },
         {
           "stop_id": "70199",
@@ -7121,8 +7120,7 @@
             "Green-E"
           ],
           "announce_arriving": false,
-          "announce_boarding": true,
-          "multi_berth": true
+          "announce_boarding": true
         }
       ]
     }
@@ -7149,8 +7147,7 @@
             "Green-B"
           ],
           "announce_arriving": false,
-          "announce_boarding": true,
-          "multi_berth": true
+          "announce_boarding": true
         },
         {
           "stop_id": "70197",
@@ -7159,8 +7156,7 @@
             "Green-C"
           ],
           "announce_arriving": false,
-          "announce_boarding": true,
-          "multi_berth": true
+          "announce_boarding": true
         }
       ]
     }

--- a/test/signs/utilities/source_config_test.exs
+++ b/test/signs/utilities/source_config_test.exs
@@ -21,8 +21,7 @@ defmodule Signs.Utilities.SourceConfigTest do
         "routes": ["Bar"],
         "direction_id": 1,
         "announce_arriving": true,
-        "announce_boarding": false,
-        "multi_berth": true
+        "announce_boarding": false
       }
     ]
   }
@@ -80,8 +79,7 @@ defmodule Signs.Utilities.SourceConfigTest do
         "routes": ["Bar"],
         "direction_id": 1,
         "announce_arriving": true,
-        "announce_boarding": false,
-        "multi_berth": true
+        "announce_boarding": false
       }
     ]
   }
@@ -100,16 +98,14 @@ defmodule Signs.Utilities.SourceConfigTest do
                      routes: ["Foo"],
                      direction_id: 0,
                      announce_arriving?: false,
-                     announce_boarding?: false,
-                     multi_berth?: false
+                     announce_boarding?: false
                    },
                    %SourceConfig{
                      stop_id: "234",
                      routes: ["Bar"],
                      direction_id: 1,
                      announce_arriving?: true,
-                     announce_boarding?: false,
-                     multi_berth?: true
+                     announce_boarding?: false
                    }
                  ]
                }
@@ -162,16 +158,14 @@ defmodule Signs.Utilities.SourceConfigTest do
                 routes: ["Foo"],
                 direction_id: 0,
                 announce_arriving?: false,
-                announce_boarding?: false,
-                multi_berth?: false
+                announce_boarding?: false
               },
               %SourceConfig{
                 stop_id: "234",
                 routes: ["Bar"],
                 direction_id: 1,
                 announce_arriving?: true,
-                announce_boarding?: false,
-                multi_berth?: true
+                announce_boarding?: false
               }
             ]
           }


### PR DESCRIPTION
#### Summary of changes

This is a small behavior change that was ok'd by product. There was some old logic that would detect a case where `ARR` would be shown on both lines, and tweak the display so the second line said `1 min` in all but a handful of cases. We're not exactly sure of the original rationale, but suspect it was to smooth over a data quality issue. The data should be better now, and also this special handling creates an inconsistency with other touchpoints, so we'd like to remove it.