### PR TITLE
[bugfix] Account for 3-part node descriptions

### DIFF
--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -77,7 +77,8 @@ defmodule Monitoring.Uptime do
   defp get_log_fields(%{"description" => description, "is_online" => is_online} = node) do
     node_type = get_node_type(node)
 
-    [line, station, device_id, maybe_sign_zone] = String.split(description, ":")
+    [line, station, device_id, maybe_sign_zone] =
+      String.split(description, ":") |> Enum.concat([nil]) |> Enum.take(4)
 
     log_fields = [
       tag: "device_uptime",

--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -77,8 +77,8 @@ defmodule Monitoring.Uptime do
   defp get_log_fields(%{"description" => description, "is_online" => is_online} = node) do
     node_type = get_node_type(node)
 
-    [line, station, device_id, maybe_sign_zone] =
-      String.split(description, ":") |> Enum.concat([nil]) |> Enum.take(4)
+    [line, station, device_id | rest] = String.split(description, ":")
+    maybe_sign_zone = List.first(rest)
 
     log_fields = [
       tag: "device_uptime",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Process ARINC JSON for LivePA connectivity into Splunk](https://app.asana.com/0/1185117109217413/1208851406631730/f)

After deploying the initial change, we lost logging of some device types. I think this is due to the description screen for these devices only having three parts to them rather than 4. Oddly, I'm not able to find any `MatchError` logs in Splunk which is what I would expect, but the `Endpoint` process is crashing every 2 minutes which is the cadence at which we receive device status logs.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
