### PR TITLE
show destination-based alert message on platform signs

### DIFF
--- a/lib/content/audio/no_service.ex
+++ b/lib/content/audio/no_service.ex
@@ -85,20 +85,20 @@ defmodule Content.Audio.NoService do
            use_shuttle?: use_shuttle?,
            use_routes?: use_routes?
          }) do
-      shuttle = if(use_shuttle?, do: " Use shuttle.", else: "")
-
-      cond do
-        use_routes? ->
+      suffix =
+        cond do
+          use_shuttle? -> " Use shuttle."
           # Hardcoded for Union Square
-          "No Train Service. Use routes 86, 87, or 91"
+          use_routes? -> " Use routes 86, 87, or 91"
+          true -> ""
+        end
 
-        destination ->
-          {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
-          "No #{destination_text} service.#{shuttle}"
-
-        true ->
-          line = if(route, do: "#{route} Line", else: "train")
-          "There is no #{line} service at this station.#{shuttle}"
+      if destination do
+        {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
+        "No #{destination_text} service.#{suffix}"
+      else
+        line = if(route, do: "#{route} Line", else: "train")
+        "There is no #{line} service at this station.#{suffix}"
       end
     end
   end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -239,33 +239,37 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
-  defp alert_messages(alert_status, %{pa_ess_loc: "GUNS"}, _) do
+  defp alert_messages(alert_status, %{pa_ess_loc: "GUNS"}, config) do
+    route = Signs.Utilities.SourceConfig.single_route(config)
+    destination = config.headway_destination
+
     if alert_status in [:none, :alert_along_route],
       do: nil,
-      else: {%Alert.NoService{}, %Alert.UseRoutes{}}
+      else: {%Alert.NoService{route: route, destination: destination}, %Alert.UseRoutes{}}
   end
 
   defp alert_messages(alert_status, sign, config) do
     route = Signs.Utilities.SourceConfig.single_route(config)
+    destination = config.headway_destination
 
     case {alert_status, sign.uses_shuttles} do
       {:shuttles_transfer_station, _} ->
         {%Content.Message.Empty{}, %Content.Message.Empty{}}
 
       {:shuttles_closed_station, true} ->
-        {%Alert.NoService{route: route}, %Alert.UseShuttleBus{}}
+        {%Alert.NoService{route: route, destination: destination}, %Alert.UseShuttleBus{}}
 
       {:shuttles_closed_station, false} ->
-        {%Alert.NoService{route: route}, %Content.Message.Empty{}}
+        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
 
       {:suspension_transfer_station, _} ->
         {%Content.Message.Empty{}, %Content.Message.Empty{}}
 
       {:suspension_closed_station, _} ->
-        {%Alert.NoService{route: route}, %Content.Message.Empty{}}
+        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
 
       {:station_closure, _} ->
-        {%Alert.NoService{route: route}, %Content.Message.Empty{}}
+        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
 
       _ ->
         nil

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -275,10 +275,10 @@ defmodule Signs.RealtimeTest do
 
     test "when sign is at a station closed by shuttles and there are no predictions, it says so" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
-      expect_messages({"No Red Line", "Use shuttle bus"})
+      expect_messages({"No Southbound svc", "Use shuttle bus"})
 
-      expect_audios([{:canned, {"199", ["3005"], :audio}}], [
-        {"There is no Red Line service at this station. Use shuttle.", nil}
+      expect_audios([{:ad_hoc, {"No Southbound service. Use shuttle.", :audio}}], [
+        {"No Southbound service. Use shuttle.", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -286,23 +286,43 @@ defmodule Signs.RealtimeTest do
 
     test "when sign is at a station closed and there are no predictions, but shuttles do not run at this station" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
-      expect_messages({"No Red Line", ""})
-      expect_audios([@no_service_audio], [{"There is no Red Line service at this station.", nil}])
+      expect_messages({"No Southbound svc", ""})
+
+      expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
+        {"No Southbound service.", nil}
+      ])
+
       Signs.Realtime.handle_info(:run_loop, %{@sign | uses_shuttles: false})
     end
 
     test "when sign is at a station closed due to suspension and there are no predictions, it says so" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_closed_station end)
-      expect_messages({"No Red Line", ""})
-      expect_audios([@no_service_audio], [{"There is no Red Line service at this station.", nil}])
+      expect_messages({"No Southbound svc", ""})
+
+      expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
+        {"No Southbound service.", nil}
+      ])
+
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
     test "when sign is at a closed station and there are no predictions, it says so" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect_messages({"No Southbound svc", ""})
+
+      expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
+        {"No Southbound service.", nil}
+      ])
+
+      assert {_, %{announced_alert: true}} = Signs.Realtime.handle_info(:run_loop, @sign)
+    end
+
+    test "mezzanine sign with alert" do
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
       expect_messages({"No Red Line", ""})
       expect_audios([@no_service_audio], [{"There is no Red Line service at this station.", nil}])
-      assert {_, %{announced_alert: true}} = Signs.Realtime.handle_info(:run_loop, @sign)
+      Signs.Realtime.handle_info(:run_loop, @mezzanine_sign)
     end
 
     test "multi-route mezzanine sign with alert" do
@@ -384,8 +404,12 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
-      expect_messages({"No Red Line", ""})
-      expect_audios([@no_service_audio], [{"There is no Red Line service at this station.", nil}])
+      expect_messages({"No Southbound svc", ""})
+
+      expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
+        {"No Southbound service.", nil}
+      ])
+
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
@@ -925,10 +949,10 @@ defmodule Signs.RealtimeTest do
 
     test "reads alerts" do
       expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
-      expect_messages({"No Red Line", "Use shuttle bus"})
+      expect_messages({"No Southbound svc", "Use shuttle bus"})
 
-      expect_audios([{:canned, {"199", ["3005"], :audio}}], [
-        {"There is no Red Line service at this station. Use shuttle.", nil}
+      expect_audios([{:ad_hoc, {"No Southbound service. Use shuttle.", :audio}}], [
+        {"No Southbound service. Use shuttle.", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_alert: true})
@@ -1598,10 +1622,10 @@ defmodule Signs.RealtimeTest do
           text_zone: "x"
       }
 
-      expect_messages({"No train service", "Use Routes 86, 87, or 91"})
+      expect_messages({"No Southbound svc", "Use Routes 86, 87, or 91"})
 
-      expect_audios([{:ad_hoc, {"No Train Service. Use routes 86, 87, or 91", :audio}}], [
-        {"No Train Service. Use routes 86, 87, or 91", nil}
+      expect_audios([{:ad_hoc, {"No Southbound service. Use routes 86, 87, or 91", :audio}}], [
+        {"No Southbound service. Use routes 86, 87, or 91", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, sign)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Use destination instead of line name in alerts on platforms](https://app.asana.com/0/1185117109217422/1208651234672895/f)

This uses destination-specific language when showing alert messages on platform signs, as described in the ticket.