### PR TITLE
announce four-car trains

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -1,11 +1,12 @@
 defmodule Content.Audio.Predictions do
-  @enforce_keys [:prediction, :special_sign, :terminal?, :next_or_following]
+  @enforce_keys [:prediction, :special_sign, :terminal?, :multiple?, :next_or_following]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           prediction: Predictions.Prediction.t(),
           special_sign: :jfk_mezzanine | :bowdoin_eastbound | nil,
           terminal?: boolean(),
+          multiple?: boolean(),
           next_or_following: :next | :following
         }
 
@@ -13,14 +14,22 @@ defmodule Content.Audio.Predictions do
           Predictions.Prediction.t(),
           :jfk_mezzanine | :bowdoin_eastbound | nil,
           boolean(),
+          boolean(),
           :next | :following
         ) :: [t()]
-  def new(%Predictions.Prediction{} = prediction, special_sign, terminal?, next_or_following) do
+  def new(
+        %Predictions.Prediction{} = prediction,
+        special_sign,
+        terminal?,
+        multiple?,
+        next_or_following
+      ) do
     [
       %__MODULE__{
         prediction: prediction,
         special_sign: special_sign,
         terminal?: terminal?,
+        multiple?: multiple?,
         next_or_following: next_or_following
       }
     ]
@@ -74,8 +83,9 @@ defmodule Content.Audio.Predictions do
           end
 
         {prefix, suffix} = if(platform_prefix?, do: {qualifier, []}, else: {[], qualifier})
+        four_cars = if four_cars?(audio), do: [:four_car_train_message], else: []
 
-        [the_next_or_following] ++ train ++ prefix ++ status ++ suffix ++ followup
+        [the_next_or_following] ++ train ++ prefix ++ status ++ suffix ++ followup ++ four_cars
       end
       |> PaEss.Utilities.audio_message()
     end
@@ -120,7 +130,9 @@ defmodule Content.Audio.Predictions do
               _ -> ""
             end
 
-          "The #{next_or_following} #{train}#{prefix} #{status}#{suffix}.#{followup}"
+          four_cars = if four_cars?(audio), do: PaEss.Utilities.four_cars_text(), else: ""
+
+          "The #{next_or_following} #{train}#{prefix} #{status}#{suffix}.#{followup}#{four_cars}"
         end
 
       {text, nil}
@@ -145,6 +157,11 @@ defmodule Content.Audio.Predictions do
         minutes == 1 or !jfk_mezzanine? -> {platform, true, nil}
         true -> {platform, false, nil}
       end
+    end
+
+    defp four_cars?(audio) do
+      PaEss.Utilities.prediction_four_cars?(audio.prediction) and !audio.terminal? and
+        !audio.multiple?
     end
 
     defp platform_string(:ashmont), do: "Ashmont"

--- a/lib/content/message/four_cars.ex
+++ b/lib/content/message/four_cars.ex
@@ -1,0 +1,9 @@
+defmodule Content.Message.FourCars do
+  defstruct []
+
+  defimpl Content.Message do
+    def to_string(%Content.Message.FourCars{}) do
+      Content.Utilities.width_padded_string("4 cars", "Move to front", 24)
+    end
+  end
+end

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -22,6 +22,15 @@ defmodule Message.Predictions do
        %Content.Message.PlatformPredictionBottom{stop_id: top.stop_id, minutes: minutes}}
     end
 
+    def to_multi_line(
+          %Message.Predictions{
+            terminal?: false,
+            predictions: [%{route_id: "Red", multi_carriage_details: [_, _, _, _]} = top | _]
+          } = message
+        ) do
+      {prediction_message(top, message.terminal?, nil), %Content.Message.FourCars{}}
+    end
+
     def to_multi_line(%Message.Predictions{predictions: [top]} = message) do
       {prediction_message(top, message.terminal?, message.special_sign), %Content.Message.Empty{}}
     end
@@ -37,13 +46,18 @@ defmodule Message.Predictions do
         |> Enum.uniq()
         |> length() == 1
 
-      Enum.take(message.predictions, if(multiple?, do: 1, else: 2))
+      four_cars? =
+        hd(message.predictions) |> PaEss.Utilities.prediction_four_cars?() and !multiple? and
+          !message.terminal?
+
+      Enum.take(message.predictions, if(multiple? or four_cars?, do: 1, else: 2))
       |> Enum.zip(if(same_destination?, do: [:next, :following], else: [:next, :next]))
       |> Enum.map(fn {prediction, next_or_following} ->
         %Content.Audio.Predictions{
           prediction: prediction,
           special_sign: message.special_sign,
           terminal?: message.terminal?,
+          multiple?: multiple?,
           next_or_following: next_or_following
         }
       end)

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -368,6 +368,10 @@ defmodule PaEss.Utilities do
     end
   end
 
+  def four_cars_text() do
+    " It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge."
+  end
+
   @spec green_line_branch_var(Content.Utilities.green_line_branch()) :: String.t()
   def green_line_branch_var(:b), do: "536"
   def green_line_branch_var(:c), do: "537"
@@ -563,6 +567,11 @@ defmodule PaEss.Utilities do
     String.to_integer(str)
   end
 
+  @spec prediction_four_cars?(Predictions.Prediction.t()) :: boolean()
+  def prediction_four_cars?(prediction) do
+    prediction.route_id == "Red" and match?([_, _, _, _], prediction.multi_carriage_details)
+  end
+
   @headsign_take_mappings [
     {"Ruggles", "4086"},
     {"Downtown", "563"},
@@ -732,6 +741,7 @@ defmodule PaEss.Utilities do
     board_routes_71_and_73_on_upper_level: "618",
     will_announce_platform_soon: "849",
     will_announce_platform_later: "857",
+    four_car_train_message: "922",
     departing: "530",
     arriving: "531",
     on_track_1: "541",

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -85,7 +85,13 @@ defmodule Signs.Utilities.Audio do
             # Announce stopped trains
             PaEss.Utilities.prediction_stopped?(prediction, message.terminal?) && index == 0 &&
                 prediction_stopped_key(prediction) not in sign.announced_stalls ->
-              {Audio.Predictions.new(prediction, message.special_sign, message.terminal?, :next),
+              {Audio.Predictions.new(
+                 prediction,
+                 message.special_sign,
+                 message.terminal?,
+                 length(messages) > 1,
+                 :next
+               ),
                update_in(
                  sign.announced_stalls,
                  &cache_value(&1, prediction_stopped_key(prediction))
@@ -95,8 +101,13 @@ defmodule Signs.Utilities.Audio do
             # now we do, announce the next prediction.
             is_integer(minutes) && index == 0 && sign.prev_prediction_keys &&
                 prediction_key(prediction) not in sign.prev_prediction_keys ->
-              {Audio.Predictions.new(prediction, message.special_sign, message.terminal?, :next),
-               sign}
+              {Audio.Predictions.new(
+                 prediction,
+                 message.special_sign,
+                 message.terminal?,
+                 length(messages) > 1,
+                 :next
+               ), sign}
 
             true ->
               {[], sign}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Approaching announcement for 4-car trains](https://app.asana.com/0/1185117109217413/1209274790976903)
**Asana Ticket:** [New PA/ESS state when next train is 4-car](https://app.asana.com/0/1185117109217413/1209294078164624)

This modifies the approaching announcement and prediction rendering to include special messages for 4-car trains. See tickets for full details.