### PR TITLE
use new headway periods

### DIFF
--- a/test/engine/config/headway_test.exs
+++ b/test/engine/config/headway_test.exs
@@ -19,31 +19,17 @@ defmodule Engine.Config.HeadwayTest do
 
   describe "current_time_period/1" do
     test "correctly determines peak and offpeak" do
-      dt1 = DateTime.from_naive!(~N[2020-03-20 06:00:00], "America/New_York")
-      dt2 = DateTime.from_naive!(~N[2020-03-20 07:00:00], "America/New_York")
-      dt3 = DateTime.from_naive!(~N[2020-03-20 07:45:00], "America/New_York")
-      dt4 = DateTime.from_naive!(~N[2020-03-20 09:00:01], "America/New_York")
-      dt5 = DateTime.from_naive!(~N[2020-03-20 12:00:00], "America/New_York")
-      dt6 = DateTime.from_naive!(~N[2020-03-20 15:00:00], "America/New_York")
-      dt7 = DateTime.from_naive!(~N[2020-03-20 16:00:00], "America/New_York")
-      dt8 = DateTime.from_naive!(~N[2020-03-20 18:00:00], "America/New_York")
-      dt9 = DateTime.from_naive!(~N[2020-03-20 18:20:00], "America/New_York")
-      dt10 = DateTime.from_naive!(~N[2020-03-20 18:40:00], "America/New_York")
-      dt11 = DateTime.from_naive!(~N[2020-03-21 06:00:00], "America/New_York")
-      dt12 = DateTime.from_naive!(~N[2020-03-21 08:00:00], "America/New_York")
+      assert DateTime.new!(~D[2020-03-20], ~T[18:00:00], "America/New_York")
+             |> Headway.current_time_period() == :peak
 
-      assert Headway.current_time_period(dt1) == :off_peak
-      assert Headway.current_time_period(dt2) == :peak
-      assert Headway.current_time_period(dt3) == :peak
-      assert Headway.current_time_period(dt4) == :off_peak
-      assert Headway.current_time_period(dt5) == :off_peak
-      assert Headway.current_time_period(dt6) == :off_peak
-      assert Headway.current_time_period(dt7) == :peak
-      assert Headway.current_time_period(dt8) == :peak
-      assert Headway.current_time_period(dt9) == :peak
-      assert Headway.current_time_period(dt10) == :off_peak
-      assert Headway.current_time_period(dt11) == :off_peak
-      assert Headway.current_time_period(dt12) == :off_peak
+      assert DateTime.new!(~D[2020-03-21], ~T[02:00:00], "America/New_York")
+             |> Headway.current_time_period() == :off_peak
+
+      assert DateTime.new!(~D[2020-03-21], ~T[08:00:00], "America/New_York")
+             |> Headway.current_time_period() == :saturday
+
+      assert DateTime.new!(~D[2020-03-22], ~T[12:00:00], "America/New_York")
+             |> Headway.current_time_period() == :sunday
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change RTS to read these new values, handle appropriately](https://app.asana.com/0/1185117109217413/1208512927678681/f)

This supersedes #837 after we realized that the requirements weren't quite right. Switches to reading the new headway periods.