### PR TITLE
Migrate to update_type

### DIFF
--- a/lib/content/message/predictions.ex
+++ b/lib/content/message/predictions.ex
@@ -35,7 +35,6 @@ defmodule Content.Message.Predictions do
       end
 
     min = round(sec / 60)
-    reverse_prediction? = Signs.Utilities.Predictions.reverse_prediction?(prediction, terminal?)
 
     {minutes, approximate?} =
       cond do
@@ -43,7 +42,7 @@ defmodule Content.Message.Predictions do
         !terminal? and sec <= 30 -> {:arriving, false}
         !terminal? and sec <= 60 -> {:approaching, false}
         min > 60 -> {60, true}
-        reverse_prediction? and min > 20 -> {div(min, 10) * 10, true}
+        prediction.type == :reverse and min > 20 -> {div(min, 10) * 10, true}
         true -> {max(min, 1), false}
       end
 

--- a/lib/fake/httpoison.ex
+++ b/lib/fake/httpoison.ex
@@ -70,8 +70,7 @@ defmodule Fake.HTTPoison do
               "stop_time_update" => [
                 %{
                   "arrival" => %{
-                    "time" => 1_491_570_120,
-                    "uncertainty" => nil
+                    "time" => 1_491_570_120
                   },
                   "departure" => nil,
                   "schedule_relationship" => "SCHEDULED",
@@ -80,8 +79,7 @@ defmodule Fake.HTTPoison do
                 },
                 %{
                   "arrival" => %{
-                    "time" => 1_491_570_180,
-                    "uncertainty" => nil
+                    "time" => 1_491_570_180
                   },
                   "departure" => nil,
                   "schedule_relationship" => "SCHEDULED",
@@ -243,8 +241,7 @@ defmodule Fake.HTTPoison do
               "stop_time_update" => [
                 %{
                   "arrival" => %{
-                    "time" => 1_491_570_180,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_180
                   },
                   "departure" => nil,
                   "stop_id" => "stop_to_update",
@@ -299,8 +296,7 @@ defmodule Fake.HTTPoison do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_080,
-                    "uncertainty" => nil
+                    "time" => 1_491_570_080
                   },
                   "departure" => nil,
                   "schedule_relationship" => "SCHEDULED",

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -1,9 +1,7 @@
 defmodule Predictions.Prediction do
   defstruct stop_id: nil,
             seconds_until_arrival: nil,
-            arrival_certainty: nil,
             seconds_until_departure: nil,
-            departure_certainty: nil,
             seconds_until_passthrough: nil,
             direction_id: nil,
             schedule_relationship: nil,
@@ -13,16 +11,16 @@ defmodule Predictions.Prediction do
             stopped_at_predicted_stop?: false,
             boarding_status: nil,
             revenue_trip?: true,
-            vehicle_id: nil
+            vehicle_id: nil,
+            type: nil
 
   @type trip_id :: String.t()
+  @type prediction_type :: :mid_trip | :terminal | :reverse | nil
 
   @type t :: %__MODULE__{
           stop_id: String.t(),
           seconds_until_arrival: non_neg_integer() | nil,
-          arrival_certainty: non_neg_integer() | nil,
           seconds_until_departure: non_neg_integer() | nil,
-          departure_certainty: non_neg_integer() | nil,
           seconds_until_passthrough: non_neg_integer() | nil,
           direction_id: 0 | 1,
           schedule_relationship: :scheduled | :skipped | nil,
@@ -32,6 +30,7 @@ defmodule Predictions.Prediction do
           stopped_at_predicted_stop?: boolean(),
           boarding_status: String.t() | nil,
           revenue_trip?: boolean(),
-          vehicle_id: String.t() | nil
+          vehicle_id: String.t() | nil,
+          type: prediction_type()
         }
 end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -197,12 +197,12 @@ defmodule Signs.Utilities.Messages do
        end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
     |> then(fn predictions -> if(sign_config == :headway, do: [], else: predictions) end)
-    |> filter_early_am_predictions(config, current_time, scheduled)
+    |> filter_early_am_predictions(current_time, scheduled)
     |> filter_large_red_line_gaps()
     |> get_unique_destination_predictions(Signs.Utilities.SourceConfig.single_route(config))
   end
 
-  defp filter_early_am_predictions(predictions, config, current_time, scheduled) do
+  defp filter_early_am_predictions(predictions, current_time, scheduled) do
     cond do
       !in_early_am?(current_time, scheduled) ->
         predictions
@@ -216,7 +216,7 @@ defmodule Signs.Utilities.Messages do
         # except for Prudential or Symphony EB
         Enum.reject(
           predictions,
-          &(Signs.Utilities.Predictions.reverse_prediction?(&1, config.terminal?) and
+          &(&1.type == :reverse and
               &1.stop_id not in ["70240", "70242"])
         )
     end

--- a/test/content/messages/predictions_test.exs
+++ b/test/content/messages/predictions_test.exs
@@ -72,10 +72,10 @@ defmodule Content.Message.PredictionsTest do
     test "shows approximate minutes for longer turnaround predictions" do
       prediction = %Predictions.Prediction{
         seconds_until_arrival: 25 * 60,
-        arrival_certainty: 360,
         direction_id: 0,
         route_id: "Mattapan",
-        destination_stop_id: "70275"
+        destination_stop_id: "70275",
+        type: :reverse
       }
 
       msg = Content.Message.Predictions.new(prediction, false, nil)

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -19,8 +19,7 @@ defmodule Predictions.PredictionsTest do
             %{
               "arrival" => nil,
               "departure" => %{
-                "time" => 1_491_570_120,
-                "uncertainty" => 60
+                "time" => 1_491_570_120
               },
               "stop_id" => "70263",
               "stop_sequence" => 1,
@@ -28,8 +27,7 @@ defmodule Predictions.PredictionsTest do
             },
             %{
               "arrival" => %{
-                "time" => 1_491_570_180,
-                "uncertainty" => 60
+                "time" => 1_491_570_180
               },
               "departure" => nil,
               "stop_id" => "70261",
@@ -50,7 +48,8 @@ defmodule Predictions.PredictionsTest do
             "id" => "G-10040",
             "label" => "3260",
             "license_plate" => nil
-          }
+          },
+          "update_type" => "mid_trip"
         },
         "vehicle" => nil
       }
@@ -69,21 +68,20 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70261",
             seconds_until_arrival: 180,
-            arrival_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
-            vehicle_id: "G-10040"
+            vehicle_id: "G-10040",
+            type: :mid_trip
           }
         ],
         {"70263", 0} => [
           %Predictions.Prediction{
             stop_id: "70263",
             seconds_until_departure: 120,
-            departure_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
@@ -91,7 +89,8 @@ defmodule Predictions.PredictionsTest do
             boarding_status: "Stopped 1 stop away",
             trip_id: "32568935",
             revenue_trip?: true,
-            vehicle_id: "G-10040"
+            vehicle_id: "G-10040",
+            type: :mid_trip
           }
         ]
       }
