### PR TITLE
Use "Southbound" for Red Line non revenue trains

### DIFF
--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -41,7 +41,11 @@ defmodule Content.Audio.Passthrough do
     end
 
     defp tts_text(%Content.Audio.Passthrough{} = audio) do
-      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+      train =
+        if audio.destination in [:ashmont, :braintree],
+          do: PaEss.Utilities.train_description(:southbound, audio.route_id),
+          else: PaEss.Utilities.train_description(audio.destination, audio.route_id)
+
       "The next #{train} does not take customers. Please stand back from the yellow line."
     end
 

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -56,8 +56,8 @@ defmodule Content.Audio.Passthrough do
 
     @spec destination_var(PaEss.destination(), String.t()) :: String.t() | nil
     defp destination_var(:alewife, _route_id), do: "32114"
-    defp destination_var(:ashmont, "Red"), do: "32117"
-    defp destination_var(:braintree, _route_id), do: "32118"
+    defp destination_var(:ashmont, "Red"), do: "891"
+    defp destination_var(:braintree, _route_id), do: "891"
     defp destination_var(:bowdoin, _route_id), do: "32111"
     defp destination_var(:wonderland, _route_id), do: "32110"
     defp destination_var(:forest_hills, _route_id), do: "32113"

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -41,11 +41,7 @@ defmodule Content.Audio.Passthrough do
     end
 
     defp tts_text(%Content.Audio.Passthrough{} = audio) do
-      train =
-        if audio.destination in [:ashmont, :braintree],
-          do: PaEss.Utilities.train_description(:southbound, audio.route_id),
-          else: PaEss.Utilities.train_description(audio.destination, audio.route_id)
-
+      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
       "The next #{train} does not take customers. Please stand back from the yellow line."
     end
 
@@ -60,8 +56,7 @@ defmodule Content.Audio.Passthrough do
 
     @spec destination_var(PaEss.destination(), String.t()) :: String.t() | nil
     defp destination_var(:alewife, _route_id), do: "32114"
-    defp destination_var(:ashmont, "Red"), do: "891"
-    defp destination_var(:braintree, _route_id), do: "891"
+    defp destination_var(:southbound, "Red"), do: "891"
     defp destination_var(:bowdoin, _route_id), do: "32111"
     defp destination_var(:wonderland, _route_id), do: "32110"
     defp destination_var(:forest_hills, _route_id), do: "32113"

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -68,9 +68,9 @@ defmodule Signs.Utilities.Predictions do
     |> Enum.sort_by(fn prediction -> prediction.seconds_until_passthrough end)
     |> Enum.flat_map(fn prediction ->
       destination =
-        case Content.Utilities.destination_for_prediction(prediction) do
-          :southbound -> :ashmont
-          destination -> destination
+        case prediction do
+          %{route_id: "Red", direction_id: 0} -> :southbound
+          _ -> Content.Utilities.destination_for_prediction(prediction)
         end
 
       [

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -175,11 +175,12 @@ defmodule Signs.RealtimeTest do
         ]
       end)
 
-      expect_audios([{:canned, {"103", ["32118"], :audio_visual}}], [
-        {"The next Braintree train does not take customers. Please stand back from the yellow line.",
+      expect_audios([{:canned, {"103", ["891"], :audio_visual}}], [
+        {"The next Southbound train does not take customers. Please stand back from the yellow line.",
          [
-           {"The next Braintree train", "does not take customers.", 3},
-           {"Please stand back from", "the yellow line.", 3}
+           {"The next Southbound", "train does not take", 3},
+           {"customers. Please stand", "back from the yellow", 3},
+           {"line.", "", 3}
          ]}
       ])
 
@@ -196,11 +197,12 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :alewife, seconds_until_passthrough: 30, trip_id: "124")]
       end)
 
-      expect_audios([{:canned, {"103", ["32118"], :audio_visual}}], [
-        {"The next Braintree train does not take customers. Please stand back from the yellow line.",
+      expect_audios([{:canned, {"103", ["891"], :audio_visual}}], [
+        {"The next Southbound train does not take customers. Please stand back from the yellow line.",
          [
-           {"The next Braintree train", "does not take customers.", 3},
-           {"Please stand back from", "the yellow line.", 3}
+           {"The next Southbound", "train does not take", 3},
+           {"customers. Please stand", "back from the yellow", 3},
+           {"line.", "", 3}
          ]}
       ])
 
@@ -220,11 +222,12 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :southbound, seconds_until_passthrough: 30)]
       end)
 
-      expect_audios([{:canned, {"103", ["32117"], :audio_visual}}], [
-        {"The next Ashmont train does not take customers. Please stand back from the yellow line.",
+      expect_audios([{:canned, {"103", ["891"], :audio_visual}}], [
+        {"The next Southbound train does not take customers. Please stand back from the yellow line.",
          [
-           {"The next Ashmont train", "does not take customers.", 3},
-           {"Please stand back from", "the yellow line.", 3}
+           {"The next Southbound", "train does not take", 3},
+           {"customers. Please stand", "back from the yellow", 3},
+           {"line.", "", 3}
          ]}
       ])
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Use "Southbound" instead of Ashmont/Braintree for non-revenue trains](https://app.asana.com/0/1185117109217413/1208651243993394/f)

Adds take `891` which announces Ashmont and Braintree Red Line passthroughs as "Southbound". Also adjusts the TTS codepaths to do the same.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
