### PR TITLE
use day-of-week based headway periods

### DIFF
--- a/lib/engine/config/headway.ex
+++ b/lib/engine/config/headway.ex
@@ -3,7 +3,7 @@ defmodule Engine.Config.Headway do
   defstruct @enforce_keys
 
   @type headway_group :: String.t()
-  @type time_period :: :peak | :off_peak
+  @type time_period :: :weekday | :saturday | :sunday
   @type headway_id :: {headway_group(), time_period()}
 
   @type t :: %__MODULE__{
@@ -12,40 +12,13 @@ defmodule Engine.Config.Headway do
           range_low: integer()
         }
 
-  @spec from_map(String.t(), String.t(), any()) :: {:ok, t()} | :error
-  def from_map(group, time_period, %{"range_high" => high, "range_low" => low})
-      when is_integer(high) and is_integer(low) do
-    case parse_time_period(time_period) do
-      {:ok, time_period} ->
-        {:ok,
-         %__MODULE__{
-           headway_id: {group, time_period},
-           range_high: high,
-           range_low: low
-         }}
-
-      :error ->
-        :error
-    end
-  end
-
-  def from_map(_, _, _), do: :error
-
   @spec current_time_period(DateTime.t()) :: time_period()
   def current_time_period(dt) do
-    day_of_week = dt |> DateTime.to_date() |> Date.day_of_week()
-
-    weekday? = day_of_week in 1..5
-
-    rush_hour? =
-      (dt.hour >= 7 and dt.hour < 9) or (dt.hour >= 16 and dt.hour < 18) or
-        (dt.hour == 18 and dt.minute <= 30)
-
-    if(weekday? and rush_hour?, do: :peak, else: :off_peak)
+    # Subtract 3 hours, since the service day ends at 3 AM
+    case DateTime.add(dt, -3, :hour) |> Date.day_of_week() do
+      6 -> :saturday
+      7 -> :sunday
+      _ -> :weekday
+    end
   end
-
-  @spec parse_time_period(String.t()) :: {:ok, time_period()} | :error
-  defp parse_time_period("peak"), do: {:ok, :peak}
-  defp parse_time_period("off_peak"), do: {:ok, :off_peak}
-  defp parse_time_period(_), do: :error
 end

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -25,7 +25,7 @@ defmodule Fake.ExternalConfig.Local do
         "signs" => %{},
         "configured_headways" => %{
           "custom_headway" => %{
-            "peak" => %{"range_high" => 10, "range_low" => 8}
+            "weekday" => %{"range_high" => 10, "range_low" => 8}
           }
         }
       }

--- a/test/engine/config/headway_test.exs
+++ b/test/engine/config/headway_test.exs
@@ -2,48 +2,19 @@ defmodule Engine.Config.HeadwayTest do
   use ExUnit.Case, async: true
   alias Engine.Config.Headway
 
-  describe "from_map/2" do
-    test "parses successfully" do
-      assert Headway.from_map("A", "peak", %{"range_low" => 5, "range_high" => 10}) ==
-               {:ok, %Headway{headway_id: {"A", :peak}, range_low: 5, range_high: 10}}
-    end
-
-    test "returns error for invalid data" do
-      assert Headway.from_map("A", "peak", %{}) == :error
-    end
-
-    test "returns error for invalid time period" do
-      assert Headway.from_map("A", "invalid", %{"range_low" => 5, "range_high" => 10}) == :error
-    end
-  end
-
   describe "current_time_period/1" do
-    test "correctly determines peak and offpeak" do
-      dt1 = DateTime.from_naive!(~N[2020-03-20 06:00:00], "America/New_York")
-      dt2 = DateTime.from_naive!(~N[2020-03-20 07:00:00], "America/New_York")
-      dt3 = DateTime.from_naive!(~N[2020-03-20 07:45:00], "America/New_York")
-      dt4 = DateTime.from_naive!(~N[2020-03-20 09:00:01], "America/New_York")
-      dt5 = DateTime.from_naive!(~N[2020-03-20 12:00:00], "America/New_York")
-      dt6 = DateTime.from_naive!(~N[2020-03-20 15:00:00], "America/New_York")
-      dt7 = DateTime.from_naive!(~N[2020-03-20 16:00:00], "America/New_York")
-      dt8 = DateTime.from_naive!(~N[2020-03-20 18:00:00], "America/New_York")
-      dt9 = DateTime.from_naive!(~N[2020-03-20 18:20:00], "America/New_York")
-      dt10 = DateTime.from_naive!(~N[2020-03-20 18:40:00], "America/New_York")
-      dt11 = DateTime.from_naive!(~N[2020-03-21 06:00:00], "America/New_York")
-      dt12 = DateTime.from_naive!(~N[2020-03-21 08:00:00], "America/New_York")
+    test "correctly determines day" do
+      assert DateTime.new!(~D[2020-03-20], ~T[06:00:00], "America/New_York")
+             |> Headway.current_time_period() == :weekday
 
