### PR TITLE
Change time to display "BRD" to <60 seconds until departure at terminals

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -39,7 +39,7 @@ defmodule Content.Message.Predictions do
 
     {minutes, approximate?} =
       cond do
-        prediction.stopped_at_predicted_stop? and (!terminal? or sec <= 30) -> {:boarding, false}
+        prediction.stopped_at_predicted_stop? and (!terminal? or sec <= 60) -> {:boarding, false}
         !terminal? and sec <= 30 -> {:arriving, false}
         !terminal? and sec <= 60 -> {:approaching, false}
         min > 60 -> {60, true}

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -215,7 +215,6 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
 
-
     test "put boarding on the sign when train is stopped at terminal and departing in less than 60 seconds" do
       prediction = %Predictions.Prediction{
         seconds_until_departure: 59,

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -215,9 +215,25 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
 
+
+    test "put boarding on the sign when train is stopped at terminal and departing in less than 60 seconds" do
+      prediction = %Predictions.Prediction{
+        seconds_until_departure: 59,
+        direction_id: 1,
+        route_id: "Mattapan",
+        destination_stop_id: "70261",
+        stopped_at_predicted_stop?: true,
+        boarding_status: "Stopped at station"
+      }
+
+      msg = Content.Message.Predictions.new(prediction, true, nil)
+
+      assert Content.Message.to_string(msg) == "Ashmont        BRD"
+    end
+
     test "does not put boarding on the sign too early when train is stopped at terminal" do
       prediction = %Predictions.Prediction{
-        seconds_until_departure: 35,
+        seconds_until_departure: 61,
         direction_id: 1,
         route_id: "Mattapan",
         destination_stop_id: "70261",
@@ -228,6 +244,21 @@ defmodule Content.Message.PredictionsTest do
       msg = Content.Message.Predictions.new(prediction, true, nil)
 
       assert Content.Message.to_string(msg) == "Ashmont      1 min"
+    end
+
+    test "puts minutes on sign when train is stopped at terminal but departure is >=1.5 minutes" do
+      prediction = %Predictions.Prediction{
+        seconds_until_departure: 92,
+        direction_id: 1,
+        route_id: "Mattapan",
+        destination_stop_id: "70261",
+        stopped_at_predicted_stop?: true,
+        boarding_status: "Stopped at station"
+      }
+
+      msg = Content.Message.Predictions.new(prediction, true, nil)
+
+      assert Content.Message.to_string(msg) == "Ashmont      2 min"
     end
 
     test "puts 1 min on the sign when train is not boarding, but is predicted to depart in less than a minute when offset" do

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -231,7 +231,7 @@ defmodule Content.Message.PredictionsTest do
       assert Content.Message.to_string(msg) == "Ashmont        BRD"
     end
 
-    test "does not put boarding on the sign too early when train is stopped at terminal" do
+    test "puts 1 min on sign when train is stopped at terminal but departure is between 60-90 seconds" do
       prediction = %Predictions.Prediction{
         seconds_until_departure: 61,
         direction_id: 1,

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -514,7 +514,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [
-          {:canned, {"109", ["501", "21000", "507", "21000", "4100", "21000", "544"], :audio}}
+          {:canned, {"109", ["501", "21000", "4100", "21000", "864", "21000", "544"], :audio}}
         ],
         [{"The next Mattapan train is now boarding.", nil}]
       )

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -513,6 +513,48 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, @terminal_sign)
     end
 
+    test "When the train is stopped at the terminal and departing in <= 60 seconds, shows BRD" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [
+          prediction(
+            destination: :mattapan,
+            stopped: 0,
+            seconds_until_arrival: -1,
+            seconds_until_departure: 60,
+            trip_id: "3"
+          )
+        ]
+      end)
+
+      expect_messages({"Mattapan       BRD", ""})
+
+      expect_audios(
+        [
+          {:canned, {"109", ["501", "21000", "507", "21000", "4100", "21000", "544"], :audio}}
+        ],
+        [{"The next Mattapan train is now boarding.", nil}]
+      )
+
+      Signs.Realtime.handle_info(:run_loop, @terminal_sign)
+    end
+
+    test "When the train is stopped at the terminal and departing in more than 60 seconds, shows mins to departure" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [
+          prediction(
+            destination: :mattapan,
+            stopped: 0,
+            seconds_until_arrival: nil,
+            seconds_until_departure: 91,
+            trip_id: "3"
+          )
+        ]
+      end)
+
+      expect_messages({"Mattapan     2 min", ""})
+      Signs.Realtime.handle_info(:run_loop, @terminal_sign)
+    end
+
     test "When the train is stopped a long time away, shows max time instead of stopped" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :mattapan, arrival: 3700, stopped: 8)]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change terminals "BRD" time to 60 seconds](https://app.asana.com/0/1185117109217422/1208885272304851/f)

When a train is at the terminal, this will change sign from displaying "1 min" to "BRD" when the departure time prediction goes below 60 seconds.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
