### PR TITLE
extract prediction helpers

### DIFF
--- a/lib/content/audio/next_train_countdown.ex
+++ b/lib/content/audio/next_train_countdown.ex
@@ -26,7 +26,7 @@ defmodule Content.Audio.NextTrainCountdown do
       %__MODULE__{
         destination: message.destination,
         route_id: message.prediction.route_id,
-        minutes: if(message.minutes == :approaching, do: 1, else: message.minutes),
+        minutes: message.minutes,
         verb: if(message.terminal?, do: :departs, else: :arrives),
         track_number: Content.Utilities.stop_track_number(message.prediction.stop_id),
         platform: Content.Utilities.stop_platform(message.prediction.stop_id),

--- a/lib/content/message/platform_prediction_bottom.ex
+++ b/lib/content/message/platform_prediction_bottom.ex
@@ -3,7 +3,7 @@ defmodule Content.Message.PlatformPredictionBottom do
 
   @type t :: %__MODULE__{
           stop_id: String.t(),
-          minutes: integer() | :boarding | :arriving | :approaching,
+          minutes: integer() | :boarding | :arriving,
           destination: PaEss.destination()
         }
 

--- a/lib/content/message/stopped_train.ex
+++ b/lib/content/message/stopped_train.ex
@@ -23,20 +23,11 @@ defmodule Content.Message.StoppedTrain do
 
   @spec from_prediction(Predictions.Prediction.t()) :: t() | nil
   def from_prediction(%{boarding_status: status} = prediction) when not is_nil(status) do
-    stops_away = parse_stops_away(prediction.boarding_status)
-
     %__MODULE__{
       destination: Content.Utilities.destination_for_prediction(prediction),
-      stops_away: stops_away,
+      stops_away: PaEss.Utilities.prediction_stops_away(prediction),
       prediction: prediction
     }
-  end
-
-  defp parse_stops_away(str) do
-    ~r/Stopped (?<stops_away>\d+) stops? away/
-    |> Regex.named_captures(str)
-    |> Map.fetch!("stops_away")
-    |> String.to_integer()
   end
 
   defimpl Content.Message do

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -6,6 +6,7 @@ defmodule PaEss.Utilities do
   require Logger
 
   @space "21000"
+  @stopped_regex ~r/Stopped (\d+) stops? away/
 
   @abbreviation_replacements [
     {~r"\bOL\b", "Orange Line"},
@@ -508,6 +509,46 @@ defmodule PaEss.Utilities do
   end
 
   def prediction_route_name(%{route_id: route_id}), do: route_id
+
+  defp prediction_seconds(prediction, true) do
+    prediction.seconds_until_departure
+  end
+
+  defp prediction_seconds(prediction, false) do
+    prediction.seconds_until_arrival || prediction.seconds_until_departure
+  end
+
+  @spec prediction_minutes(Predictions.Prediction.t(), boolean()) :: {integer(), boolean()}
+  def prediction_minutes(prediction, terminal?) do
+    sec = prediction_seconds(prediction, terminal?)
+    min = round(sec / 60)
+
+    cond do
+      prediction.stopped_at_predicted_stop? and (!terminal? or sec <= 60) -> {:boarding, false}
+      !terminal? and sec <= 30 -> {:arriving, false}
+      min > 60 -> {60, true}
+      prediction.type == :reverse and min > 20 -> {div(min, 10) * 10, true}
+      true -> {max(min, 1), false}
+    end
+  end
+
+  @spec prediction_approaching?(Predictions.Prediction.t(), boolean()) :: boolean()
+  def prediction_approaching?(prediction, terminal?) do
+    !terminal? and !prediction.stopped_at_predicted_stop? and
+      prediction_seconds(prediction, terminal?) in 31..60
+  end
+
+  @spec prediction_stopped?(Predictions.Prediction.t(), boolean()) :: boolean()
+  def prediction_stopped?(%{boarding_status: boarding_status} = prediction, terminal?) do
+    {_, approximate?} = prediction_minutes(prediction, terminal?)
+    !!boarding_status and Regex.match?(@stopped_regex, boarding_status) and !approximate?
+  end
+
+  @spec prediction_stops_away(Predictions.Prediction.t()) :: integer()
+  def prediction_stops_away(%{boarding_status: status}) do
+    [_, str] = Regex.run(@stopped_regex, status)
+    String.to_integer(str)
+  end
 
   @headsign_take_mappings [
     {"Ruggles", "4086"},

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -82,9 +82,6 @@ defmodule Signs.Utilities.Audio do
       :arriving ->
         Audio.TrainIsArriving.from_message(prediction, nil)
 
-      :approaching ->
-        Audio.NextTrainCountdown.from_message(%{prediction | minutes: 1})
-
       minutes when is_integer(minutes) ->
         Audio.NextTrainCountdown.from_message(prediction)
 
@@ -170,7 +167,8 @@ defmodule Signs.Utilities.Audio do
                update_in(sign.announced_arrivals, &cache_value(&1, message.prediction.trip_id))}
 
             # Announce approaching if configured to
-            match?(%Message.Predictions{minutes: :approaching}, message) &&
+            match?(%Message.Predictions{}, message) &&
+              PaEss.Utilities.prediction_approaching?(message.prediction, message.terminal?) &&
               message.prediction.trip_id not in sign.announced_approachings &&
               announce_arriving?(sign, message) &&
                 message.prediction.route_id in @heavy_rail_routes ->

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -999,31 +999,6 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_approachings: ["1"]})
     end
 
-    test "does not read approaching for following trains" do
-      # Note: This behavior exists because we didn't have recorded audio to cover this case at the
-      # time, but we should fix this so it works the same as other readouts.
-      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [
-          prediction(destination: :ashmont, arrival: 15, trip_id: "1"),
-          prediction(destination: :ashmont, arrival: 45, trip_id: "2")
-        ]
-      end)
-
-      expect_messages({"Ashmont        ARR", "Ashmont      1 min"})
-
-      expect_audios([{:canned, {"103", ["32107"], :audio_visual}}], [
-        {"Attention passengers: The next Ashmont train is now arriving.",
-         [{"Ashmont train", "now arriving", 6}]}
-      ])
-
-      Signs.Realtime.handle_info(:run_loop, %{
-        @sign
-        | tick_read: 0,
-          announced_arrivals: ["1"],
-          announced_approachings: ["2"]
-      })
-    end
-
     test "reads approaching as 1 minute when on the bottom line and a different headsign" do
       # Note: This should be the default behavior for reading approaching trains, rather than a
       # special case.


### PR DESCRIPTION
#### Summary of changes

This extracts several helpers related to predictions, as a part of the larger message refactoring effort. Notes:

* Removes special handling of "approaching" predictions, since only the audio path cares about them.
* Unifies the logic for determining "approximate" minute values, fixing some potential edge cases.
* Fixes a rare historical edge case where approaching predictions wouldn't be read out during the normal read loop.

Aside from these few cases, the overall system behavior should be unchanged.