@@ -112,8 +111,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_120,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_120
                   },
                   "departure" => nil,
                   "stop_id" => "70263",
@@ -124,8 +122,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_180,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_180
                   },
                   "departure" => nil,
                   "stop_id" => "70261",
@@ -156,7 +153,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "G-10040",
                 "label" => "3260",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "mid_trip"
             },
             "vehicle" => nil
           },
@@ -170,8 +168,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_200,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_200
                   },
                   "departure" => nil,
                   "stop_id" => "70038",
@@ -182,8 +179,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_400,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_400
                   },
                   "departure" => nil,
                   "stop_id" => "70060",
@@ -206,7 +202,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "vehicle_2",
                 "label" => "3261",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "mid_trip"
             },
             "vehicle" => nil
           },
@@ -248,56 +245,56 @@ defmodule Predictions.PredictionsTest do
           %Predictions.Prediction{
             stop_id: "70261",
             seconds_until_arrival: 180,
-            arrival_certainty: 60,
             schedule_relationship: :scheduled,
             direction_id: 0,
             route_id: "Mattapan",
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
-            vehicle_id: "G-10040"
+            vehicle_id: "G-10040",
+            type: :mid_trip
           }
         ],
         {"70263", 0} => [
           %Predictions.Prediction{
             stop_id: "70263",
             seconds_until_arrival: 120,
-            arrival_certainty: 60,
             direction_id: 0,
             schedule_relationship: :scheduled,
             route_id: "Mattapan",
             destination_stop_id: "70261",
             trip_id: "32568935",
             revenue_trip?: true,
-            vehicle_id: "G-10040"
+            vehicle_id: "G-10040",
+            type: :mid_trip
           }
         ],
         {"70038", 1} => [
           %Predictions.Prediction{
             stop_id: "70038",
             seconds_until_arrival: 200,
-            arrival_certainty: 60,
             direction_id: 1,
             schedule_relationship: :scheduled,
             route_id: "Blue",
             destination_stop_id: "70060",
             trip_id: "trip_2",
             revenue_trip?: true,
-            vehicle_id: "vehicle_2"
+            vehicle_id: "vehicle_2",
+            type: :mid_trip
           }
         ],
         {"70060", 1} => [
           %Predictions.Prediction{
             stop_id: "70060",
             seconds_until_arrival: 400,
-            arrival_certainty: 60,
             direction_id: 1,
             schedule_relationship: :scheduled,
             route_id: "Blue",
             destination_stop_id: "70060",
             trip_id: "trip_2",
             revenue_trip?: true,
-            vehicle_id: "vehicle_2"
+            vehicle_id: "vehicle_2",
+            type: :mid_trip
           }
         ]
       }
