### PR TITLE
Modified approaching announcement window from 30-45 to 0-45 seconds

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -552,7 +552,7 @@ defmodule PaEss.Utilities do
   @spec prediction_approaching?(Predictions.Prediction.t(), boolean()) :: boolean()
   def prediction_approaching?(prediction, terminal?) do
     !terminal? and !prediction.stopped_at_predicted_stop? and
-      prediction_seconds(prediction, terminal?) in 31..45
+      prediction_seconds(prediction, terminal?) in 0..45
   end
 
   @spec prediction_stopped?(Predictions.Prediction.t(), boolean()) :: boolean()

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -589,6 +589,15 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_messages({"Clvlnd Cir     ARR", "Riverside      ARR"})
+
+      expect_audios(
+        [{:canned, {"112", spaced(["896", "903", "919", "904", "910", "21014"]), :audio_visual}}],
+        [
+          {"Attention passengers: The next C train to Cleveland Circle is now approaching.",
+           [{"C train to Clvlnd Cir is", "now approaching.", 3}]}
+        ]
+      )
+
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
@@ -988,7 +997,11 @@ defmodule Signs.RealtimeTest do
         ]
       )
 
-      Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0})
+      Signs.Realtime.handle_info(:run_loop, %{
+        @sign
+        | tick_read: 0,
+          announced_approachings: ["1"]
+      })
     end
 
     test "reads both lines when the bottom line is arriving on a multi_source sign for heavy rail" do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Prevent predictions from skipping approaching messages](https://app.asana.com/0/1185117109217413/1209370907571522)

Modified approaching announcement window from 30-45 to 0-45 seconds
- Fixed tests associated with it, now calls approaching message with two ARR on a sign

#### Reviewer Checklist
- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