-      assert Headway.current_time_period(dt1) == :off_peak
-      assert Headway.current_time_period(dt2) == :peak
-      assert Headway.current_time_period(dt3) == :peak
-      assert Headway.current_time_period(dt4) == :off_peak
-      assert Headway.current_time_period(dt5) == :off_peak
-      assert Headway.current_time_period(dt6) == :off_peak
-      assert Headway.current_time_period(dt7) == :peak
-      assert Headway.current_time_period(dt8) == :peak
-      assert Headway.current_time_period(dt9) == :peak
-      assert Headway.current_time_period(dt10) == :off_peak
-      assert Headway.current_time_period(dt11) == :off_peak
-      assert Headway.current_time_period(dt12) == :off_peak
+      assert DateTime.new!(~D[2020-03-21], ~T[02:00:00], "America/New_York")
+             |> Headway.current_time_period() == :weekday
+
+      assert DateTime.new!(~D[2020-03-21], ~T[04:00:00], "America/New_York")
+             |> Headway.current_time_period() == :saturday
+
+      assert DateTime.new!(~D[2020-03-22], ~T[08:00:00], "America/New_York")
+             |> Headway.current_time_period() == :sunday
     end
   end
 end

--- a/test/engine/config/headways_test.exs
+++ b/test/engine/config/headways_test.exs
@@ -10,29 +10,29 @@ defmodule Engine.Config.HeadwaysTest do
 
       :ok =
         Headways.update_table(table, [
-          %Headway{headway_id: {"A", :peak}, range_low: 8, range_high: 10},
-          %Headway{headway_id: {"B", :off_peak}, range_low: 10, range_high: 12}
+          %Headway{headway_id: {"A", :weekday}, range_low: 8, range_high: 10},
+          %Headway{headway_id: {"B", :saturday}, range_low: 10, range_high: 12}
         ])
 
-      assert %Headway{headway_id: {"A", :peak}, range_low: 8, range_high: 10} =
-               Headways.get_headway(table, {"A", :peak})
+      assert %Headway{headway_id: {"A", :weekday}, range_low: 8, range_high: 10} =
+               Headways.get_headway(table, {"A", :weekday})
 
-      assert %Headway{headway_id: {"B", :off_peak}, range_low: 10, range_high: 12} =
-               Headways.get_headway(table, {"B", :off_peak})
+      assert %Headway{headway_id: {"B", :saturday}, range_low: 10, range_high: 12} =
+               Headways.get_headway(table, {"B", :saturday})
 
       :ok =
         Headways.update_table(table, [
-          %Headway{headway_id: {"B", :off_peak}, range_low: 12, range_high: 14},
-          %Headway{headway_id: {"C", :peak}, range_low: 8, range_high: 10}
+          %Headway{headway_id: {"B", :saturday}, range_low: 12, range_high: 14},
+          %Headway{headway_id: {"C", :weekday}, range_low: 8, range_high: 10}
         ])
 
-      refute Headways.get_headway(table, {"A", :peak})
+      refute Headways.get_headway(table, {"A", :weekday})
 
-      assert %Headway{headway_id: {"B", :off_peak}, range_low: 12, range_high: 14} =
-               Headways.get_headway(table, {"B", :off_peak})
+      assert %Headway{headway_id: {"B", :saturday}, range_low: 12, range_high: 14} =
+               Headways.get_headway(table, {"B", :saturday})
 
-      assert %Headway{headway_id: {"C", :peak}, range_low: 8, range_high: 10} =
-               Headways.get_headway(table, {"C", :peak})
+      assert %Headway{headway_id: {"C", :weekday}, range_low: 8, range_high: 10} =
+               Headways.get_headway(table, {"C", :weekday})
     end
   end
 
