### PR TITLE
add carriage details to prediction

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -810,18 +810,13 @@ defmodule PaEss.Utilities do
 
   @spec prediction_new_cars?(Predictions.Prediction.t()) :: boolean()
   def prediction_new_cars?(prediction) do
-    case RealtimeSigns.location_engine().for_vehicle(prediction.vehicle_id) do
-      %Locations.Location{route_id: "Red", multi_carriage_details: carriage_details} ->
-        Enum.any?(carriage_details, fn carriage ->
-          # See http://roster.transithistory.org/ for numbers of new cars
-          case Integer.parse(carriage.label) do
-            :error -> false
-            {n, _remaining} -> n in 1900..2151
-          end
-        end)
-
-      _ ->
-        false
-    end
+    prediction.route_id == "Red" and !!prediction.multi_carriage_details and
+      Enum.any?(prediction.multi_carriage_details, fn carriage ->
+        # See http://roster.transithistory.org/ for numbers of new cars
+        case Integer.parse(carriage.label) do
+          :error -> false
+          {n, _remaining} -> n in 1900..2151
+        end
+      end)
   end
 end

--- a/lib/predictions/prediction.ex
+++ b/lib/predictions/prediction.ex
@@ -12,6 +12,7 @@ defmodule Predictions.Prediction do
             boarding_status: nil,
             revenue_trip?: true,
             vehicle_id: nil,
+            multi_carriage_details: nil,
             type: nil
 
   @type trip_id :: String.t()
@@ -31,6 +32,7 @@ defmodule Predictions.Prediction do
           boarding_status: String.t() | nil,
           revenue_trip?: boolean(),
           vehicle_id: String.t() | nil,
+          multi_carriage_details: [Locations.CarriageDetails.t()] | nil,
           type: prediction_type()
         }
 end

--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -109,6 +109,7 @@ defmodule Predictions.Predictions do
       boarding_status: stop_time_update["boarding_status"],
       revenue_trip?: revenue_trip?,
       vehicle_id: vehicle_id,
+      multi_carriage_details: if(vehicle_location, do: vehicle_location.multi_carriage_details),
       type: prediction_type
     }
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Special message for 4car RL consists](https://app.asana.com/0/1185117109217422/1209181549811302)

This attaches the `multi_carriage_details` field from the location struct to the prediction, so we can use it for checking for 4-car trains and new Red Line cars. This is straightforward because we already look up the location data when generating each prediction.