### PR TITLE
remove unused fallbacks for destination utils

### DIFF
--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -33,7 +33,7 @@ defmodule Content.Audio.FirstTrainScheduled do
           destination: destination,
           scheduled_time: scheduled_time
         }) do
-      {:ok, destination} = PaEss.Utilities.destination_var(destination)
+      destination = PaEss.Utilities.destination_var(destination)
 
       vars = [
         @the_first,

--- a/lib/content/audio/following_train.ex
+++ b/lib/content/audio/following_train.ex
@@ -55,27 +55,23 @@ defmodule Content.Audio.FollowingTrain do
     @minute "532"
 
     def to_params(audio) do
-      case Utilities.destination_var(audio.destination) do
-        {:ok, dest_var} ->
-          if Utilities.directional_destination?(audio.destination) do
-            do_ad_hoc_message(audio)
-          else
-            green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
+      dest_var = Utilities.destination_var(audio.destination)
 
-            cond do
-              !is_nil(green_line_branch) ->
-                green_line_with_branch_params(audio, green_line_branch, dest_var)
+      if Utilities.directional_destination?(audio.destination) do
+        do_ad_hoc_message(audio)
+      else
+        green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
 
-              audio.minutes == 1 ->
-                {:canned, {"159", [dest_var, verb_var(audio)], :audio}}
+        cond do
+          !is_nil(green_line_branch) ->
+            green_line_with_branch_params(audio, green_line_branch, dest_var)
 
-              true ->
-                {:canned, {"160", [dest_var, verb_var(audio), minutes_var(audio)], :audio}}
-            end
-          end
+          audio.minutes == 1 ->
+            {:canned, {"159", [dest_var, verb_var(audio)], :audio}}
 
-        {:error, :unknown} ->
-          do_ad_hoc_message(audio)
+          true ->
+            {:canned, {"160", [dest_var, verb_var(audio), minutes_var(audio)], :audio}}
+        end
       end
     end
 

--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -49,45 +49,39 @@ defmodule Content.Audio.NextTrainCountdown do
     @platform_when_closer "857"
 
     def to_params(audio) do
-      case Utilities.destination_var(audio.destination) do
-        {:ok, dest_var} ->
-          green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
+      dest_var = Utilities.destination_var(audio.destination)
+      green_line_branch = Content.Utilities.route_branch_letter(audio.route_id)
 
-          cond do
-            Utilities.directional_destination?(audio.destination) ->
-              do_ad_hoc_message(audio)
-
-            !is_nil(audio.track_number) ->
-              terminal_track_params(audio, dest_var)
-
-            !is_nil(green_line_branch) ->
-              green_line_with_branch_params(audio, green_line_branch, dest_var)
-
-            is_nil(audio.platform) and audio.minutes == 1 ->
-              {:canned, {"141", [dest_var, verb_var(audio)], :audio}}
-
-            is_nil(audio.platform) ->
-              {:canned, {"90", [dest_var, verb_var(audio), minutes_var(audio)], :audio}}
-
-            audio.minutes == 1 ->
-              {:canned, {"142", [dest_var, platform_var(audio), verb_var(audio)], :audio}}
-
-            audio.destination == :alewife and audio.special_sign == :jfk_mezzanine and
-                audio.minutes > 5 ->
-              platform_tbd_params(
-                audio,
-                dest_var,
-                if(audio.minutes < 10, do: @platform_soon, else: @platform_when_closer)
-              )
-
-            true ->
-              {:canned,
-               {"98", [dest_var, verb_var(audio), minutes_var(audio), platform_var(audio)],
-                :audio}}
-          end
-
-        {:error, :unknown} ->
+      cond do
+        Utilities.directional_destination?(audio.destination) ->
           do_ad_hoc_message(audio)
+
+        !is_nil(audio.track_number) ->
+          terminal_track_params(audio, dest_var)
+
+        !is_nil(green_line_branch) ->
+          green_line_with_branch_params(audio, green_line_branch, dest_var)
+
+        is_nil(audio.platform) and audio.minutes == 1 ->
+          {:canned, {"141", [dest_var, verb_var(audio)], :audio}}
+
+        is_nil(audio.platform) ->
+          {:canned, {"90", [dest_var, verb_var(audio), minutes_var(audio)], :audio}}
+
+        audio.minutes == 1 ->
+          {:canned, {"142", [dest_var, platform_var(audio), verb_var(audio)], :audio}}
+
+        audio.destination == :alewife and audio.special_sign == :jfk_mezzanine and
+            audio.minutes > 5 ->
+          platform_tbd_params(
+            audio,
+            dest_var,
+            if(audio.minutes < 10, do: @platform_soon, else: @platform_when_closer)
+          )
+
+        true ->
+          {:canned,
+           {"98", [dest_var, verb_var(audio), minutes_var(audio), platform_var(audio)], :audio}}
       end
     end
 

--- a/lib/content/audio/no_service.ex
+++ b/lib/content/audio/no_service.ex
@@ -94,7 +94,7 @@ defmodule Content.Audio.NoService do
         end
 
       if destination do
-        {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
+        destination_text = PaEss.Utilities.destination_to_ad_hoc_string(destination)
         "No #{destination_text} service.#{suffix}"
       else
         line = if(route, do: "#{route} Line", else: "train")

--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -32,28 +32,14 @@ defmodule Content.Audio.ServiceEnded do
       Utilities.take_message([line_var, @service_ended], :audio)
     end
 
-    def to_params(
-          %Content.Audio.ServiceEnded{location: :platform, destination: destination} = audio
-        ) do
-      case Utilities.destination_var(destination) do
-        {:ok, destination_var} ->
-          Utilities.take_message([@platform_closed, destination_var, @service_ended], :audio)
-
-        {:error, :unknown} ->
-          {:ad_hoc, {tts_text(audio), :audio}}
-      end
+    def to_params(%Content.Audio.ServiceEnded{location: :platform, destination: destination}) do
+      destination_var = Utilities.destination_var(destination)
+      Utilities.take_message([@platform_closed, destination_var, @service_ended], :audio)
     end
 
-    def to_params(
-          %Content.Audio.ServiceEnded{location: :direction, destination: destination} = audio
-        ) do
-      case Utilities.destination_var(destination) do
-        {:ok, destination_var} ->
-          Utilities.take_message([destination_var, @service_ended], :audio)
-
-        {:error, :unknown} ->
-          {:ad_hoc, {tts_text(audio), :audio}}
-      end
+    def to_params(%Content.Audio.ServiceEnded{location: :direction, destination: destination}) do
+      destination_var = Utilities.destination_var(destination)
+      Utilities.take_message([destination_var, @service_ended], :audio)
     end
 
     def to_tts(%Content.Audio.ServiceEnded{} = audio) do
@@ -70,12 +56,12 @@ defmodule Content.Audio.ServiceEnded do
     end
 
     defp tts_text(%Content.Audio.ServiceEnded{location: :platform, destination: destination}) do
-      {:ok, destination_string} = Utilities.destination_to_ad_hoc_string(destination)
+      destination_string = Utilities.destination_to_ad_hoc_string(destination)
       "This platform is closed. #{destination_string} service has ended for the night."
     end
 
     defp tts_text(%Content.Audio.ServiceEnded{location: :direction, destination: destination}) do
-      {:ok, destination_string} = Utilities.destination_to_ad_hoc_string(destination)
+      destination_string = Utilities.destination_to_ad_hoc_string(destination)
       "#{destination_string} service has ended for the night."
     end
   end

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -41,15 +41,13 @@ defmodule Content.Audio.StoppedTrain do
     @stopped "641"
 
     def to_params(audio) do
-      dest_var = PaEss.Utilities.destination_var(audio.destination)
-
       if Utilities.directional_destination?(audio.destination) do
         do_ad_hoc_message(audio)
       else
         vars = [
           @the_next,
           @train_to,
-          dest_var,
+          PaEss.Utilities.destination_var(audio.destination),
           @is,
           @stopped,
           number_var(audio.stops_away),

--- a/lib/content/audio/stopped_train.ex
+++ b/lib/content/audio/stopped_train.ex
@@ -41,26 +41,22 @@ defmodule Content.Audio.StoppedTrain do
     @stopped "641"
 
     def to_params(audio) do
-      case PaEss.Utilities.destination_var(audio.destination) do
-        {:ok, dest_var} ->
-          if Utilities.directional_destination?(audio.destination) do
-            do_ad_hoc_message(audio)
-          else
-            vars = [
-              @the_next,
-              @train_to,
-              dest_var,
-              @is,
-              @stopped,
-              number_var(audio.stops_away),
-              stops_away_var(audio.stops_away)
-            ]
+      dest_var = PaEss.Utilities.destination_var(audio.destination)
 
-            PaEss.Utilities.take_message(vars, :audio)
-          end
+      if Utilities.directional_destination?(audio.destination) do
+        do_ad_hoc_message(audio)
+      else
+        vars = [
+          @the_next,
+          @train_to,
+          dest_var,
+          @is,
+          @stopped,
+          number_var(audio.stops_away),
+          stops_away_var(audio.stops_away)
+        ]
 
-        {:error, :unknown} ->
-          do_ad_hoc_message(audio)
+        PaEss.Utilities.take_message(vars, :audio)
       end
     end
 

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -51,16 +51,12 @@ defmodule Content.Audio.TrainIsBoarding do
     @on_track_2 "542"
 
     def to_params(audio) do
-      case PaEss.Utilities.destination_var(audio.destination) do
-        {:ok, destination_var} ->
-          if PaEss.Utilities.directional_destination?(audio.destination) do
-            do_ad_hoc_message(audio)
-          else
-            do_to_params(audio, destination_var)
-          end
+      destination_var = PaEss.Utilities.destination_var(audio.destination)
 
-        {:error, :unknown} ->
-          do_ad_hoc_message(audio)
+      if PaEss.Utilities.directional_destination?(audio.destination) do
+        do_ad_hoc_message(audio)
+      else
+        do_to_params(audio, destination_var)
       end
     end
 

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -51,12 +51,10 @@ defmodule Content.Audio.TrainIsBoarding do
     @on_track_2 "542"
 
     def to_params(audio) do
-      destination_var = PaEss.Utilities.destination_var(audio.destination)
-
       if PaEss.Utilities.directional_destination?(audio.destination) do
         do_ad_hoc_message(audio)
       else
-        do_to_params(audio, destination_var)
+        do_to_params(audio, PaEss.Utilities.destination_var(audio.destination))
       end
     end
 

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -70,7 +70,7 @@ defmodule Content.Audio.VehiclesToDestination do
             "#{route} line trains"
 
           {destination, _} ->
-            {:ok, destination_text} = PaEss.Utilities.destination_to_ad_hoc_string(destination)
+            destination_text = PaEss.Utilities.destination_to_ad_hoc_string(destination)
             "#{destination_text} trains"
         end
 

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -177,70 +177,68 @@ defmodule PaEss.Utilities do
   end
 
   @doc "Take ID for terminal destinations"
-  @spec destination_var(PaEss.destination()) :: {:ok, String.t()} | {:error, :unknown}
-  def destination_var(:alewife), do: {:ok, "4000"}
-  def destination_var(:ashmont), do: {:ok, "4016"}
-  def destination_var(:braintree), do: {:ok, "4021"}
-  def destination_var(:mattapan), do: {:ok, "4100"}
-  def destination_var(:bowdoin), do: {:ok, "4055"}
-  def destination_var(:wonderland), do: {:ok, "4044"}
-  def destination_var(:oak_grove), do: {:ok, "4022"}
-  def destination_var(:forest_hills), do: {:ok, "4043"}
-  def destination_var(:lechmere), do: {:ok, "4056"}
-  def destination_var(:north_station), do: {:ok, "4027"}
-  def destination_var(:government_center), do: {:ok, "4061"}
-  def destination_var(:park_street), do: {:ok, "4007"}
-  def destination_var(:kenmore), do: {:ok, "4070"}
-  def destination_var(:boston_college), do: {:ok, "4202"}
-  def destination_var(:cleveland_circle), do: {:ok, "4203"}
-  def destination_var(:reservoir), do: {:ok, "4076"}
-  def destination_var(:riverside), do: {:ok, "4084"}
-  def destination_var(:heath_street), do: {:ok, "4204"}
-  def destination_var(:union_square), do: {:ok, "695"}
-  def destination_var(:medford_tufts), do: {:ok, "852"}
-  def destination_var(:southbound), do: {:ok, "787"}
-  def destination_var(:northbound), do: {:ok, "788"}
-  def destination_var(:eastbound), do: {:ok, "867"}
-  def destination_var(:westbound), do: {:ok, "868"}
-  def destination_var(:inbound), do: {:ok, "33003"}
-  def destination_var(:outbound), do: {:ok, "33004"}
-  def destination_var(_), do: {:error, :unknown}
+  @spec destination_var(PaEss.destination()) :: String.t()
+  def destination_var(:alewife), do: "4000"
+  def destination_var(:ashmont), do: "4016"
+  def destination_var(:braintree), do: "4021"
+  def destination_var(:mattapan), do: "4100"
+  def destination_var(:bowdoin), do: "4055"
+  def destination_var(:wonderland), do: "4044"
+  def destination_var(:oak_grove), do: "4022"
+  def destination_var(:forest_hills), do: "4043"
+  def destination_var(:chelsea), do: "860"
+  def destination_var(:south_station), do: "4089"
+  def destination_var(:lechmere), do: "4056"
+  def destination_var(:north_station), do: "4027"
+  def destination_var(:government_center), do: "4061"
+  def destination_var(:park_street), do: "4007"
+  def destination_var(:kenmore), do: "4070"
+  def destination_var(:boston_college), do: "4202"
+  def destination_var(:cleveland_circle), do: "4203"
+  def destination_var(:reservoir), do: "4076"
+  def destination_var(:riverside), do: "4084"
+  def destination_var(:heath_street), do: "4204"
+  def destination_var(:union_square), do: "695"
+  def destination_var(:medford_tufts), do: "852"
+  def destination_var(:southbound), do: "787"
+  def destination_var(:northbound), do: "788"
+  def destination_var(:eastbound), do: "867"
+  def destination_var(:westbound), do: "868"
+  def destination_var(:inbound), do: "33003"
+  def destination_var(:outbound), do: "33004"
 
   @doc """
   Used for parsing headway_direction_name from the source config to a PaEss.destination
   """
-  @spec headsign_to_destination(String.t()) ::
-          {:ok, PaEss.destination() | nil} | {:error, :unknown}
-  def headsign_to_destination("Alewife"), do: {:ok, :alewife}
-  def headsign_to_destination("Ashmont"), do: {:ok, :ashmont}
-  def headsign_to_destination("Braintree"), do: {:ok, :braintree}
-  def headsign_to_destination("Mattapan"), do: {:ok, :mattapan}
-  def headsign_to_destination("Bowdoin"), do: {:ok, :bowdoin}
-  def headsign_to_destination("Wonderland"), do: {:ok, :wonderland}
-  def headsign_to_destination("Oak Grove"), do: {:ok, :oak_grove}
-  def headsign_to_destination("Forest Hills"), do: {:ok, :forest_hills}
-  def headsign_to_destination("Chelsea"), do: {:ok, :chelsea}
-  def headsign_to_destination("South Station"), do: {:ok, :south_station}
-  def headsign_to_destination("Lechmere"), do: {:ok, :lechmere}
-  def headsign_to_destination("North Station"), do: {:ok, :north_station}
-  def headsign_to_destination("Government Center"), do: {:ok, :government_center}
-  def headsign_to_destination("Park Street"), do: {:ok, :park_street}
-  def headsign_to_destination("Kenmore"), do: {:ok, :kenmore}
-  def headsign_to_destination("Boston College"), do: {:ok, :boston_college}
-  def headsign_to_destination("Cleveland Circle"), do: {:ok, :cleveland_circle}
-  def headsign_to_destination("Reservoir"), do: {:ok, :reservoir}
-  def headsign_to_destination("Riverside"), do: {:ok, :riverside}
-  def headsign_to_destination("Heath Street"), do: {:ok, :heath_street}
-  def headsign_to_destination("Union Square"), do: {:ok, :union_square}
-  def headsign_to_destination("Northbound"), do: {:ok, :northbound}
-  def headsign_to_destination("Southbound"), do: {:ok, :southbound}
-  def headsign_to_destination("Eastbound"), do: {:ok, :eastbound}
-  def headsign_to_destination("Westbound"), do: {:ok, :westbound}
-  def headsign_to_destination("Inbound"), do: {:ok, :inbound}
-  def headsign_to_destination("Outbound"), do: {:ok, :outbound}
-  def headsign_to_destination("Medford/Tufts"), do: {:ok, :medford_tufts}
-  def headsign_to_destination(nil), do: {:ok, nil}
-  def headsign_to_destination(_unknown), do: {:error, :unknown}
+  @spec headsign_to_destination(String.t()) :: PaEss.destination()
+  def headsign_to_destination("Alewife"), do: :alewife
+  def headsign_to_destination("Ashmont"), do: :ashmont
+  def headsign_to_destination("Braintree"), do: :braintree
+  def headsign_to_destination("Mattapan"), do: :mattapan
+  def headsign_to_destination("Bowdoin"), do: :bowdoin
+  def headsign_to_destination("Wonderland"), do: :wonderland
+  def headsign_to_destination("Oak Grove"), do: :oak_grove
+  def headsign_to_destination("Forest Hills"), do: :forest_hills
+  def headsign_to_destination("Chelsea"), do: :chelsea
+  def headsign_to_destination("South Station"), do: :south_station
+  def headsign_to_destination("Lechmere"), do: :lechmere
+  def headsign_to_destination("North Station"), do: :north_station
+  def headsign_to_destination("Government Center"), do: :government_center
+  def headsign_to_destination("Park Street"), do: :park_street
+  def headsign_to_destination("Kenmore"), do: :kenmore
+  def headsign_to_destination("Boston College"), do: :boston_college
+  def headsign_to_destination("Cleveland Circle"), do: :cleveland_circle
+  def headsign_to_destination("Reservoir"), do: :reservoir
+  def headsign_to_destination("Riverside"), do: :riverside
+  def headsign_to_destination("Heath Street"), do: :heath_street
+  def headsign_to_destination("Union Square"), do: :union_square
+  def headsign_to_destination("Northbound"), do: :northbound
+  def headsign_to_destination("Southbound"), do: :southbound
+  def headsign_to_destination("Eastbound"), do: :eastbound
+  def headsign_to_destination("Westbound"), do: :westbound
+  def headsign_to_destination("Inbound"), do: :inbound
+  def headsign_to_destination("Outbound"), do: :outbound
+  def headsign_to_destination("Medford/Tufts"), do: :medford_tufts
 
   @doc """
   Used to translate a PaEss.destination to a string to post to countdown clocks
@@ -275,37 +273,35 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string(:outbound), do: "Outbound"
   def destination_to_sign_string(:medford_tufts), do: "Medfd/Tufts"
 
-  @spec destination_to_ad_hoc_string(PaEss.destination()) ::
-          {:ok, String.t()} | {:error, :unknown}
-  def destination_to_ad_hoc_string(:alewife), do: {:ok, "Alewife"}
-  def destination_to_ad_hoc_string(:ashmont), do: {:ok, "Ashmont"}
-  def destination_to_ad_hoc_string(:braintree), do: {:ok, "Braintree"}
-  def destination_to_ad_hoc_string(:mattapan), do: {:ok, "Mattapan"}
-  def destination_to_ad_hoc_string(:bowdoin), do: {:ok, "Bowdoin"}
-  def destination_to_ad_hoc_string(:wonderland), do: {:ok, "Wonderland"}
-  def destination_to_ad_hoc_string(:oak_grove), do: {:ok, "Oak Grove"}
-  def destination_to_ad_hoc_string(:forest_hills), do: {:ok, "Forest Hills"}
-  def destination_to_ad_hoc_string(:chelsea), do: {:ok, "Chelsea"}
-  def destination_to_ad_hoc_string(:south_station), do: {:ok, "South Station"}
-  def destination_to_ad_hoc_string(:lechmere), do: {:ok, "Lechmere"}
-  def destination_to_ad_hoc_string(:north_station), do: {:ok, "North Station"}
-  def destination_to_ad_hoc_string(:government_center), do: {:ok, "Government Center"}
-  def destination_to_ad_hoc_string(:park_street), do: {:ok, "Park Street"}
-  def destination_to_ad_hoc_string(:kenmore), do: {:ok, "Kenmore"}
-  def destination_to_ad_hoc_string(:boston_college), do: {:ok, "Boston College"}
-  def destination_to_ad_hoc_string(:cleveland_circle), do: {:ok, "Cleveland Circle"}
-  def destination_to_ad_hoc_string(:reservoir), do: {:ok, "Reservoir"}
-  def destination_to_ad_hoc_string(:riverside), do: {:ok, "Riverside"}
-  def destination_to_ad_hoc_string(:heath_street), do: {:ok, "Heath Street"}
-  def destination_to_ad_hoc_string(:union_square), do: {:ok, "Union Square"}
-  def destination_to_ad_hoc_string(:northbound), do: {:ok, "Northbound"}
-  def destination_to_ad_hoc_string(:southbound), do: {:ok, "Southbound"}
-  def destination_to_ad_hoc_string(:eastbound), do: {:ok, "Eastbound"}
-  def destination_to_ad_hoc_string(:westbound), do: {:ok, "Westbound"}
-  def destination_to_ad_hoc_string(:inbound), do: {:ok, "Inbound"}
-  def destination_to_ad_hoc_string(:outbound), do: {:ok, "Outbound"}
-  def destination_to_ad_hoc_string(:medford_tufts), do: {:ok, "Medford/Tufts"}
-  def destination_to_ad_hoc_string(_unknown), do: {:error, :unknown}
+  @spec destination_to_ad_hoc_string(PaEss.destination()) :: String.t()
+  def destination_to_ad_hoc_string(:alewife), do: "Alewife"
+  def destination_to_ad_hoc_string(:ashmont), do: "Ashmont"
+  def destination_to_ad_hoc_string(:braintree), do: "Braintree"
+  def destination_to_ad_hoc_string(:mattapan), do: "Mattapan"
+  def destination_to_ad_hoc_string(:bowdoin), do: "Bowdoin"
+  def destination_to_ad_hoc_string(:wonderland), do: "Wonderland"
+  def destination_to_ad_hoc_string(:oak_grove), do: "Oak Grove"
+  def destination_to_ad_hoc_string(:forest_hills), do: "Forest Hills"
+  def destination_to_ad_hoc_string(:chelsea), do: "Chelsea"
+  def destination_to_ad_hoc_string(:south_station), do: "South Station"
+  def destination_to_ad_hoc_string(:lechmere), do: "Lechmere"
+  def destination_to_ad_hoc_string(:north_station), do: "North Station"
+  def destination_to_ad_hoc_string(:government_center), do: "Government Center"
+  def destination_to_ad_hoc_string(:park_street), do: "Park Street"
+  def destination_to_ad_hoc_string(:kenmore), do: "Kenmore"
+  def destination_to_ad_hoc_string(:boston_college), do: "Boston College"
+  def destination_to_ad_hoc_string(:cleveland_circle), do: "Cleveland Circle"
+  def destination_to_ad_hoc_string(:reservoir), do: "Reservoir"
+  def destination_to_ad_hoc_string(:riverside), do: "Riverside"
+  def destination_to_ad_hoc_string(:heath_street), do: "Heath Street"
+  def destination_to_ad_hoc_string(:union_square), do: "Union Square"
+  def destination_to_ad_hoc_string(:northbound), do: "Northbound"
+  def destination_to_ad_hoc_string(:southbound), do: "Southbound"
+  def destination_to_ad_hoc_string(:eastbound), do: "Eastbound"
+  def destination_to_ad_hoc_string(:westbound), do: "Westbound"
+  def destination_to_ad_hoc_string(:inbound), do: "Inbound"
+  def destination_to_ad_hoc_string(:outbound), do: "Outbound"
+  def destination_to_ad_hoc_string(:medford_tufts), do: "Medford/Tufts"
 
   def line_to_var("Red"), do: "3005"
   def line_to_var("Orange"), do: "3006"
@@ -327,12 +323,8 @@ defmodule PaEss.Utilities do
 
     destination_text =
       case av do
-        :audio ->
-          {:ok, string} = destination_to_ad_hoc_string(destination)
-          string
-
-        :visual ->
-          destination_to_sign_string(destination)
+        :audio -> destination_to_ad_hoc_string(destination)
+        :visual -> destination_to_sign_string(destination)
       end
 
     if route_text do

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -121,7 +121,7 @@ defmodule Signs.Utilities.SourceConfig do
         "terminal" => terminal,
         "sources" => sources
       }) do
-    {:ok, headway_destination} = PaEss.Utilities.headsign_to_destination(headway_direction_name)
+    headway_destination = PaEss.Utilities.headsign_to_destination(headway_direction_name)
 
     %{
       headway_group: headway_group,

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -37,49 +37,48 @@ defmodule Content.Audio.UtilitiesTest do
   end
 
   test "destination_var/1" do
-    assert destination_var(:alewife) == {:ok, "4000"}
-    assert destination_var(:ashmont) == {:ok, "4016"}
-    assert destination_var(:boston_college) == {:ok, "4202"}
-    assert destination_var(:bowdoin) == {:ok, "4055"}
-    assert destination_var(:braintree) == {:ok, "4021"}
-    assert destination_var(:cleveland_circle) == {:ok, "4203"}
-    assert destination_var(:forest_hills) == {:ok, "4043"}
-    assert destination_var(:government_center) == {:ok, "4061"}
-    assert destination_var(:heath_street) == {:ok, "4204"}
-    assert destination_var(:kenmore) == {:ok, "4070"}
-    assert destination_var(:lechmere) == {:ok, "4056"}
-    assert destination_var(:mattapan) == {:ok, "4100"}
-    assert destination_var(:north_station) == {:ok, "4027"}
-    assert destination_var(:oak_grove) == {:ok, "4022"}
-    assert destination_var(:park_street) == {:ok, "4007"}
-    assert destination_var(:reservoir) == {:ok, "4076"}
-    assert destination_var(:riverside) == {:ok, "4084"}
-    assert destination_var(:wonderland) == {:ok, "4044"}
-    assert destination_var(:union_square) == {:ok, "695"}
-    assert destination_var(:medford_tufts) == {:ok, "852"}
+    assert destination_var(:alewife) == "4000"
+    assert destination_var(:ashmont) == "4016"
+    assert destination_var(:boston_college) == "4202"
+    assert destination_var(:bowdoin) == "4055"
+    assert destination_var(:braintree) == "4021"
+    assert destination_var(:cleveland_circle) == "4203"
+    assert destination_var(:forest_hills) == "4043"
+    assert destination_var(:government_center) == "4061"
+    assert destination_var(:heath_street) == "4204"
+    assert destination_var(:kenmore) == "4070"
+    assert destination_var(:lechmere) == "4056"
+    assert destination_var(:mattapan) == "4100"
+    assert destination_var(:north_station) == "4027"
+    assert destination_var(:oak_grove) == "4022"
+    assert destination_var(:park_street) == "4007"
+    assert destination_var(:reservoir) == "4076"
+    assert destination_var(:riverside) == "4084"
+    assert destination_var(:wonderland) == "4044"
+    assert destination_var(:union_square) == "695"
+    assert destination_var(:medford_tufts) == "852"
   end
 
   test "headsign_to_destination/1" do
-    assert headsign_to_destination("Alewife") == {:ok, :alewife}
-    assert headsign_to_destination("Ashmont") == {:ok, :ashmont}
-    assert headsign_to_destination("Boston College") == {:ok, :boston_college}
-    assert headsign_to_destination("Bowdoin") == {:ok, :bowdoin}
-    assert headsign_to_destination("Braintree") == {:ok, :braintree}
-    assert headsign_to_destination("Cleveland Circle") == {:ok, :cleveland_circle}
-    assert headsign_to_destination("Forest Hills") == {:ok, :forest_hills}
-    assert headsign_to_destination("Government Center") == {:ok, :government_center}
-    assert headsign_to_destination("Heath Street") == {:ok, :heath_street}
-    assert headsign_to_destination("Lechmere") == {:ok, :lechmere}
-    assert headsign_to_destination("Union Square") == {:ok, :union_square}
-    assert headsign_to_destination("Mattapan") == {:ok, :mattapan}
-    assert headsign_to_destination("North Station") == {:ok, :north_station}
-    assert headsign_to_destination("Oak Grove") == {:ok, :oak_grove}
-    assert headsign_to_destination("Park Street") == {:ok, :park_street}
-    assert headsign_to_destination("Reservoir") == {:ok, :reservoir}
-    assert headsign_to_destination("Riverside") == {:ok, :riverside}
-    assert headsign_to_destination("Wonderland") == {:ok, :wonderland}
-    assert headsign_to_destination("Medford/Tufts") == {:ok, :medford_tufts}
-    assert headsign_to_destination("Unknown") == {:error, :unknown}
+    assert headsign_to_destination("Alewife") == :alewife
+    assert headsign_to_destination("Ashmont") == :ashmont
+    assert headsign_to_destination("Boston College") == :boston_college
+    assert headsign_to_destination("Bowdoin") == :bowdoin
+    assert headsign_to_destination("Braintree") == :braintree
+    assert headsign_to_destination("Cleveland Circle") == :cleveland_circle
+    assert headsign_to_destination("Forest Hills") == :forest_hills
+    assert headsign_to_destination("Government Center") == :government_center
+    assert headsign_to_destination("Heath Street") == :heath_street
+    assert headsign_to_destination("Lechmere") == :lechmere
+    assert headsign_to_destination("Union Square") == :union_square
+    assert headsign_to_destination("Mattapan") == :mattapan
+    assert headsign_to_destination("North Station") == :north_station
+    assert headsign_to_destination("Oak Grove") == :oak_grove
+    assert headsign_to_destination("Park Street") == :park_street
+    assert headsign_to_destination("Reservoir") == :reservoir
+    assert headsign_to_destination("Riverside") == :riverside
+    assert headsign_to_destination("Wonderland") == :wonderland
+    assert headsign_to_destination("Medford/Tufts") == :medford_tufts
   end
 
   test "destination_to_sign_string/1" do
@@ -88,8 +87,8 @@ defmodule Content.Audio.UtilitiesTest do
   end
 
   test "destination_to_ad_hoc_string/1" do
-    assert destination_to_ad_hoc_string(:heath_street) == {:ok, "Heath Street"}
-    assert destination_to_ad_hoc_string(:southbound) == {:ok, "Southbound"}
+    assert destination_to_ad_hoc_string(:heath_street) == "Heath Street"
+    assert destination_to_ad_hoc_string(:southbound) == "Southbound"
   end
 
   describe "replace_abbreviations/1" do

--- a/test/signs/utilities/source_config_test.exs
+++ b/test/signs/utilities/source_config_test.exs
@@ -146,7 +146,7 @@ defmodule Signs.Utilities.SourceConfigTest do
     end
 
     test "logs error when headway destination is invalid" do
-      assert_raise MatchError, fn ->
+      assert_raise FunctionClauseError, fn ->
         @invalid_headway_destination_json |> Jason.decode!() |> SourceConfig.parse!() ==
           %{
             headway_group: "headway_group",


### PR DESCRIPTION
#### Summary of changes

This removes some fallback code dealing with destination names, which is never actually needed in practice, because we can produce content for all supported destinations. This simplifies the calling code. Adds `destination_var` values for Chelsea and South Station for completeness (though they are not strictly required, since we don't use those destinations from the rail code, and the bus code has its own way of handling that).