### PR TITLE
streamline approaching announcement

### DIFF
--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -24,23 +24,11 @@ defmodule Content.Audio.ApproachingTest do
       assert Content.Audio.to_params(audio) == nil
     end
 
-    test "No longer returns params for new Orange Line cars" do
-      audio = %Approaching{destination: :oak_grove, route_id: "Orange", new_cars?: true}
-
-      assert Content.Audio.to_params(audio) ==
-               {:canned, {"103", ["32122"], :audio_visual}}
-    end
-
     test "Returns params for new Red Line cars" do
       audio = %Approaching{destination: :alewife, route_id: "Red", new_cars?: true}
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"106", ["783", "4000", "21000", "786"], :audio_visual}}
-    end
-
-    test "Falls back on audio without new cars message if needed" do
-      audio = %Approaching{destination: :bowdoin, route_id: "Blue", new_cars?: true}
-      assert Content.Audio.to_params(audio) == {:canned, {"103", ["32121"], :audio_visual}}
+               {:canned, {"107", ["783", "21000", "4000", "21000", "786"], :audio_visual}}
     end
 
     test "Returns crowding info" do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1458,7 +1458,7 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Ashmont      1 min", ""})
 
-      expect_audios([{:canned, {"106", ["783", "4016", "21000", "786"], :audio_visual}}], [
+      expect_audios([{:canned, {"107", spaced(["783", "4016", "786"]), :audio_visual}}], [
         {"Attention passengers: The next Ashmont train is now approaching, with all new Red Line cars.",
          [{"Ashmont train", "now approaching", 6}, {"with all new Red Line", "cars", 3}]}
       ])


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Change timing/existence of approaching/arriving messages](https://app.asana.com/0/1185117109217413/1209206869122456)

This is a preliminary change in support of both the approaching/arriving consolidation and the new four-cars announcements. It unifies the code paths for creating approaching audio, and removes some extraneous checks. Note that while this removes some RL-specific guards in this code, the upstream code already does a similar restriction, so the end result is the same.

The slight change in output is the result of adding an extra space to the message for consistency, which shouldn't have any visible impact after the message is formatted.