### PR TITLE
use new audio takes for approaching message

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -33,8 +33,14 @@ defmodule Content.Audio.Approaching do
   end
 
   defimpl Content.Audio do
-    @attention_passengers "783"
-    @now_approaching_new_rl_cars "786"
+    # audio: "Attention passengers, the next", visual: ""
+    @attention_passengers_the_next "896"
+    @train_to "919"
+    @train "920"
+    @is_now_approaching "910"
+    @with_all_new_red_line_cars "893"
+    @comma "21012"
+    @period "21014"
 
     def to_params(%Content.Audio.Approaching{route_id: route_id} = audio)
         when route_id in ["Mattapan", "Green-B", "Green-C", "Green-D", "Green-E"] do
@@ -42,39 +48,34 @@ defmodule Content.Audio.Approaching do
     end
 
     def to_params(%Content.Audio.Approaching{} = audio) do
-      message =
-        if audio.new_cars? do
-          [
-            @attention_passengers,
-            PaEss.Utilities.destination_var(audio.destination),
-            @now_approaching_new_rl_cars
-          ]
-        else
-          [destination_var(audio.destination, audio.platform, audio.route_id)]
-        end
+      train =
+        if branch = Content.Utilities.route_branch_letter(audio.route_id),
+          do: [branch_var(branch), @train_to, destination_var(audio.destination)],
+          else: [destination_var(audio.destination), @train]
+
+      platform = if audio.platform, do: [platform_var(audio.platform)], else: []
+      new_cars = if audio.new_cars?, do: [@comma, @with_all_new_red_line_cars], else: []
 
       crowding =
-        if audio.crowding_description do
-          [Content.Utilities.crowding_description_var(audio.crowding_description)]
-        else
-          []
-        end
+        if audio.crowding_description,
+          do: [Content.Utilities.crowding_description_var(audio.crowding_description)],
+          else: []
 
