### PR TITLE
modify Spanish voice and bridge message

### DIFF
--- a/lib/content/audio.ex
+++ b/lib/content/audio.ex
@@ -15,7 +15,8 @@ defprotocol Content.Audio do
 
   @type language :: :english | :spanish
   @type value :: canned_message() | ad_hoc_message() | nil
-  @type tts_value :: {audio :: String.t(), visual :: Content.Message.pages() | nil}
+  @type tts_value ::
+          {audio :: String.t() | {:spanish, String.t()}, visual :: Content.Message.pages() | nil}
 
   @doc "Converts an audio struct to the mid/vars params for the PA system"
   @spec to_params(Content.Audio.t()) :: value()

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -690,22 +690,22 @@ defmodule Signs.Bus do
       {duration, duration_spanish} =
         case bridge_status_minutes(bridge_status, current_time) do
           minutes when minutes < 2 ->
-            {"We expect it to be lowered soon.", "Esperamos que se baje pronto."}
+            {"We expect it to be lowered soon.", "Esperamos que cierre pronto."}
 
           minutes ->
             {"We expect this to last for at least #{minutes} more minutes.",
-             "Esperamos que esto dure al menos #{minutes} minutos más."}
+             "Permanecerá abierto aproximadamente #{minutes} minutos."}
         end
 
       english_text =
         "The Chelsea Street bridge is raised. #{duration} SL3 buses may be delayed, detoured, or turned back."
 
       spanish_text =
-        "El puente de Chelsea Street está levantado. #{duration_spanish} Los autobuses SL3 pueden sufrir retrasos, desvíos o dar marcha atrás."
+        "El puente levadizo de Chelsea está abierto. #{duration_spanish} Autobuses S.L. tres pueden experimentar retrasos, ser desviados o devueltos."
 
       [
         {english_text, PaEss.Utilities.paginate_text(english_text)},
-        {spanish_text, PaEss.Utilities.paginate_text(spanish_text)}
+        {{:spanish, spanish_text}, PaEss.Utilities.paginate_text(spanish_text)}
       ]
     else
       []

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -313,13 +313,16 @@ defmodule Signs.BusTest do
              {"SL3 buses may be", "delayed, detoured, or", 3},
              {"turned back.", "", 3}
            ]},
-          {"El puente de Chelsea Street está levantado. Esperamos que esto dure al menos 4 minutos más. Los autobuses SL3 pueden sufrir retrasos, desvíos o dar marcha atrás.",
-           [
-             {"El puente de Chelsea", "Street está levantado.", 3},
-             {"Esperamos que esto dure", "al menos 4 minutos más.", 3},
-             {"Los autobuses SL3 pueden", "sufrir retrasos, desvíos", 3},
-             {"o dar marcha atrás.", "", 3}
-           ]}
+          {
+            {:spanish,
+             "El puente levadizo de Chelsea está abierto. Permanecerá abierto aproximadamente 4 minutos. Autobuses S.L. tres pueden experimentar retrasos, ser desviados o devueltos."},
+            [
+              {"El puente levadizo de", "Chelsea está abierto.", 3},
+              {"Permanecerá abierto", "aproximadamente 4", 3},
+              {"minutos. Autobuses S.L.", "tres pueden experimentar", 3},
+              {"retrasos, ser desviados", "o devueltos.", 3}
+            ]
+          }
         ]
       )
 
@@ -347,13 +350,16 @@ defmodule Signs.BusTest do
              {"SL3 buses may be", "delayed, detoured, or", 3},
              {"turned back.", "", 3}
            ]},
-          {"El puente de Chelsea Street está levantado. Esperamos que esto dure al menos 4 minutos más. Los autobuses SL3 pueden sufrir retrasos, desvíos o dar marcha atrás.",
-           [
-             {"El puente de Chelsea", "Street está levantado.", 3},
-             {"Esperamos que esto dure", "al menos 4 minutos más.", 3},
-             {"Los autobuses SL3 pueden", "sufrir retrasos, desvíos", 3},
-             {"o dar marcha atrás.", "", 3}
-           ]}
+          {
+            {:spanish,
+             "El puente levadizo de Chelsea está abierto. Permanecerá abierto aproximadamente 4 minutos. Autobuses S.L. tres pueden experimentar retrasos, ser desviados o devueltos."},
+            [
+              {"El puente levadizo de", "Chelsea está abierto.", 3},
+              {"Permanecerá abierto", "aproximadamente 4", 3},
+              {"minutos. Autobuses S.L.", "tres pueden experimentar", 3},
+              {"retrasos, ser desviados", "o devueltos.", 3}
+            ]
+          }
         ]
       )
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change voice and parameters used when generating Spanish audio, and use updated Spanish TTS content](https://app.asana.com/0/1185117109217413/1208634633982700/f)

This changes the Spanish bridge message as outlined in the ticket, using the "Mia" voice. Adds the appropriate SSML wrapper around all audio messages.

Note that we're generating accented characters, but the sign is not capable of displaying them. This will be followed by a Scully PR to strip accents during display.