@@ -318,8 +315,7 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => Timex.to_unix(@current_time) - 100,
-                    "uncertainty" => 60
+                    "time" => Timex.to_unix(@current_time) - 100
                   },
                   "departure" => nil,
                   "schedule_relationship" => "SCHEDULED",
@@ -372,7 +368,7 @@ defmodule Predictions.PredictionsTest do
               }, _} = get_all(feed_message, @current_time)
     end
 
-    test "include predictions with low uncertainty" do
+    test "include non reverse predictions" do
       reassign_env(:filter_uncertain_predictions?, true)
 
       feed_message = %{
@@ -388,8 +384,7 @@ defmodule Predictions.PredictionsTest do
                   "arrival" => nil,
                   "departure" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_120,
-                    "uncertainty" => 60
+                    "time" => 1_491_570_120
                   },
                   "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70063",
@@ -413,7 +408,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "R-54639F6C",
                 "label" => "1631",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "mid_trip"
             },
             "vehicle" => nil
           }
@@ -434,7 +430,7 @@ defmodule Predictions.PredictionsTest do
               }, _} = get_all(feed_message, @current_time)
     end
 
-    test "filter predictions with high uncertainty" do
+    test "filter reverse predictions" do
       reassign_env(:filter_uncertain_predictions?, true)
 
       feed_message = %{
@@ -449,13 +445,11 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_110,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_110
                   },
                   "departure" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_120,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_120
                   },
                   "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70063",
@@ -479,7 +473,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "R-54639F6C",
                 "label" => "1631",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "reverse_trip"
             },
             "vehicle" => nil
           }
@@ -496,7 +491,7 @@ defmodule Predictions.PredictionsTest do
       assert predictions_map == %{}
     end
 
-    test "doesn't filter predictions with high uncertainty when feature is off" do
+    test "doesn't filter reverse predictions when feature is off" do
       reassign_env(:filter_uncertain_predictions?, false)
 
       feed_message = %{
@@ -511,13 +506,11 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_110,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_110
                   },
                   "departure" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_120,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_120
                   },
                   "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70063",
@@ -541,7 +534,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "R-54639F6C",
                 "label" => "1631",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "reverse_trip"
             },
             "vehicle" => nil
           }
@@ -563,7 +557,7 @@ defmodule Predictions.PredictionsTest do
               }, _} = get_all(feed_message, @current_time)
     end
 
-    test "doesn't filter out uncertain light rail predictions" do
+    test "doesn't filter out light rail reverse predictions" do
       reassign_env(:filter_uncertain_predictions?, true)
 
       feed_message = %{
@@ -578,13 +572,11 @@ defmodule Predictions.PredictionsTest do
                 %{
                   "arrival" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_110,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_110
                   },
                   "departure" => %{
                     "delay" => nil,
-                    "time" => 1_491_570_120,
-                    "uncertainty" => 360
+                    "time" => 1_491_570_120
                   },
                   "schedule_relationship" => "SCHEDULED",
                   "stop_id" => "70263",
@@ -608,7 +600,8 @@ defmodule Predictions.PredictionsTest do
                 "id" => "G-10040",
                 "label" => "3260",
                 "license_plate" => nil
-              }
+              },
+              "update_type" => "reverse_trip"
             },
             "vehicle" => nil
           }

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -504,7 +504,7 @@ defmodule Signs.RealtimeTest do
             destination: :mattapan,
             seconds_until_departure: 2020,
             stopped: 8,