-      Utilities.take_message(message ++ crowding, :audio_visual)
+      ([@attention_passengers_the_next] ++
+         train ++ [@is_now_approaching] ++ platform ++ new_cars ++ [@period] ++ crowding)
+      |> Utilities.take_message(:audio_visual)
     end
 
     def to_tts(%Content.Audio.Approaching{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+      platform = platform_string(audio.platform)
+      new_cars = new_cars_string(audio.new_cars?)
 
-      new_cars =
-        if(audio.new_cars? && audio.route_id == "Red", do: "with all new Red Line cars", else: "")
-
-      pages =
-        [{train, "now approaching", 6}] ++
-          PaEss.Utilities.paginate_text(new_cars) ++ PaEss.Utilities.paginate_text(crowding)
-
-      {tts_text(audio), pages}
+      {tts_text(audio),
+       PaEss.Utilities.paginate_text(
+         "#{train} is now approaching#{platform}#{new_cars}.#{crowding}"
+       )}
     end
 
     def to_logs(%Content.Audio.Approaching{}) do
@@ -84,15 +85,10 @@ defmodule Content.Audio.Approaching do
     defp tts_text(%Content.Audio.Approaching{} = audio) do
       train = Utilities.train_description(audio.destination, audio.route_id)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
+      platform = platform_string(audio.platform)
+      new_cars = new_cars_string(audio.new_cars?)
 
-      new_cars =
-        if audio.new_cars? && audio.route_id == "Red" do
-          ", with all new Red Line cars."
-        else
-          "."
-        end
-
-      "Attention passengers: The next #{train} is now approaching#{new_cars}#{crowding}"
+      "Attention passengers: The next #{train} is now approaching#{platform}#{new_cars}.#{crowding}"
     end
 
     @spec handle_unknown_destination(Content.Audio.Approaching.t()) :: nil
@@ -104,15 +100,40 @@ defmodule Content.Audio.Approaching do
       nil
     end
 
-    @spec destination_var(PaEss.destination(), Content.platform(), String.t()) :: String.t() | nil
-    defp destination_var(:alewife, :ashmont, _route_id), do: "32125"
-    defp destination_var(:alewife, :braintree, _route_id), do: "32126"
-    defp destination_var(:alewife, nil, _route_id), do: "32124"
-    defp destination_var(:ashmont, nil, "Red"), do: "32127"
-    defp destination_var(:braintree, nil, _route_id), do: "32128"
-    defp destination_var(:bowdoin, nil, _route_id), do: "32121"
-    defp destination_var(:wonderland, nil, _route_id), do: "32120"
-    defp destination_var(:forest_hills, nil, _route_id), do: "32123"
-    defp destination_var(:oak_grove, nil, _route_id), do: "32122"
+    defp destination_var(:alewife), do: "892"
+    defp destination_var(:ashmont), do: "895"
+    defp destination_var(:braintree), do: "902"
+    defp destination_var(:mattapan), do: "913"
+    defp destination_var(:bowdoin), do: "900"
+    defp destination_var(:wonderland), do: "921"
+    defp destination_var(:oak_grove), do: "915"
+    defp destination_var(:forest_hills), do: "907"
+    defp destination_var(:lechmere), do: "912"
+    defp destination_var(:north_station), do: "914"
+    defp destination_var(:government_center), do: "908"
+    defp destination_var(:park_street), do: "916"
+    defp destination_var(:kenmore), do: "911"
+    defp destination_var(:boston_college), do: "899"
+    defp destination_var(:cleveland_circle), do: "904"
+    defp destination_var(:reservoir), do: "917"
+    defp destination_var(:riverside), do: "918"
+    defp destination_var(:heath_street), do: "909"
+    # Fall back to original takes
+    defp destination_var(destination), do: PaEss.Utilities.destination_var(destination)
+
+    defp platform_var(:ashmont), do: "894"
+    defp platform_var(:braintree), do: "901"
+
+    defp branch_var(:b), do: "897"
+    defp branch_var(:c), do: "903"
+    defp branch_var(:d), do: "905"
+    defp branch_var(:e), do: "906"
+
+    defp platform_string(:ashmont), do: " on the Ashmont platform"
+    defp platform_string(:braintree), do: " on the Braintree platform"
+    defp platform_string(_), do: ""
+
+    defp new_cars_string(true), do: ", with all new Red Line cars"
+    defp new_cars_string(false), do: ""
   end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -6,6 +6,8 @@ defmodule PaEss.Utilities do
   require Logger
 
   @space "21000"
+  @comma "21012"
+  @period "21014"
   @stopped_regex ~r/Stopped (\d+) stops? away/
 
   @abbreviation_replacements [
@@ -161,8 +163,18 @@ defmodule PaEss.Utilities do
   @doc "Constructs message from TAKE variables"
   @spec take_message([String.t()], Content.Audio.av_type()) :: Content.Audio.canned_message()
   def take_message(vars, av_type) do
-    vars_with_spaces = Enum.intersperse(vars, @space)
+    vars_with_spaces = pad_takes(vars)
     {:canned, {take_message_id(vars_with_spaces), vars_with_spaces, av_type}}
+  end
+
+  @doc "Intersperse spaces in a list of takes, accounting for punctuation"
+  @spec pad_takes([String.t()]) :: [String.t()]
+  def pad_takes(vars) do
+    Enum.chunk_every(vars, 2, 1, [nil])
+    |> Enum.flat_map(fn
+      [var, next] when next in [nil, @comma, @period] -> [var]
+      [var, _] -> [var, @space]
+    end)
   end
 
   @spec take_message_id([String.t()]) :: String.t()

--- a/test/content/audio/approaching_test.exs
+++ b/test/content/audio/approaching_test.exs
@@ -6,12 +6,17 @@ defmodule Content.Audio.ApproachingTest do
   describe "to_params/1" do
     test "Returns params when platform is present" do
       audio = %Approaching{destination: :alewife, platform: :braintree, route_id: "Red"}
-      assert Content.Audio.to_params(audio) == {:canned, {"103", ["32126"], :audio_visual}}
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"112", spaced(["896", "892", "920", "910", "901", "21014"]), :audio_visual}}
     end
 
     test "Returns params when platform is not present" do
       audio = %Approaching{destination: :oak_grove, route_id: "Orange"}
-      assert Content.Audio.to_params(audio) == {:canned, {"103", ["32122"], :audio_visual}}
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned, {"110", spaced(["896", "915", "920", "910", "21014"]), :audio_visual}}
     end
 
     test "Returns nil for Green Line trips" do
@@ -28,7 +33,9 @@ defmodule Content.Audio.ApproachingTest do
       audio = %Approaching{destination: :alewife, route_id: "Red", new_cars?: true}
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"107", ["783", "21000", "4000", "21000", "786"], :audio_visual}}
+               {:canned,
+                {"113", spaced(["896", "892", "920", "910", "21012", "893", "21014"]),
+                 :audio_visual}}
     end
 
     test "Returns crowding info" do
@@ -39,7 +46,12 @@ defmodule Content.Audio.ApproachingTest do
       }
 
       assert Content.Audio.to_params(audio) ==
-               {:canned, {"105", ["32123", "21000", "876"], :audio_visual}}
+               {:canned,
+                {"112",
+                 ["896", "21000", "907", "21000", "920", "21000", "910", "21014", "21000", "876"],
+                 :audio_visual}}
     end
   end
+
+  defp spaced(list), do: PaEss.Utilities.pad_takes(list)
 end

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -117,4 +117,10 @@ defmodule Content.Audio.UtilitiesTest do
     assert [{"fits", "", 3}] = paginate_text("fits", 24)
     assert [] = paginate_text("")
   end
