### PR TITLE
wire up message priority

### DIFF
--- a/lib/pa_ess/scu_updater.ex
+++ b/lib/pa_ess/scu_updater.ex
@@ -41,7 +41,7 @@ defmodule PaEss.ScuUpdater do
 
     if scu_ip_map do
       http_poster.post(
-        "https://#{Map.fetch!(scu_ip_map, scu_id)}#{path}",
+        "http://#{Map.fetch!(scu_ip_map, scu_id)}#{path}",
         body,
         [{"Content-type", "application/json"}, {"x-api-key", scully_api_key}],
         hackney: [pool: :arinc_pool]
@@ -70,7 +70,7 @@ defmodule PaEss.ScuUpdater do
 
     if sign_ui_url do
       http_poster.post(
-        "https://#{sign_ui_url}#{path}",
+        "http://#{sign_ui_url}#{path}",
         body,
         [
           {"Content-type", "application/json"},

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -56,6 +56,7 @@ defmodule PaEss.Updater do
               Signs.Realtime.t() | Signs.Bus.t(),
               [Content.Audio.value()],
               [Content.Audio.tts_value()],
+              integer(),
               [keyword()]
             ) ::
               :ok
@@ -68,6 +69,7 @@ defmodule PaEss.Updater do
         },
         audios,
         tts_audios,
+        priority,
         log_metas
       ) do
     tags = Enum.map(audios, fn _ -> create_tag() end)
@@ -110,6 +112,7 @@ defmodule PaEss.Updater do
                audio_zones: audio_zones,
                audio_data: [Base.encode64(file)],
                expiration: 30,
+               priority: priority,
                tag: tag
              }, log_meta}
           )

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -975,6 +975,7 @@ defmodule Signs.Bus do
         state,
         audios,
         tts_audios,
+        2,
         Enum.map(audios, fn _ -> [message_type: "Bus"] end)
       )
     end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -365,6 +365,10 @@ defmodule Signs.Utilities.Audio do
       sign,
       Enum.map(audios, &Content.Audio.to_params(&1)),
       Enum.map(audios, &Content.Audio.to_tts(&1)),
+      case audios do
+        [%PaMessages.PaMessage{priority: priority}] -> priority
+        _ -> 2
+      end,
       Enum.map(audios, fn audio ->
         [message_type: Module.split(audio.__struct__) |> List.last()] ++
           Content.Audio.to_logs(audio)

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -420,7 +420,7 @@ defmodule Signs.BusTest do
   end
 
   defp expect_audios(audios, tts_audios) do
-    expect(PaEss.Updater.Mock, :play_message, fn _, list, tts_list, _ ->
+    expect(PaEss.Updater.Mock, :play_message, fn _, list, tts_list, _, _ ->
       assert list == audios
       assert tts_list == tts_audios
       :ok

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1876,7 +1876,7 @@ defmodule Signs.RealtimeTest do
   end
 
   defp expect_audios(audios, tts_audios) do
-    expect(PaEss.Updater.Mock, :play_message, fn _, list, tts_list, _ ->
+    expect(PaEss.Updater.Mock, :play_message, fn _, list, tts_list, _, _ ->
       assert audios == list
       assert tts_audios == tts_list
       :ok


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Fix announcement priority for migrated SCUs](https://app.asana.com/0/1185117109217422/1209272297071108/f)

This passes the required priority value to Scully when playing messages. Priority `2` is default, except PA messages which specify their own priority. Also fixes incorrect usage of `https`, which should be `http`