-            departure_certainty: 360
+            prediction_type: :reverse
           )
         ]
       end)
@@ -1230,8 +1230,8 @@ defmodule Signs.RealtimeTest do
     test "When sign in partial am suppression shows mid-trip and terminal predictions but filters out reverse predictions" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
-          prediction(destination: :ashmont, arrival: 120, arrival_certainty: 360),
-          prediction(destination: :ashmont, arrival: 240, arrival_certainty: 120)
+          prediction(destination: :ashmont, arrival: 120, prediction_type: :reverse),
+          prediction(destination: :ashmont, arrival: 240, prediction_type: :terminal)
         ]
       end)
 
@@ -1266,16 +1266,16 @@ defmodule Signs.RealtimeTest do
       })
     end
 
-    test "When sign in partial am suppression, filters stopped predictions based on certainty" do
+    test "When sign in partial am suppression, filters stopped predictions based on prediction type" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
-          prediction(destination: :ashmont, arrival: 120, stopped: 2, arrival_certainty: 360),
+          prediction(destination: :ashmont, arrival: 120, stopped: 2, prediction_type: :reverse),
           prediction(
             destination: :ashmont,
             arrival: 240,
             stopped: 3,
-            arrival_certainty: 120,
-            trip_id: "1"
+            trip_id: "1",
+            prediction_type: :terminal
           )
         ]
       end)
@@ -1311,7 +1311,7 @@ defmodule Signs.RealtimeTest do
 
     test "mezzanine sign, one line in full am suppression, one line in partial am suppression defaulting to headways" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(arrival: 180, destination: :ashmont, arrival_certainty: 360)]
+        [prediction(arrival: 180, destination: :ashmont, prediction_type: :reverse)]
       end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
@@ -1341,7 +1341,7 @@ defmodule Signs.RealtimeTest do
 
     test "mezzanine sign, early am, both lines in partial am suppression defaulting to headways" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(arrival: 180, destination: :ashmont, arrival_certainty: 360)]
+        [prediction(arrival: 180, destination: :ashmont, prediction_type: :reverse)]
       end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
@@ -1444,7 +1444,7 @@ defmodule Signs.RealtimeTest do
             destination: :alewife,
             arrival: 240,
             stop_id: "70086",
-            arrival_certainty: 360
+            prediction_type: :reverse
           )
         ]
       end)
@@ -1916,9 +1916,7 @@ defmodule Signs.RealtimeTest do
     %Predictions.Prediction{
       stop_id: Keyword.get(opts, :stop_id, "1"),
       seconds_until_arrival: Keyword.get(opts, :seconds_until_arrival),
-      arrival_certainty: Keyword.get(opts, :arrival_certainty),
       seconds_until_departure: Keyword.get(opts, :seconds_until_departure),
-      departure_certainty: Keyword.get(opts, :departure_certainty),
       seconds_until_passthrough: Keyword.get(opts, :seconds_until_passthrough),
       direction_id: Keyword.get(opts, :direction_id, 0),
       schedule_relationship: Keyword.get(opts, :schedule_relationship),
@@ -1928,7 +1926,8 @@ defmodule Signs.RealtimeTest do
       stopped_at_predicted_stop?: Keyword.get(opts, :stopped_at_predicted_stop, false),
       boarding_status: Keyword.get(opts, :boarding_status),
       revenue_trip?: true,
-      vehicle_id: "v1"
+      vehicle_id: "v1",
+      type: Keyword.get(opts, :prediction_type, :mid_trip)
     }
   end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Migrate to Update_type for trip type](https://app.asana.com/0/1185117109217413/1206604799720436/f)

RTS currently uses the `uncertainty` field in order to distinguish different types of predictions (mid trip, terminal, and reverse). This field will eventually be deprecated by the Transit Data team and has been replaced by a new field provided at the trip level called `update_type`. This PR migrates RTS to using this new field in favor of `uncertainty` which also made it easier to clean up the predictions feed parsing code a bit as well.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
