### PR TITLE
introduce Message structs

### DIFF
--- a/lib/message.ex
+++ b/lib/message.ex
@@ -1,0 +1,13 @@
+defprotocol Message do
+  @doc "render a single line of content, may include line-level paging"
+  @spec to_single_line(Message.t()) :: Content.Message.t()
+  def to_single_line(message)
+
+  @doc "render two lines of content, must not include line-level paging"
+  @spec to_full_page(Message.t()) :: {Content.Message.t(), Content.Message.t()}
+  def to_full_page(message)
+
+  @doc "render two lines of content, may include line-level paging"
+  @spec to_multi_line(Message.t()) :: {Content.Message.t(), Content.Message.t()}
+  def to_multi_line(message)
+end

--- a/lib/message/alert.ex
+++ b/lib/message/alert.ex
@@ -1,0 +1,67 @@
+defmodule Message.Alert do
+  @enforce_keys [:route, :destination, :status, :uses_shuttles?, :union_square?]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination(),
+          route: String.t() | nil,
+          status: Engine.Alerts.Fetcher.stop_status(),
+          uses_shuttles?: boolean(),
+          union_square?: boolean()
+        }
+
+  defimpl Message do
+    def to_single_line(
+          %Message.Alert{status: :shuttles_closed_station, uses_shuttles?: true} = message
+        ) do
+      %Content.Message.Alert.NoServiceUseShuttle{
+        route: message.route,
+        destination: message.destination
+      }
+    end
+
+    def to_single_line(
+          %Message.Alert{status: :shuttles_closed_station, uses_shuttles?: false} = message
+        ) do
+      %Content.Message.Alert.DestinationNoService{
+        route: message.route,
+        destination: message.destination
+      }
+    end
+
+    def to_single_line(%Message.Alert{status: status} = message)
+        when status in [:suspension_closed_station, :station_closure] do
+      %Content.Message.Alert.DestinationNoService{
+        route: message.route,
+        destination: message.destination
+      }
+    end
+
+    def to_full_page(%Message.Alert{union_square?: true} = message) do
+      {%Content.Message.Alert.NoService{route: message.route, destination: message.destination},
+       %Content.Message.Alert.UseRoutes{}}
+    end
+
+    def to_full_page(
+          %Message.Alert{status: :shuttles_closed_station, uses_shuttles?: true} = message
+        ) do
+      {%Content.Message.Alert.NoService{route: message.route, destination: message.destination},
+       %Content.Message.Alert.UseShuttleBus{}}
+    end
+
+    def to_full_page(
+          %Message.Alert{status: :shuttles_closed_station, uses_shuttles?: false} = message
+        ) do
+      {%Content.Message.Alert.NoService{route: message.route, destination: message.destination},
+       %Content.Message.Empty{}}
+    end
+
+    def to_full_page(%Message.Alert{status: status} = message)
+        when status in [:suspension_closed_station, :station_closure] do
+      {%Content.Message.Alert.NoService{route: message.route, destination: message.destination},
+       %Content.Message.Empty{}}
+    end
+
+    def to_multi_line(%Message.Alert{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/message/custom.ex
+++ b/lib/message/custom.ex
@@ -1,0 +1,22 @@
+defmodule Message.Custom do
+  @enforce_keys [:top, :bottom]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          top: String.t(),
+          bottom: String.t()
+        }
+
+  defimpl Message do
+    def to_single_line(%Message.Custom{}) do
+      raise "Cannot render custom message on one line"
+    end
+
+    def to_full_page(%Message.Custom{} = message) do
+      {Content.Message.Custom.new(message.top, :top),
+       Content.Message.Custom.new(message.bottom, :bottom)}
+    end
+
+    def to_multi_line(%Message.Custom{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/message/empty.ex
+++ b/lib/message/empty.ex
@@ -1,0 +1,17 @@
+defmodule Message.Empty do
+  defstruct []
+
+  @type t :: %__MODULE__{}
+
+  defimpl Message do
+    def to_single_line(%Message.Empty{}) do
+      %Content.Message.Empty{}
+    end
+
+    def to_full_page(%Message.Empty{}) do
+      {%Content.Message.Empty{}, %Content.Message.Empty{}}
+    end
+
+    def to_multi_line(%Message.Empty{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/message/first_train.ex
+++ b/lib/message/first_train.ex
@@ -1,0 +1,25 @@
+defmodule Message.FirstTrain do
+  @enforce_keys [:destination, :scheduled]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination(),
+          scheduled: DateTime.t()
+        }
+
+  defimpl Message do
+    def to_single_line(%Message.FirstTrain{destination: destination, scheduled: scheduled}) do
+      %Content.Message.EarlyAm.DestinationScheduledTime{
+        destination: destination,
+        scheduled_time: scheduled
+      }
+    end
+
+    def to_full_page(%Message.FirstTrain{destination: destination, scheduled: scheduled}) do
+      {%Content.Message.EarlyAm.DestinationTrain{destination: destination},
+       %Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled}}
+    end
+
+    def to_multi_line(%Message.FirstTrain{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/message/headway.ex
+++ b/lib/message/headway.ex
@@ -1,0 +1,23 @@
+defmodule Message.Headway do
+  @enforce_keys [:route, :destination, :range]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination() | nil,
+          range: {non_neg_integer(), non_neg_integer()},
+          route: String.t() | nil
+        }
+
+  defimpl Message do
+    def to_single_line(%Message.Headway{destination: destination, range: range, route: route}) do
+      %Content.Message.Headways.Paging{destination: destination, range: range, route: route}
+    end
+
+    def to_full_page(%Message.Headway{destination: destination, range: range, route: route}) do
+      {%Content.Message.Headways.Top{destination: destination, route: route},
+       %Content.Message.Headways.Bottom{range: range}}
+    end
+
+    def to_multi_line(%Message.Headway{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -1,0 +1,42 @@
+defmodule Message.Predictions do
+  @enforce_keys [:predictions, :terminal?, :special_sign]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          predictions: [Predictions.Prediction.t()],
+          terminal?: boolean(),
+          special_sign: :jfk_mezzanine | :bowdoin_eastbound | nil
+        }
+
+  defimpl Message do
+    def to_single_line(%Message.Predictions{predictions: [top | _]} = message) do
+      prediction_message(top, message.terminal?, message.special_sign)
+    end
+
+    def to_full_page(
+          %Message.Predictions{predictions: [top | _], special_sign: :jfk_mezzanine} = message
+        ) do
+      {minutes, _} = PaEss.Utilities.prediction_minutes(top, message.terminal?)
+
+      {prediction_message(top, message.terminal?, nil),
+       %Content.Message.PlatformPredictionBottom{stop_id: top.stop_id, minutes: minutes}}
+    end
+
+    def to_multi_line(%Message.Predictions{predictions: [top]} = message) do
+      {prediction_message(top, message.terminal?, message.special_sign), %Content.Message.Empty{}}
+    end
+
+    def to_multi_line(%Message.Predictions{predictions: [top, bottom]} = message) do
+      {prediction_message(top, message.terminal?, message.special_sign),
+       prediction_message(bottom, message.terminal?, message.special_sign)}
+    end
+
+    defp prediction_message(prediction, terminal?, special_sign) do
+      if PaEss.Utilities.prediction_stopped?(prediction, terminal?) do
+        Content.Message.StoppedTrain.new(prediction, terminal?, special_sign)
+      else
+        Content.Message.Predictions.new(prediction, terminal?, special_sign)
+      end
+    end
+  end
+end

--- a/lib/message/service_ended.ex
+++ b/lib/message/service_ended.ex
@@ -1,0 +1,27 @@
+defmodule Message.ServiceEnded do
+  @enforce_keys [:route, :destination]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          destination: PaEss.destination() | nil,
+          route: String.t() | nil
+        }
+
+  defimpl Message do
+    def to_single_line(%Message.ServiceEnded{route: route, destination: destination}) do
+      %Content.Message.LastTrip.NoService{destination: destination, route: route}
+    end
+
+    def to_full_page(%Message.ServiceEnded{destination: nil, route: route}) do
+      {%Content.Message.LastTrip.StationClosed{route: route},
+       %Content.Message.LastTrip.ServiceEnded{destination: nil}}
+    end
+
+    def to_full_page(%Message.ServiceEnded{destination: destination}) do
+      {%Content.Message.LastTrip.PlatformClosed{destination: destination},
+       %Content.Message.LastTrip.ServiceEnded{destination: destination}}
+    end
+
+    def to_multi_line(%Message.ServiceEnded{} = message), do: to_full_page(message)
+  end
+end

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -6,30 +6,14 @@ defmodule Signs.Utilities.Headways do
   alias Signs.Utilities.SourceConfig
   require Logger
 
-  @spec headway_messages(SourceConfig.config(), DateTime.t()) ::
-          Signs.Realtime.sign_messages() | nil
-  def headway_messages(config, current_time) do
-    case fetch_headways(config.headway_group, config.sources, current_time) do
-      nil ->
-        nil
-
-      headways ->
-        {%Content.Message.Headways.Top{
-           destination: config.headway_destination,
-           route: SourceConfig.single_route(config)
-         }, %Content.Message.Headways.Bottom{range: {headways.range_low, headways.range_high}}}
-    end
-  end
-
-  @spec headway_message(SourceConfig.config(), DateTime.t()) ::
-          Signs.Realtime.line_content() | nil
+  @spec headway_message(SourceConfig.config(), DateTime.t()) :: Message.t() | nil
   def headway_message(config, current_time) do
     case fetch_headways(config.headway_group, config.sources, current_time) do
       nil ->
         nil
 
       headways ->
-        %Content.Message.Headways.Paging{
+        %Message.Headway{
           destination: config.headway_destination,
           range: {headways.range_low, headways.range_high},
           route: SourceConfig.single_route(config)

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -4,7 +4,6 @@ defmodule Signs.Utilities.Messages do
   be displaying
   """
 
-  alias Content.Message.Alert
   @early_am_start ~T[03:29:00]
   @early_am_buffer -40
 
@@ -30,145 +29,111 @@ defmodule Signs.Utilities.Messages do
     cond do
       match?({:static_text, {_, _}}, sign_config) ->
         {:static_text, {line1, line2}} = sign_config
-
-        {Content.Message.Custom.new(line1, :top), Content.Message.Custom.new(line2, :bottom)}
+        [%Message.Custom{top: line1, bottom: line2}]
 
       sign_config == :off ->
-        {%Content.Message.Empty{}, %Content.Message.Empty{}}
+        [%Message.Empty{}]
 
-      match?(%{source_config: {_, _}}, sign) ->
-        Enum.zip([
-          Tuple.to_list(sign.source_config),
-          Tuple.to_list(predictions),
-          Tuple.to_list(alert_status),
-          Tuple.to_list(scheduled),
-          Tuple.to_list(service_status)
-        ])
+      true ->
+        if match?(%{source_config: {_, _}}, sign) do
+          Enum.zip([
+            Tuple.to_list(sign.source_config),
+            Tuple.to_list(predictions),
+            Tuple.to_list(alert_status),
+            Tuple.to_list(scheduled),
+            Tuple.to_list(service_status)
+          ])
+        else
+          [{sign.source_config, predictions, alert_status, scheduled, service_status}]
+        end
         |> Enum.map(fn {config, predictions, alert_status, scheduled, service_status} ->
           predictions =
             filter_predictions(predictions, config, sign_config, current_time, scheduled)
 
           alert_status = filter_alert_status(alert_status, sign_config)
 
-          Signs.Utilities.Predictions.prediction_message(predictions, config, sign) ||
+          prediction_message(predictions, config, sign) ||
             service_ended_message(service_status, config) ||
             alert_message(alert_status, sign, config) ||
             Signs.Utilities.Headways.headway_message(config, current_time) ||
             early_am_message(current_time, scheduled, config) ||
-            %Content.Message.Empty{}
+            %Message.Empty{}
         end)
-        |> List.to_tuple()
-        |> transform_messages()
+    end
+    |> transform_messages()
+    |> render_messages()
+  end
+
+  @spec transform_messages([Message.t()]) :: [Message.t()]
+  defp transform_messages([
+         %Message.Headway{range: range} = top,
+         %Message.Headway{range: range} = bottom
+       ]) do
+    [
+      %Message.Headway{
+        destination: nil,
+        route: combine_routes(top.route, bottom.route),
+        range: range
+      }
+    ]
+  end
+
+  defp transform_messages([
+         %Message.Alert{status: status} = top,
+         %Message.Alert{status: status} = bottom
+       ]) do
+    [
+      %Message.Alert{
+        destination: nil,
+        route: combine_routes(top.route, bottom.route),
+        status: status,
+        uses_shuttles?: top.uses_shuttles?,
+        union_square?: top.union_square?
+      }
+    ]
+  end
+
+  defp transform_messages([%Message.ServiceEnded{} = top, %Message.ServiceEnded{} = bottom]) do
+    [%Message.ServiceEnded{destination: nil, route: combine_routes(top.route, bottom.route)}]
+  end
+
+  defp transform_messages(messages), do: messages
+
+  defp render_messages([single]) do
+    Message.to_multi_line(single)
+  end
+
+  defp render_messages([top, bottom]) do
+    cond do
+      fits_on_top_line?(top) ->
+        {Message.to_single_line(top), Message.to_single_line(bottom)}
+
+      fits_on_top_line?(bottom) ->
+        {Message.to_single_line(bottom), Message.to_single_line(top)}
+
+      can_shrink?(top) ->
+        {%{Message.to_single_line(top) | variant: :short}, Message.to_single_line(bottom)}
+
+      can_shrink?(bottom) ->
+        {%{Message.to_single_line(bottom) | variant: :short}, Message.to_single_line(top)}
 
       true ->
-        config = sign.source_config
-
-        predictions =
-          filter_predictions(predictions, config, sign_config, current_time, scheduled)
-
-        alert_status = filter_alert_status(alert_status, sign_config)
-
-        Signs.Utilities.Predictions.prediction_messages(predictions, config, sign) ||
-          service_ended_messages(service_status, config) ||
-          alert_messages(alert_status, sign, config) ||
-          Signs.Utilities.Headways.headway_messages(config, current_time) ||
-          early_am_messages(current_time, scheduled, config) ||
-          {%Content.Message.Empty{}, %Content.Message.Empty{}}
-    end
-  end
-
-  @spec transform_messages(Signs.Realtime.sign_messages()) :: Signs.Realtime.sign_messages()
-  defp transform_messages(
-         {%Content.Message.Headways.Paging{range: range, route: top_route},
-          %Content.Message.Headways.Paging{range: range, route: bottom_route}}
-       ) do
-    {%Content.Message.Headways.Top{route: combine_routes(top_route, bottom_route)},
-     %Content.Message.Headways.Bottom{range: range}}
-  end
-
-  defp transform_messages(
-         {%Content.Message.Alert.DestinationNoService{route: top_route},
-          %Content.Message.Alert.DestinationNoService{route: bottom_route}}
-       ) do
-    {%Content.Message.Alert.NoService{route: combine_routes(top_route, bottom_route)},
-     %Content.Message.Empty{}}
-  end
-
-  defp transform_messages(
-         {%Content.Message.Alert.NoServiceUseShuttle{route: top_route},
-          %Content.Message.Alert.NoServiceUseShuttle{route: bottom_route}}
-       ) do
-    {%Content.Message.Alert.NoService{route: combine_routes(top_route, bottom_route)},
-     %Alert.UseShuttleBus{}}
-  end
-
-  defp transform_messages(
-         {%Content.Message.LastTrip.NoService{route: top_route},
-          %Content.Message.LastTrip.NoService{route: bottom_route}}
-       ) do
-    {%Content.Message.LastTrip.StationClosed{route: combine_routes(top_route, bottom_route)},
-     %Content.Message.LastTrip.ServiceEnded{}}
-  end
-
-  defp transform_messages({top, bottom}) do
-    cond do
-      fits_on_top_line?(top) -> {top, bottom}
-      fits_on_top_line?(bottom) -> {bottom, top}
-      can_shrink?(top) -> {%{top | variant: :short}, bottom}
-      can_shrink?(bottom) -> {%{bottom | variant: :short}, top}
-      true -> paginate(expand_message(top), expand_message(bottom))
+        paginate(Message.to_full_page(top), Message.to_full_page(bottom))
     end
   end
 
   defp fits_on_top_line?(message) do
-    case Content.Message.to_string(message) do
+    case Message.to_single_line(message) |> Content.Message.to_string() do
       list when is_list(list) -> Enum.map(list, &elem(&1, 0))
       single -> [single]
     end
     |> Enum.all?(&(String.length(&1) <= 18))
   end
 
-  defp can_shrink?(message), do: Map.has_key?(message, :variant)
+  defp can_shrink?(message), do: Message.to_single_line(message) |> Map.has_key?(:variant)
 
   defp combine_routes(route, route), do: route
   defp combine_routes(_, _), do: nil
-
-  @spec expand_message(Content.Message.t()) :: Signs.Realtime.sign_messages()
-  defp expand_message(%Content.Message.Headways.Paging{
-         range: range,
-         route: route,
-         destination: destination
-       }) do
-    {%Content.Message.Headways.Top{route: route, destination: destination},
-     %Content.Message.Headways.Bottom{range: range}}
-  end
-
-  defp expand_message(
-         %Content.Message.Predictions{
-           special_sign: :jfk_mezzanine,
-           prediction: %{stop_id: stop_id},
-           minutes: minutes
-         } = prediction
-       ) do
-    {%{prediction | special_sign: nil},
-     %Content.Message.PlatformPredictionBottom{stop_id: stop_id, minutes: minutes}}
-  end
-
-  defp expand_message(%Content.Message.EarlyAm.DestinationScheduledTime{
-         destination: destination,
-         scheduled_time: scheduled_time
-       }) do
-    {%Content.Message.EarlyAm.DestinationTrain{destination: destination},
-     %Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled_time}}
-  end
-
-  defp expand_message(%Content.Message.Alert.NoServiceUseShuttle{
-         route: route,
-         destination: destination
-       }) do
-    {%Content.Message.Alert.NoService{destination: destination, route: route},
-     %Alert.UseShuttleBus{}}
-  end
 
   defp paginate({first_top, first_bottom}, {second_top, second_bottom}) do
     {%Content.Message.GenericPaging{messages: [first_top, second_top]},
@@ -276,82 +241,52 @@ defmodule Signs.Utilities.Messages do
     Timex.before?(current_time, Timex.shift(scheduled, minutes: @early_am_buffer))
   end
 
-  defp early_am_message(current_time, scheduled_time, config) do
-    if in_early_am?(current_time, scheduled_time) do
-      %Content.Message.EarlyAm.DestinationScheduledTime{
-        destination: config.headway_destination,
-        scheduled_time: scheduled_time
+  @spec prediction_message(
+          [Predictions.Prediction.t()],
+          Signs.Utilities.SourceConfig.config(),
+          Signs.Realtime.t()
+        ) :: Message.t() | nil
+  defp prediction_message(predictions, %{terminal?: terminal?}, sign) do
+    if predictions != [] do
+      %Message.Predictions{
+        predictions: predictions,
+        terminal?: terminal?,
+        special_sign:
+          case sign do
+            %{pa_ess_loc: "RJFK", text_zone: "m"} -> :jfk_mezzanine
+            %{pa_ess_loc: "BBOW", text_zone: "e"} -> :bowdoin_eastbound
+            _ -> nil
+          end
       }
     end
   end
 
-  defp early_am_messages(current_time, scheduled_time, config) do
+  defp early_am_message(current_time, scheduled_time, config) do
     if in_early_am?(current_time, scheduled_time) do
-      {%Content.Message.EarlyAm.DestinationTrain{destination: config.headway_destination},
-       %Content.Message.EarlyAm.ScheduledTime{scheduled_time: scheduled_time}}
-    end
-  end
-
-  defp alert_messages(alert_status, %{pa_ess_loc: "GUNS"}, config) do
-    route = Signs.Utilities.SourceConfig.single_route(config)
-    destination = config.headway_destination
-
-    if alert_status in [:none, :alert_along_route],
-      do: nil,
-      else: {%Alert.NoService{route: route, destination: destination}, %Alert.UseRoutes{}}
-  end
-
-  defp alert_messages(alert_status, sign, config) do
-    route = Signs.Utilities.SourceConfig.single_route(config)
-    destination = config.headway_destination
-
-    case {alert_status, sign.uses_shuttles} do
-      {:shuttles_transfer_station, _} ->
-        {%Content.Message.Empty{}, %Content.Message.Empty{}}
-
-      {:shuttles_closed_station, true} ->
-        {%Alert.NoService{route: route, destination: destination}, %Alert.UseShuttleBus{}}
-
-      {:shuttles_closed_station, false} ->
-        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
-
-      {:suspension_transfer_station, _} ->
-        {%Content.Message.Empty{}, %Content.Message.Empty{}}
-
-      {:suspension_closed_station, _} ->
-        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
-
-      {:station_closure, _} ->
-        {%Alert.NoService{route: route, destination: destination}, %Content.Message.Empty{}}
-
-      _ ->
-        nil
+      %Message.FirstTrain{destination: config.headway_destination, scheduled: scheduled_time}
     end
   end
 
   defp alert_message(alert_status, sign, config) do
     route = Signs.Utilities.SourceConfig.single_route(config)
+    transfer_alert? = alert_status in [:suspension_transfer_station, :shuttles_transfer_station]
+    union_square? = sign.pa_ess_loc == "GUNS"
 
-    case {alert_status, sign.uses_shuttles} do
-      {:shuttles_transfer_station, _} ->
-        %Content.Message.Empty{}
+    cond do
+      alert_status in [:shuttles_closed_station, :suspension_closed_station, :station_closure] or
+          (union_square? and transfer_alert?) ->
+        %Message.Alert{
+          route: route,
+          destination: config.headway_destination,
+          status: alert_status,
+          uses_shuttles?: sign.uses_shuttles,
+          union_square?: union_square?
+        }
 
-      {:shuttles_closed_station, true} ->
-        %Alert.NoServiceUseShuttle{route: route, destination: config.headway_destination}
+      transfer_alert? ->
+        %Message.Empty{}
 
-      {:shuttles_closed_station, false} ->
-        %Alert.DestinationNoService{route: route, destination: config.headway_destination}
-
-      {:suspension_transfer_station, _} ->
-        %Content.Message.Empty{}
-
-      {:suspension_closed_station, _} ->
-        %Alert.DestinationNoService{route: route, destination: config.headway_destination}
-
-      {:station_closure, _} ->
-        %Alert.DestinationNoService{route: route, destination: config.headway_destination}
-
-      _ ->
+      true ->
         nil
     end
   end
@@ -360,14 +295,7 @@ defmodule Signs.Utilities.Messages do
     route = Signs.Utilities.SourceConfig.single_route(config)
 
     if service_ended? do
-      %Content.Message.LastTrip.NoService{destination: config.headway_destination, route: route}
-    end
-  end
-
-  defp service_ended_messages(service_ended?, config) do
-    if service_ended? do
-      {%Content.Message.LastTrip.PlatformClosed{destination: config.headway_destination},
-       %Content.Message.LastTrip.ServiceEnded{destination: config.headway_destination}}
+      %Message.ServiceEnded{destination: config.headway_destination, route: route}
     end
   end
 end

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -5,50 +5,6 @@ defmodule Signs.Utilities.Predictions do
   for the top and bottom lines.
   """
 
-  require Logger
-  require Content.Utilities
-  alias Signs.Utilities.SourceConfig
-
-  def prediction_message(predictions, config, sign) do
-    case prediction_messages(predictions, config, sign) do
-      nil -> nil
-      {first, _} -> first
-    end
-  end
-
-  @spec prediction_messages(
-          [Predictions.Prediction.t()],
-          SourceConfig.config(),
-          Signs.Realtime.t()
-        ) :: Signs.Realtime.sign_messages() | nil
-  def prediction_messages(predictions, %{terminal?: terminal?}, sign) do
-    special_sign =
-      case sign do
-        %{pa_ess_loc: "RJFK", text_zone: "m"} -> :jfk_mezzanine
-        %{pa_ess_loc: "BBOW", text_zone: "e"} -> :bowdoin_eastbound
-        _ -> nil
-      end
-
-    predictions
-    |> Enum.map(fn prediction ->
-      if PaEss.Utilities.prediction_stopped?(prediction, terminal?) do
-        Content.Message.StoppedTrain.new(prediction, terminal?, special_sign)
-      else
-        Content.Message.Predictions.new(prediction, terminal?, special_sign)
-      end
-    end)
-    |> case do
-      [] ->
-        nil
-
-      [msg] ->
-        {msg, Content.Message.Empty.new()}
-
-      [msg1, msg2] ->
-        {msg1, msg2}
-    end
-  end
-
   @spec get_passthrough_train_audio(Signs.Realtime.predictions()) :: [Content.Audio.t()]
   def get_passthrough_train_audio({top_predictions, bottom_predictions}) do
     prediction_passthrough_audios(top_predictions) ++


### PR DESCRIPTION
#### Summary of changes

This introduces a new `Message` protocol and associated structs as part of the ongoing refactoring effort. These new structs represent a piece of sign content at a purely semantic level, in contrast with the existing `Content.Message` structs which encode more concrete, line-level content. The new protocol allows these abstract messages to be "rendered" into various concrete visual (and eventually audio) forms.

Conceptually, message generation is broken into several steps: First, generate the abstract messages to display. Then, optionally transform these messages, e.g. to combine headway or alert statuses. Finally, render the messages into actual line content, including flipping, shortening, or paging as needed.

One immediate benefit of this change is that the message generation algorithm is no longer split between the platform and mezzanine cases. A followup PR will leverage this new framework to generate audio messages as well.

Note that although we still assume we're dealing with at most 2 messages, nothing about this approach specifically requires that. It would be reasonably straightforward to support more messages at some point by rewriting `transform_messages` and `render_messages` accordingly.