### PR TITLE
passive readout for ARR/BRD

### DIFF
--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -39,26 +39,13 @@ defmodule Message.Predictions do
 
       Enum.take(message.predictions, if(multiple?, do: 1, else: 2))
       |> Enum.zip(if(same_destination?, do: [:next, :following], else: [:next, :next]))
-      |> Enum.flat_map(fn {prediction, next_or_following} ->
-        {minutes, _} = PaEss.Utilities.prediction_minutes(prediction, message.terminal?)
-
-        case minutes do
-          :boarding ->
-            Content.Audio.TrainIsBoarding.new(prediction, message.special_sign)
-
-          :arriving ->
-            Content.Audio.TrainIsArriving.new(prediction, nil)
-
-          _ ->
-            [
-              %Content.Audio.Predictions{
-                prediction: prediction,
-                special_sign: message.special_sign,
-                terminal?: message.terminal?,
-                next_or_following: next_or_following
-              }
-            ]
-        end
+      |> Enum.map(fn {prediction, next_or_following} ->
+        %Content.Audio.Predictions{
+          prediction: prediction,
+          special_sign: message.special_sign,
+          terminal?: message.terminal?,
+          next_or_following: next_or_following
+        }
       end)
     end
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1038,12 +1038,11 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [
-          {:canned, {"103", ["32107"], :audio_visual}},
+          {:canned, {"109", spaced(["501", "4016", "864", "24055"]), :audio}},
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5002", "505"]), :audio}}
         ],
         [
-          {"Attention passengers: The next Ashmont train is now arriving.",
-           [{"Ashmont train", "now arriving", 6}]},
+          {"The next Ashmont train is now arriving.", nil},
           {"The following Ashmont train arrives in 2 minutes.", nil}
         ]
       )
@@ -1065,12 +1064,11 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [
           {:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5002", "505"]), :audio}},
-          {:canned, {"103", ["32104"], :audio_visual}}
+          {:canned, {"109", spaced(["501", "4000", "864", "24055"]), :audio}}
         ],
         [
           {"The next Ashmont train arrives in 2 minutes.", nil},
-          {"Attention passengers: The next Alewife train is now arriving.",
-           [{"Alewife train", "now arriving", 6}]}
+          {"The next Alewife train is now arriving.", nil}
         ]
       )
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change timing/existence of approaching/arriving messages](https://app.asana.com/0/1185117109217413/1209206869122456)

This is a precursor to changing the structure of approaching/arriving announcements. Previously we borrowed the arriving/boarding announcement audios when generating passive readouts of predictions with those statuses. This changes to use a special, passive phrasing for this, which also doesn't include the (extraneous) visual component.

Note that this will almost never actually happen in practice, because the transition to those states will generate the corresponding announcement, which will then _delay_ passive readouts (typically until that status is over). However, this change will allow us to delete the arriving announcement code shortly. Product has ok'd the user-facing change.