@@ -40,21 +40,21 @@ defmodule Engine.Config.HeadwaysTest do
     test "parses data and ignores invalid entries" do
       data = %{
         "red_trunk" => %{
-          "peak" => %{
+          "weekday" => %{
             "range_low" => 8,
             "range_high" => 10
           },
-          "off_peak" => %{
+          "saturday" => %{
             "range_low" => 12,
             "range_high" => 15
           }
         },
         "red_braintree" => %{
-          "peak" => %{
+          "weekday" => %{
             "range_low" => 16,
             "range_high" => 20
           },
-          "off_peak" => %{
+          "saturday" => %{
             "range_low" => 24,
             "range_high" => 30
           },
@@ -67,10 +67,10 @@ defmodule Engine.Config.HeadwaysTest do
       headways = Headways.parse(data)
 
       assert [
-               %Headway{headway_id: {"red_braintree", :off_peak}, range_low: 24, range_high: 30},
-               %Headway{headway_id: {"red_braintree", :peak}, range_low: 16, range_high: 20},
-               %Headway{headway_id: {"red_trunk", :off_peak}, range_low: 12, range_high: 15},
-               %Headway{headway_id: {"red_trunk", :peak}, range_low: 8, range_high: 10}
+               %Headway{headway_id: {"red_braintree", :saturday}, range_low: 24, range_high: 30},
+               %Headway{headway_id: {"red_braintree", :weekday}, range_low: 16, range_high: 20},
+               %Headway{headway_id: {"red_trunk", :saturday}, range_low: 12, range_high: 15},
+               %Headway{headway_id: {"red_trunk", :weekday}, range_low: 8, range_high: 10}
              ] = Enum.sort(headways)
     end
   end

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -154,7 +154,12 @@ defmodule Engine.ScheduledHeadwaysTest do
     test "returns true/false depending on time" do
       table = :display_headways_test
       stop = "stop"
-      headways = %Engine.Config.Headway{headway_id: {"test", :peak}, range_high: 12, range_low: 5}
+
+      headways = %Engine.Config.Headway{
+        headway_id: {"test", :weekday},
+        range_high: 12,
+        range_low: 5
+      }
 
       first_departure = DateTime.from_naive!(~N[2020-03-24 10:00:00], "America/New_York")
       last_departure = DateTime.from_naive!(~N[2020-03-25 01:00:00], "America/New_York")
@@ -196,7 +201,12 @@ defmodule Engine.ScheduledHeadwaysTest do
       early_last_dep = DateTime.from_naive!(~N[2020-03-21 00:00:00], "America/New_York")
       later_last_dep = DateTime.from_naive!(~N[2020-03-21 02:00:00], "America/New_York")
       no_service_late = DateTime.from_naive!(~N[2020-03-21 01:00:00], "America/New_York")
-      headways = %Engine.Config.Headway{headway_id: {"test", :peak}, range_high: 0, range_low: 0}
+
+      headways = %Engine.Config.Headway{
+        headway_id: {"test", :weekday},
+        range_high: 0,
+        range_low: 0
+      }
 
       :ets.new(table, @ets_table_params)
       :ets.insert(table, {"stop1", {early_first_dep, later_last_dep}})
@@ -220,7 +230,12 @@ defmodule Engine.ScheduledHeadwaysTest do
     test "handles when the only departure times are nil" do
       table = :dh_nil_test
       datetime = DateTime.from_naive!(~N[2020-03-20 12:00:00], "America/New_York")
-      headways = %Engine.Config.Headway{headway_id: {"test", :peak}, range_high: 0, range_low: 0}
+
+      headways = %Engine.Config.Headway{
+        headway_id: {"test", :weekday},
+        range_high: 0,
+        range_low: 0
+      }
 
       :ets.new(table, @ets_table_params)
       :ets.insert(table, {"stop_id", {nil, nil}})
@@ -232,13 +247,25 @@ defmodule Engine.ScheduledHeadwaysTest do
     test "returns false if missing first/last trip timing" do
       :ets.new(:no_data, @ets_table_params)
       time = DateTime.from_naive!(~N[2020-03-20 10:00:00], "America/New_York")
-      headways = %Engine.Config.Headway{headway_id: {"test", :peak}, range_high: 0, range_low: 0}
+
+      headways = %Engine.Config.Headway{
+        headway_id: {"test", :weekday},
+        range_high: 0,
+        range_low: 0
+      }
+
       refute Engine.ScheduledHeadways.display_headways?(:no_data, ["no_stop"], time, headways)
     end
 
     test "display_headways?/3 fills in ETS table name" do
       time = DateTime.from_naive!(~N[2020-03-20 10:00:00], "America/New_York")
-      headways = %Engine.Config.Headway{headway_id: {"test", :peak}, range_high: 0, range_low: 0}
+
+      headways = %Engine.Config.Headway{
+        headway_id: {"test", :weekday},
+        range_high: 0,
+        range_low: 0
+      }
+
       refute Engine.ScheduledHeadways.display_headways?(["no_data"], time, headways)
     end
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change RTS to read these new values, handle appropriately](https://app.asana.com/0/1185117109217413/1208512927678681/f)

This switches to reading the new day-of-week based headway periods.

Also modifies the config parsing code so it doesn't log errors when encountering unexpected data (which we'll have during the transition). Note that the current code _will_ log errors in this case, so we expect to see some errors logged between deploying the signs-ui change and deploying this.