### PR TITLE
aggregate PA message playback

### DIFF
--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -131,8 +131,9 @@ defmodule Signs.Bus do
            tts_audios :: [Content.Audio.tts_value()]}
 
   @impl true
-  def handle_info({:play_pa_message, pa_message}, sign) do
-    {:noreply, Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)}
+  def handle_call({:play_pa_message, pa_message}, _from, sign) do
+    {sign, should_play?} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)
+    {:reply, {sign, should_play?}, sign}
   end
 
   @impl true

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -136,8 +136,9 @@ defmodule Signs.Realtime do
     {:ok, sign}
   end
 
-  def handle_info({:play_pa_message, pa_message}, sign) do
-    {:noreply, Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)}
+  def handle_call({:play_pa_message, pa_message}, _from, sign) do
+    {sign, should_play?} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)
+    {:reply, {sign, should_play?}, sign}
   end
 
   def handle_info(:run_loop, sign) do

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -375,18 +375,17 @@ defmodule Signs.Utilities.Audio do
   end
 
   @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) ::
-          Signs.Realtime.t() | Signs.Bus.t()
+          {Signs.Realtime.t() | Signs.Bus.t(), boolean()}
   def handle_pa_message_play(pa_message, sign) do
     last_sent = sign.pa_message_plays[pa_message.id]
     now = DateTime.utc_now()
 
     if !last_sent || DateTime.diff(now, last_sent, :millisecond) >= pa_message.interval_in_ms do
       Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
-      send_audio(sign, [pa_message])
-      update_in(sign.pa_message_plays, &Map.put(&1, pa_message.id, now))
+      {update_in(sign.pa_message_plays, &Map.put(&1, pa_message.id, now)), true}
     else
       Logger.warn("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
-      sign
+      {sign, false}
     end
   end
 end

--- a/test/engine/pa_messages_test.exs
+++ b/test/engine/pa_messages_test.exs
@@ -1,5 +1,4 @@
 defmodule Engine.PaMessagesTest do
-  alias PaMessages.PaMessage
   use ExUnit.Case
 
   @state %{
@@ -45,14 +44,14 @@ defmodule Engine.PaMessagesTest do
 
       state = %{
         pa_messages_last_sent: %{
-          4 => {%PaMessage{}, last_played},
-          5 => {%PaMessage{}, last_played}
+          4 => last_played,
+          5 => last_played
         }
       }
 
       {:noreply, state} = Engine.PaMessages.handle_info(:update, state)
-      assert last_played == Map.get(state.pa_messages_last_sent, 4) |> elem(1)
-      assert last_played == Map.get(state.pa_messages_last_sent, 5) |> elem(1)
+      assert last_played == Map.get(state.pa_messages_last_sent, 4)
+      assert last_played == Map.get(state.pa_messages_last_sent, 5)
     end
 
     test "Ignores inactive PA messages" do
@@ -77,7 +76,7 @@ defmodule Engine.PaMessagesTest do
 
     test "Plays PA Message when interval is edited to be shorter" do
       last_play = DateTime.utc_now() |> DateTime.add(-2, :minute)
-      state = %{pa_messages_last_sent: %{5 => {%PaMessage{}, last_play}}}
+      state = %{pa_messages_last_sent: %{5 => last_play}}
 
       Application.put_env(
         :realtime_signs,
@@ -86,7 +85,7 @@ defmodule Engine.PaMessagesTest do
       )
 
       {:noreply, state} = Engine.PaMessages.handle_info(:update, state)
-      refute last_play == Map.get(state.pa_messages_last_sent, 5) |> elem(1)
+      refute last_play == Map.get(state.pa_messages_last_sent, 5)
     end
   end
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1788,24 +1788,17 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Plays message if no prior plays" do
-      expect_audios([{:ad_hoc, {"A PA Message", :audio_visual}}], [
-        {"A PA Message", [{"A PA Message", "", 3}]}
-      ])
-
       pa_message = %PaMessages.PaMessage{
         id: 1,
         visual_text: "A PA Message",
         audio_text: "A PA Message"
       }
 
-      Signs.Realtime.handle_info({:play_pa_message, pa_message}, @sign)
+      assert {:reply, {_, true}, _} =
+               Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, @sign)
     end
 
     test "Plays message if interval has passed" do
-      expect_audios([{:ad_hoc, {"A PA Message", :audio_visual}}], [
-        {"A PA Message", [{"A PA Message", "", 3}]}
-      ])
-
       pa_message = %PaMessages.PaMessage{
         id: 1,
         visual_text: "A PA Message",
@@ -1815,7 +1808,8 @@ defmodule Signs.RealtimeTest do
 
       sign = %{@sign | pa_message_plays: %{1 => ~U[2024-06-10 12:00:00.000Z]}}
 
-      Signs.Realtime.handle_info({:play_pa_message, pa_message}, sign)
+      assert {:reply, {_, true}, _} =
+               Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
     end
 
     test "Does not play if less than interval has passed" do
@@ -1828,7 +1822,8 @@ defmodule Signs.RealtimeTest do
 
       sign = %{@sign | pa_message_plays: %{1 => DateTime.utc_now()}}
 
-      Signs.Realtime.handle_info({:play_pa_message, pa_message}, sign)
+      assert {:reply, {_, false}, _} =
+               Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Revise RTS to remove PA Message bottleneck failures in Legacy PA/ESS](https://app.asana.com/0/1185117109217413/1208950993234729/f)

This changes the playback code for PA messages to send a single aggregate message to all targeted zones within a station, instead of individual per-sign messages. This involves moving the responsibility for playback into the PA message engine, and having the signs just provide their configs (and continue to track playbacks in order to guard against accidental duplicates).