+
+  test "pad_takes" do
+    assert ["1", "21000", "2", "21000", "3"] = pad_takes(["1", "2", "3"])
+    assert ["1", "21012", "21000", "2"] = pad_takes(["1", "21012", "2"])
+    assert ["1", "21000", "2", "21014"] = pad_takes(["1", "2", "21014"])
+  end
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -726,10 +726,13 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Ashmont      1 min", ""})
 
-      expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
-        {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Ashmont train", "now approaching", 6}]}
-      ])
+      expect_audios(
+        [{:canned, {"110", spaced(["896", "895", "920", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next Ashmont train is now approaching.",
+           [{"Ashmont train is now", "approaching.", 3}]}
+        ]
+      )
 
       assert {_, %{announced_approachings: ["1"]}} = Signs.Realtime.handle_info(:run_loop, @sign)
     end
@@ -786,10 +789,13 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Ashmont      1 min", ""})
 
-      expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
-        {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Ashmont train", "now approaching", 6}]}
-      ])
+      expect_audios(
+        [{:canned, {"110", spaced(["896", "895", "920", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next Ashmont train is now approaching.",
+           [{"Ashmont train is now", "approaching.", 3}]}
+        ]
+      )
 
       assert {_, %{tick_read: 119}} =
                Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 20})
@@ -806,10 +812,13 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Frst Hills   1 min", ""})
 
-      expect_audios([{:canned, {"103", ["32123"], :audio_visual}}], [
-        {"Attention passengers: The next Forest Hills train is now approaching.",
-         [{"Frst Hills train", "now approaching", 6}]}
-      ])
+      expect_audios(
+        [{:canned, {"110", spaced(["896", "907", "920", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next Forest Hills train is now approaching.",
+           [{"Frst Hills train is now", "approaching.", 3}]}
+        ]
+      )
 
       assert {_, %{announced_approachings_with_crowding: ["1"]}} =
                Signs.Realtime.handle_info(:run_loop, @sign)
@@ -826,10 +835,13 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Frst Hills   1 min", ""})
 
-      expect_audios([{:canned, {"103", ["32123"], :audio_visual}}], [
-        {"Attention passengers: The next Forest Hills train is now approaching.",
-         [{"Frst Hills train", "now approaching", 6}]}
-      ])
+      expect_audios(
+        [{:canned, {"110", spaced(["896", "907", "920", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next Forest Hills train is now approaching.",
+           [{"Frst Hills train is now", "approaching.", 3}]}
+        ]
+      )
 
       assert {_, %{announced_approachings_with_crowding: []}} =
                Signs.Realtime.handle_info(:run_loop, @sign)
@@ -1458,10 +1470,16 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Ashmont      1 min", ""})
 
-      expect_audios([{:canned, {"107", spaced(["783", "4016", "786"]), :audio_visual}}], [
-        {"Attention passengers: The next Ashmont train is now approaching, with all new Red Line cars.",
-         [{"Ashmont train", "now approaching", 6}, {"with all new Red Line", "cars", 3}]}
-      ])
+      expect_audios(
+        [
+          {:canned,
+           {"113", spaced(["896", "895", "920", "910", "21012", "893", "21014"]), :audio_visual}}
+        ],
+        [
+          {"Attention passengers: The next Ashmont train is now approaching, with all new Red Line cars.",
+           [{"Ashmont train is now", "approaching, with all", 3}, {"new Red Line cars.", "", 3}]}
+        ]
+      )
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
@@ -1488,10 +1506,13 @@ defmodule Signs.RealtimeTest do
 
       expect_messages({"Ashmont      1 min", ""})
 
-      expect_audios([{:canned, {"103", ["32127"], :audio_visual}}], [
-        {"Attention passengers: The next Ashmont train is now approaching.",
-         [{"Ashmont train", "now approaching", 6}]}
-      ])
+      expect_audios(
+        [{:canned, {"110", spaced(["896", "895", "920", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next Ashmont train is now approaching.",
+           [{"Ashmont train is now", "approaching.", 3}]}
+        ]
+      )
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
@@ -1966,7 +1987,7 @@ defmodule Signs.RealtimeTest do
 
   defp datetime(time), do: DateTime.new!(~D[2023-01-01], time, "America/New_York")
 
-  defp spaced(list), do: Enum.intersperse(list, "21000")
+  defp spaced(list), do: PaEss.Utilities.pad_takes(list)
 
   defp make_carriage_details(list) do
     Enum.map(list, fn {vehicle_id, occupancy_percentage} ->


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Switch to Polly approaching messages and add yellow line message](https://app.asana.com/0/1185117109217413/1209206869122457)

This switches to the new polly-generated audio takes for approaching messages. Includes the following behavior changes:
* Uses the new standard "[destination] train" phrasing
* Includes both platform and "new cars" modifiers if applicable
* The migrated code no longer does custom formatting, for a closer match with the ARINC behavior (we can change this later).