### PR TITLE
reference prediction directly and remove individual fields

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -24,9 +24,9 @@ defmodule Content.Audio.Approaching do
     [
       %__MODULE__{
         destination: message.destination,
-        trip_id: message.trip_id,
-        platform: Content.Utilities.stop_platform(message.stop_id),
-        route_id: message.route_id,
+        trip_id: message.prediction.trip_id,
+        platform: Content.Utilities.stop_platform(message.prediction.stop_id),
+        route_id: message.prediction.route_id,
         new_cars?: message.new_cars?,
         crowding_description: if(include_crowding?, do: message.crowding_description)
       }

--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -24,7 +24,7 @@ defmodule Content.Audio.FollowingTrain do
   def from_predictions_message(%Content.Message.Predictions{
         minutes: n,
         destination: destination,
-        route_id: route_id,
+        prediction: prediction,
         station_code: station_code,
         terminal?: terminal
       })
@@ -32,7 +32,7 @@ defmodule Content.Audio.FollowingTrain do
     [
       %__MODULE__{
         destination: destination,
-        route_id: route_id,
+        route_id: prediction.route_id,
         minutes: n,
         verb: arrives_or_departs(terminal),
         station_code: station_code

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -26,11 +26,11 @@ defmodule Content.Audio.NextTrainCountdown do
     [
       %__MODULE__{
         destination: message.destination,
-        route_id: message.route_id,
+        route_id: message.prediction.route_id,
         minutes: if(message.minutes == :approaching, do: 1, else: message.minutes),
         verb: if(message.terminal?, do: :departs, else: :arrives),
-        track_number: Content.Utilities.stop_track_number(message.stop_id),
-        platform: Content.Utilities.stop_platform(message.stop_id),
+        track_number: Content.Utilities.stop_track_number(message.prediction.stop_id),
+        platform: Content.Utilities.stop_platform(message.prediction.stop_id),
         station_code: message.station_code,
         zone: message.zone
       }

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -19,10 +19,10 @@ defmodule Content.Audio.StoppedTrain do
   def from_message(%Content.Message.StoppedTrain{
         destination: destination,
         stops_away: stops_away,
-        route_id: route_id
+        prediction: prediction
       })
       when stops_away > 0 do
-    [%__MODULE__{destination: destination, route_id: route_id, stops_away: stops_away}]
+    [%__MODULE__{destination: destination, route_id: prediction.route_id, stops_away: stops_away}]
   end
 
   def from_message(%Content.Message.StoppedTrain{stops_away: 0}) do

--- a/lib/content/audio/train_is_arriving.ex
+++ b/lib/content/audio/train_is_arriving.ex
@@ -22,9 +22,9 @@ defmodule Content.Audio.TrainIsArriving do
     [
       %__MODULE__{
         destination: message.destination,
-        trip_id: message.trip_id,
-        platform: Content.Utilities.stop_platform(message.stop_id),
-        route_id: message.route_id,
+        trip_id: message.prediction.trip_id,
+        platform: Content.Utilities.stop_platform(message.prediction.stop_id),
+        route_id: message.prediction.route_id,
         crowding_description: if(include_crowding?, do: message.crowding_description)
       }
     ]

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -22,17 +22,17 @@ defmodule Content.Audio.TrainIsBoarding do
       [
         %Audio.TrackChange{
           destination: message.destination,
-          route_id: message.route_id,
-          berth: message.stop_id
+          route_id: message.prediction.route_id,
+          berth: message.prediction.stop_id
         }
       ]
     else
       [
         %__MODULE__{
           destination: message.destination,
-          trip_id: message.trip_id,
-          route_id: message.route_id,
-          track_number: Content.Utilities.stop_track_number(message.stop_id)
+          trip_id: message.prediction.trip_id,
+          route_id: message.prediction.route_id,
+          track_number: Content.Utilities.stop_track_number(message.prediction.stop_id)
         }
       ] ++
         if message.station_code == "BBOW" && message.zone == "e" do

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -13,16 +13,12 @@ defmodule Content.Message.StoppedTrain do
   require Logger
 
   @enforce_keys [:destination, :stops_away]
-  defstruct @enforce_keys ++ [:certainty, :stop_id, :trip_id, :route_id, :direction_id]
+  defstruct @enforce_keys ++ [:prediction]
 
   @type t :: %__MODULE__{
           destination: PaEss.destination(),
           stops_away: non_neg_integer(),
-          certainty: non_neg_integer() | nil,
-          stop_id: String.t(),
-          trip_id: Predictions.Prediction.trip_id(),
-          route_id: String.t(),
-          direction_id: 0 | 1
+          prediction: Predictions.Prediction.t()
         }
 
   @spec from_prediction(Predictions.Prediction.t()) :: t() | nil
@@ -32,11 +28,7 @@ defmodule Content.Message.StoppedTrain do
     %__MODULE__{
       destination: Content.Utilities.destination_for_prediction(prediction),
       stops_away: stops_away,
-      certainty: prediction.arrival_certainty || prediction.departure_certainty,
-      stop_id: prediction.stop_id,
-      trip_id: prediction.trip_id,
-      route_id: prediction.route_id,
-      direction_id: prediction.direction_id
+      prediction: prediction
     }
   end
 

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -148,7 +148,7 @@ defmodule Signs.Utilities.Messages do
          %Content.Message.Predictions{
            station_code: "RJFK",
            zone: "m",
-           stop_id: stop_id,
+           prediction: %{stop_id: stop_id},
            minutes: minutes
          } = prediction
        ) do

--- a/test/content/audio/following_train_test.exs
+++ b/test/content/audio/following_train_test.exs
@@ -16,7 +16,7 @@ defmodule Content.Audio.FollowingTrainTest do
     test "when its a non terminal it uses arrives" do
       message = %Content.Message.Predictions{
         destination: :ashmont,
-        route_id: "Mattapan",
+        prediction: %Predictions.Prediction{route_id: "Mattapan"},
         minutes: 5,
         terminal?: false
       }
@@ -36,7 +36,7 @@ defmodule Content.Audio.FollowingTrainTest do
     test "when its a terminal it uses departs" do
       message = %Content.Message.Predictions{
         destination: :ashmont,
-        route_id: "Mattapan",
+        prediction: %Predictions.Prediction{route_id: "Mattapan"},
         minutes: 5,
         terminal?: true
       }

--- a/test/content/audio/stopped_train_test.exs
+++ b/test/content/audio/stopped_train_test.exs
@@ -53,7 +53,7 @@ defmodule Content.Audio.StoppedTrainTest do
     test "Converts a stopped train message with known headsign" do
       msg = %Content.Message.StoppedTrain{
         destination: :forest_hills,
-        route_id: "Orange",
+        prediction: %Predictions.Prediction{route_id: "Orange"},
         stops_away: 1
       }
 

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -103,20 +103,6 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Mattapan   20+ min"
     end
 
-    test "can use a shorter line length" do
-      prediction = %Predictions.Prediction{
-        seconds_until_arrival: 550,
-        route_id: "Mattapan",
-        direction_id: 0,
-        stopped?: false,
-        stops_away: 3,
-        destination_stop_id: "70275"
-      }
-
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign, 15)
-      assert Content.Message.to_string(msg) == "Mattapan  9 min"
-    end
-
     test "1 minute (singular) prediction" do
       prediction = %Predictions.Prediction{
         seconds_until_arrival: 65,
@@ -190,22 +176,6 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
 
       assert Content.Message.to_string(msg) == "Ashmont      2 min"
-    end
-
-    test "Includes the prediction's trip_id" do
-      prediction = %Predictions.Prediction{
-        seconds_until_arrival: 91,
-        route_id: "Mattapan",
-        direction_id: 1,
-        stopped?: false,
-        stops_away: 2,
-        destination_stop_id: "70261",
-        trip_id: "trip1"
-      }
-
-      msg = Content.Message.Predictions.non_terminal(prediction, "test", "m", @sign)
-
-      assert msg.trip_id == "trip1"
     end
 
     test "Includes Ashmont platform when northbound to JFK/UMass Mezzanine" do
@@ -349,22 +319,6 @@ defmodule Content.Message.PredictionsTest do
                {"Oak Grove    2 min", 6},
                {"Oak Grove    Trk 2", 6}
              ]
-    end
-
-    test "Includes the prediction's trip_id" do
-      prediction = %Predictions.Prediction{
-        seconds_until_departure: 91,
-        route_id: "Mattapan",
-        direction_id: 1,
-        stopped?: false,
-        stops_away: 2,
-        destination_stop_id: "70261",
-        trip_id: "trip1"
-      }
-
-      msg = Content.Message.Predictions.terminal(prediction, "test", "m", @sign)
-
-      assert msg.trip_id == "trip1"
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

Prediction and stopped-train messages, unsurprisingly, end up needing most of the fields from the underlying prediction. This stores a reference to the prediction struct itself, rather than copying each individual field, which simplifies the representation and reduces boilerplate. Also inlines the `width` parameter, which never actually varies.