### PR TITLE
refactor take messages

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -42,44 +42,25 @@ defmodule Content.Audio.Approaching do
   end
 
   defimpl Content.Audio do
-    # audio: "Attention passengers, the next", visual: ""
-    @attention_passengers_the_next "896"
-    # audio: "Attention passengers, the next", visual: "Shorter 4 car"
-    @shorter_4_car "923"
-    @train_to "919"
-    @train "920"
-    @is_now_approaching "910"
-    # audio: "is now approaching", visual: "now approaching"
-    @now_approaching "924"
-    @with_all_new_red_line_cars "893"
-    # audio: "It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.", visual: "Please move to front of the train to board."
-    @four_car_train_message "922"
-    # "Please stand back from the platform edge."
-    @stand_back_message "925"
-    @comma "21012"
-    @period "21014"
-
     def to_params(%Content.Audio.Approaching{} = audio) do
-      prefix = if audio.four_cars?, do: [@shorter_4_car], else: [@attention_passengers_the_next]
+      prefix = if audio.four_cars?, do: [:shorter_4_car], else: [:attention_passengers_the_next]
 
       train =
         if branch = Content.Utilities.route_branch_letter(audio.route_id),
-          do: [branch_var(branch), @train_to, destination_var(audio.destination)],
-          else: [destination_var(audio.destination), @train]
+          do: [branch_token(branch), :train_to_, destination_token(audio.destination)],
+          else: [destination_token(audio.destination), :train_]
 
-      approaching = if audio.four_cars?, do: [@now_approaching], else: [@is_now_approaching]
-      platform = if audio.platform, do: [platform_var(audio.platform)], else: []
-      new_cars = if audio.new_cars?, do: [@comma, @with_all_new_red_line_cars], else: []
-      followup = if audio.four_cars?, do: [@four_car_train_message], else: [@stand_back_message]
+      approaching = if audio.four_cars?, do: [:now_approaching], else: [:is_now_approaching]
+      platform = if audio.platform, do: [platform_token(audio.platform)], else: []
+      new_cars = if audio.new_cars?, do: [:",", :with_all_new_red_line_cars], else: []
+      followup = if audio.four_cars?, do: [:four_car_train_message], else: [:stand_back_message]
 
       crowding =
-        if audio.crowding_description,
-          do: [Content.Utilities.crowding_description_var(audio.crowding_description)],
-          else: []
+        if audio.crowding_description, do: [{:crowding, audio.crowding_description}], else: []
 
       (prefix ++
-         train ++ approaching ++ platform ++ new_cars ++ [@period] ++ followup ++ crowding)
-      |> Utilities.take_message(:audio_visual)
+         train ++ approaching ++ platform ++ new_cars ++ [:.] ++ followup ++ crowding)
+      |> Utilities.audio_message(:audio_visual)
     end
 
     def to_tts(%Content.Audio.Approaching{} = audio) do
@@ -119,34 +100,34 @@ defmodule Content.Audio.Approaching do
       "Attention passengers: The next #{train} is now approaching#{platform}#{new_cars}.#{followup}#{crowding}"
     end
 
-    defp destination_var(:alewife), do: "892"
-    defp destination_var(:ashmont), do: "895"
-    defp destination_var(:braintree), do: "902"
-    defp destination_var(:mattapan), do: "913"
-    defp destination_var(:bowdoin), do: "900"
-    defp destination_var(:wonderland), do: "921"
-    defp destination_var(:oak_grove), do: "915"
-    defp destination_var(:forest_hills), do: "907"
-    defp destination_var(:lechmere), do: "912"
-    defp destination_var(:north_station), do: "914"
-    defp destination_var(:government_center), do: "908"
-    defp destination_var(:park_street), do: "916"
-    defp destination_var(:kenmore), do: "911"
-    defp destination_var(:boston_college), do: "899"
-    defp destination_var(:cleveland_circle), do: "904"
-    defp destination_var(:reservoir), do: "917"
-    defp destination_var(:riverside), do: "918"
-    defp destination_var(:heath_street), do: "909"
+    defp destination_token(:alewife), do: :alewife_
+    defp destination_token(:ashmont), do: :ashmont_
+    defp destination_token(:braintree), do: :braintree_
+    defp destination_token(:mattapan), do: :mattapan_
+    defp destination_token(:bowdoin), do: :bowdoin_
+    defp destination_token(:wonderland), do: :wonderland_
+    defp destination_token(:oak_grove), do: :oak_grove_
+    defp destination_token(:forest_hills), do: :forest_hills_
+    defp destination_token(:lechmere), do: :lechmere_
+    defp destination_token(:north_station), do: :north_station_
+    defp destination_token(:government_center), do: :government_center_
+    defp destination_token(:park_street), do: :park_street_
+    defp destination_token(:kenmore), do: :kenmore_
+    defp destination_token(:boston_college), do: :boston_college_
+    defp destination_token(:cleveland_circle), do: :cleveland_circle_
+    defp destination_token(:reservoir), do: :reservoir_
+    defp destination_token(:riverside), do: :riverside_
+    defp destination_token(:heath_street), do: :heath_street_
     # Fall back to original takes
-    defp destination_var(destination), do: PaEss.Utilities.destination_var(destination)
+    defp destination_token(destination), do: destination
 
-    defp platform_var(:ashmont), do: "894"
-    defp platform_var(:braintree), do: "901"
+    defp platform_token(:ashmont), do: :on_the_ashmont_platform
+    defp platform_token(:braintree), do: :on_the_braintree_platform
 
-    defp branch_var(:b), do: "897"
-    defp branch_var(:c), do: "903"
-    defp branch_var(:d), do: "905"
-    defp branch_var(:e), do: "906"
+    defp branch_token(:b), do: :b_
+    defp branch_token(:c), do: :c_
+    defp branch_token(:d), do: :d_
+    defp branch_token(:e), do: :e_
 
     defp platform_string(:ashmont), do: " on the Ashmont platform"
     defp platform_string(:braintree), do: " on the Braintree platform"

--- a/lib/content/audio/boarding_button.ex
+++ b/lib/content/audio/boarding_button.ex
@@ -3,10 +3,8 @@ defmodule Content.Audio.BoardingButton do
   defstruct []
 
   defimpl Content.Audio do
-    @boarding_button_message "869"
-
     def to_params(_audio) do
-      Utilities.take_message([@boarding_button_message], :audio_visual)
+      Utilities.audio_message([:boarding_button_message], :audio_visual)
     end
 
     def to_tts(%Content.Audio.BoardingButton{}) do

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -7,28 +7,19 @@ defmodule Content.Audio.FirstTrainScheduled do
         }
 
   defimpl Content.Audio do
-    @the_first "866"
-    @train "864"
-    @is "533"
-    @scheduled_to_arrive_at "865"
-
     def to_params(%Content.Audio.FirstTrainScheduled{
           destination: destination,
           scheduled_time: scheduled_time
         }) do
-      destination = PaEss.Utilities.destination_var(destination)
-
-      vars = [
-        @the_first,
+      PaEss.Utilities.audio_message([
+        :the_first,
         destination,
-        @train,
-        @is,
-        @scheduled_to_arrive_at,
-        PaEss.Utilities.time_hour_var(scheduled_time.hour),
-        PaEss.Utilities.time_minutes_var(scheduled_time.minute)
-      ]
-
-      PaEss.Utilities.take_message(vars, :audio)
+        :train,
+        :is,
+        :scheduled_to_arrive_at,
+        {:hour, scheduled_time.hour},
+        {:minute, scheduled_time.minute}
+      ])
     end
 
     def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do

--- a/lib/content/audio/no_service.ex
+++ b/lib/content/audio/no_service.ex
@@ -10,9 +10,6 @@ defmodule Content.Audio.NoService do
         }
 
   defimpl Content.Audio do
-    @there_is_no "861"
-    @service_at_this_station "863"
-
     def to_params(%Content.Audio.NoService{use_routes?: true} = audio) do
       {:ad_hoc, {tts_text(audio), :audio}}
     end
@@ -22,12 +19,10 @@ defmodule Content.Audio.NoService do
           route: route,
           use_shuttle?: use_shuttle?
         }) do
-      line_var = PaEss.Utilities.line_to_var(route)
-
       if use_shuttle? do
-        {:canned, {"199", [line_var], :audio}}
+        {:canned, {"199", [PaEss.Utilities.audio_take({:line, route})], :audio}}
       else
-        PaEss.Utilities.take_message([@there_is_no, line_var, @service_at_this_station], :audio)
+        PaEss.Utilities.audio_message([:there_is_no_, {:line, route}, :service_at_this_station])
       end
     end
 

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -21,13 +21,10 @@ defmodule Content.Audio.Passthrough do
     end
 
     def to_params(audio) do
-      case destination_var(audio.destination, audio.route_id) do
-        nil ->
-          {:ad_hoc, {tts_text(audio), :audio_visual}}
-
-        var ->
-          {:canned, {"103", [var], :audio_visual}}
-      end
+      PaEss.Utilities.audio_message(
+        [{:passthrough, audio.destination, audio.route_id}],
+        :audio_visual
+      )
     end
 
     def to_tts(%Content.Audio.Passthrough{} = audio) do
@@ -53,14 +50,5 @@ defmodule Content.Audio.Passthrough do
 
       nil
     end
-
-    @spec destination_var(PaEss.destination(), String.t()) :: String.t() | nil
-    defp destination_var(:alewife, _route_id), do: "32114"
-    defp destination_var(:southbound, "Red"), do: "891"
-    defp destination_var(:bowdoin, _route_id), do: "32111"
-    defp destination_var(:wonderland, _route_id), do: "32110"
-    defp destination_var(:forest_hills, _route_id), do: "32113"
-    defp destination_var(:oak_grove, _route_id), do: "32112"
-    defp destination_var(_destination, _route_id), do: nil
   end
 end

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -71,7 +71,7 @@ defmodule Content.Audio.Predictions do
           cond do
             track_number == 1 -> [:on_track_1]
             track_number == 2 -> [:on_track_2]
-            platform -> [:on_the, {:destination, platform}, :platform]
+            platform -> [:on_the, platform, :platform]
             true -> []
           end
 

--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -11,23 +11,16 @@ defmodule Content.Audio.ServiceEnded do
         }
 
   defimpl Content.Audio do
-    @service_ended "882"
-    # @station_closed "883"
-    @platform_closed "884"
-
     def to_params(%Content.Audio.ServiceEnded{location: :station, route: route}) do
-      line_var = Utilities.line_to_var(route)
-      Utilities.take_message([line_var, @service_ended], :audio)
+      Utilities.audio_message([{:line, route}, :service_ended])
     end
 
     def to_params(%Content.Audio.ServiceEnded{location: :platform, destination: destination}) do
-      destination_var = Utilities.destination_var(destination)
-      Utilities.take_message([@platform_closed, destination_var, @service_ended], :audio)
+      Utilities.audio_message([:platform_closed, destination, :service_ended])
     end
 
     def to_params(%Content.Audio.ServiceEnded{location: :direction, destination: destination}) do
-      destination_var = Utilities.destination_var(destination)
-      Utilities.take_message([destination_var, @service_ended], :audio)
+      Utilities.audio_message([destination, :service_ended])
     end
 
     def to_tts(%Content.Audio.ServiceEnded{} = audio) do

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -22,53 +22,11 @@ defmodule Content.Audio.TrackChange do
   def park_track_change?(_prediction), do: false
 
   defimpl Content.Audio do
-    @track_change "540"
-    @b_to_boston_college_c_platform "813"
-    @c_to_cleveland_circle_b_platform "814"
-    @d_to_reservoir_e_platform "815"
-    @d_to_riverside_e_platform "818"
-    @e_to_heath_d_platform "816"
-    @kenmore_b_platform "823"
-    @kenmore_c_platform "820"
-    @kenmore_d_platform "821"
-    @kenmore_e_platform "822"
-
-    def to_params(audio) do
-      case {audio.route_id, audio.berth, audio.destination} do
-        {"Green-B", "70197", :boston_college} ->
-          track_change_message(@b_to_boston_college_c_platform)
-
-        {"Green-B", "70197", :kenmore} ->
-          track_change_message(@kenmore_c_platform)
-
-        {"Green-C", "70196", :cleveland_circle} ->
-          track_change_message(@c_to_cleveland_circle_b_platform)
-
-        {"Green-C", "70196", :kenmore} ->
-          track_change_message(@kenmore_b_platform)
-
-        {"Green-D", "70199", :reservoir} ->
-          track_change_message(@d_to_reservoir_e_platform)
-
-        {"Green-D", "70199", :riverside} ->
-          track_change_message(@d_to_riverside_e_platform)
-
-        {"Green-D", "70199", :kenmore} ->
-          track_change_message(@kenmore_e_platform)
-
-        {"Green-E", "70198", :heath_street} ->
-          track_change_message(@e_to_heath_d_platform)
-
-        {"Green-E", "70198", :kenmore} ->
-          track_change_message(@kenmore_d_platform)
-
-        {route, berth, destination} ->
-          Logger.error(
-            "TrackChange.to_params unknown route, berth, destination: #{inspect({route, berth, destination})}"
-          )
-
-          nil
-      end
+    def to_params(%{route_id: route_id, berth: berth, destination: destination}) do
+      PaEss.Utilities.audio_message(
+        [:track_change, {:boarding, route_id, berth, destination}],
+        :audio_visual
+      )
     end
 
     def to_tts(%Content.Audio.TrackChange{} = audio) do
@@ -88,11 +46,6 @@ defmodule Content.Audio.TrackChange do
 
     def to_logs(%Content.Audio.TrackChange{}) do
       []
-    end
-
-    defp track_change_message(msg_id) do
-      vars = [@track_change, msg_id]
-      PaEss.Utilities.take_message(vars, :audio_visual)
     end
   end
 end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -136,15 +136,4 @@ defmodule Content.Utilities do
 
   def render_datetime_as_time(time),
     do: Calendar.strftime(time, "%I:%M") |> String.replace_leading("0", "")
-
-  def crowding_description_var(crowding_description) do
-    case crowding_description do
-      {:front, _} -> "870"
-      {:back, _} -> "871"
-      {:middle, _} -> "872"
-      {:front_and_back, _} -> "873"
-      {:train_level, :crowded} -> "876"
-      _ -> "21000"
-    end
-  end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -160,13 +160,6 @@ defmodule PaEss.Utilities do
     Integer.to_string(5000 + n)
   end
 
-  @doc "Constructs message from TAKE variables"
-  @spec take_message([String.t()], Content.Audio.av_type()) :: Content.Audio.canned_message()
-  def take_message(vars, av_type) do
-    vars_with_spaces = pad_takes(vars)
-    {:canned, {take_message_id(vars_with_spaces), vars_with_spaces, av_type}}
-  end
-
   @doc "Intersperse spaces in a list of takes, accounting for punctuation"
   @spec pad_takes([String.t()]) :: [String.t()]
   def pad_takes(vars) do
@@ -188,37 +181,6 @@ defmodule PaEss.Utilities do
     end
     |> Integer.to_string()
   end
-
-  @doc "Take ID for terminal destinations"
-  @spec destination_var(PaEss.destination()) :: String.t()
-  def destination_var(:alewife), do: "4000"
-  def destination_var(:ashmont), do: "4016"
-  def destination_var(:braintree), do: "4021"
-  def destination_var(:mattapan), do: "4100"
-  def destination_var(:bowdoin), do: "4055"
-  def destination_var(:wonderland), do: "4044"
-  def destination_var(:oak_grove), do: "4022"
-  def destination_var(:forest_hills), do: "4043"
-  def destination_var(:chelsea), do: "860"
-  def destination_var(:south_station), do: "4089"
-  def destination_var(:lechmere), do: "4056"
-  def destination_var(:north_station), do: "4027"
-  def destination_var(:government_center), do: "4061"
-  def destination_var(:park_street), do: "4007"
-  def destination_var(:kenmore), do: "4070"
-  def destination_var(:boston_college), do: "4202"
-  def destination_var(:cleveland_circle), do: "4203"
-  def destination_var(:reservoir), do: "4076"
-  def destination_var(:riverside), do: "4084"
-  def destination_var(:heath_street), do: "4204"
-  def destination_var(:union_square), do: "695"
-  def destination_var(:medford_tufts), do: "852"
-  def destination_var(:southbound), do: "787"
-  def destination_var(:northbound), do: "788"
-  def destination_var(:eastbound), do: "867"
-  def destination_var(:westbound), do: "868"
-  def destination_var(:inbound), do: "33003"
-  def destination_var(:outbound), do: "33004"
 
   @doc """
   Used for parsing headway_direction_name from the source config to a PaEss.destination
@@ -316,13 +278,6 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:outbound), do: "Outbound"
   def destination_to_ad_hoc_string(:medford_tufts), do: "Medford/Tufts"
 
-  def line_to_var("Red"), do: "3005"
-  def line_to_var("Orange"), do: "3006"
-  def line_to_var("Blue"), do: "3007"
-  def line_to_var("Green"), do: "3008"
-  def line_to_var("Mattapan"), do: "3009"
-  def line_to_var(_), do: "864"
-
   def directional_destination?(destination),
     do: destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound]
 
@@ -349,12 +304,7 @@ defmodule PaEss.Utilities do
 
   def train_description_tokens(destination, route_id) do
     branch = Content.Utilities.route_branch_letter(route_id)
-
-    if branch do
-      [branch, :train_to, {:destination, destination}]
-    else
-      [{:destination, destination}, :train]
-    end
+    if branch, do: [branch, :train_to, destination], else: [destination, :train]
   end
 
   def crowding_text(crowding_description) do
@@ -371,12 +321,6 @@ defmodule PaEss.Utilities do
   def four_cars_text() do
     " It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge."
   end
-
-  @spec green_line_branch_var(Content.Utilities.green_line_branch()) :: String.t()
-  def green_line_branch_var(:b), do: "536"
-  def green_line_branch_var(:c), do: "537"
-  def green_line_branch_var(:d), do: "538"
-  def green_line_branch_var(:e), do: "539"
 
   def time_hour_var(hour) when hour >= 0 and hour < 24 do
     adjusted_hour = rem(hour, 12)
@@ -661,110 +605,124 @@ defmodule PaEss.Utilities do
     {"Linden Sq", "889"}
   ]
 
-  @route_take_lookup %{
-    "SL5" => "587",
-    "SL4" => "586",
-    "1" => "573",
-    "8" => "574",
-    "14" => "575",
-    "15" => "576",
-    "19" => "577",
-    "23" => "578",
-    "24" => "622",
-    "27" => "623",
-    "2427" => "629",
-    "28" => "579",
-    "29" => "624",
-    "30" => "625",
-    "31" => "626",
-    "33" => "627",
-    "34" => "678",
-    "34E" => "679",
-    "35" => "680",
-    "36" => "681",
-    "37" => "682",
-    "38" => "683",
-    "39" => "684",
-    "40" => "685",
-    "41" => "580",
-    "42" => "581",
-    "44" => "582",
-    "45" => "583",
-    "47" => "584",
-    "50" => "686",
-    "51" => "687",
-    "66" => "585",
-    "69" => "590",
-    "71" => "591",
-    "72" => "592",
-    "73" => "594",
-    "74" => "595",
-    "75" => "596",
-    "77" => "597",
-    "77A" => "598",
-    "78" => "599",
-    "80" => "600",
-    "86" => "601",
-    "87" => "602",
-    "88" => "603",
-    "89" => "688",
-    "90" => "689",
-    "94" => "690",
-    "96" => "604",
-    "109" => "890",
-    "170" => "588",
-    "171" => "589",
-    "226" => "809",
-    "230" => "810",
-    "236" => "811",
-    "245" => "628",
-    "716" => "888"
-  }
+  @spec audio_take(term()) :: String.t() | nil
+  def audio_take(:alewife), do: "4000"
+  def audio_take(:alewife_), do: "892"
+  def audio_take(:ashmont), do: "4016"
+  def audio_take(:ashmont_), do: "895"
+  def audio_take(:braintree), do: "4021"
+  def audio_take(:braintree_), do: "902"
+  def audio_take(:mattapan), do: "4100"
+  def audio_take(:mattapan_), do: "913"
+  def audio_take(:bowdoin), do: "4055"
+  def audio_take(:bowdoin_), do: "900"
+  def audio_take(:wonderland), do: "4044"
+  def audio_take(:wonderland_), do: "921"
+  def audio_take(:oak_grove), do: "4022"
+  def audio_take(:oak_grove_), do: "915"
+  def audio_take(:forest_hills), do: "4043"
+  def audio_take(:forest_hills_), do: "907"
+  def audio_take(:chelsea), do: "860"
+  def audio_take(:south_station), do: "4089"
+  def audio_take(:lechmere), do: "4056"
+  def audio_take(:lechmere_), do: "912"
+  def audio_take(:north_station), do: "4027"
+  def audio_take(:north_station_), do: "914"
+  def audio_take(:government_center), do: "4061"
+  def audio_take(:government_center_), do: "908"
+  def audio_take(:park_street), do: "4007"
+  def audio_take(:park_street_), do: "916"
+  def audio_take(:kenmore), do: "4070"
+  def audio_take(:kenmore_), do: "911"
+  def audio_take(:boston_college), do: "4202"
+  def audio_take(:boston_college_), do: "899"
+  def audio_take(:cleveland_circle), do: "4203"
+  def audio_take(:cleveland_circle_), do: "904"
+  def audio_take(:reservoir), do: "4076"
+  def audio_take(:reservoir_), do: "917"
+  def audio_take(:riverside), do: "4084"
+  def audio_take(:riverside_), do: "918"
+  def audio_take(:heath_street), do: "4204"
+  def audio_take(:heath_street_), do: "909"
+  def audio_take(:union_square), do: "695"
+  def audio_take(:medford_tufts), do: "852"
+  def audio_take(:southbound), do: "787"
+  def audio_take(:northbound), do: "788"
+  def audio_take(:eastbound), do: "867"
+  def audio_take(:westbound), do: "868"
+  def audio_take(:inbound), do: "33003"
+  def audio_take(:outbound), do: "33004"
+  def audio_take(:the_next_bus_to), do: "543"
+  def audio_take(:the_following_bus_to), do: "858"
+  def audio_take(:the_next), do: "501"
+  def audio_take(:the_following), do: "667"
+  def audio_take(:train), do: "864"
+  def audio_take(:train_), do: "920"
+  def audio_take(:bus_to), do: "859"
+  def audio_take(:train_to), do: "507"
+  def audio_take(:train_to_), do: "919"
+  def audio_take(:departs), do: "502"
+  def audio_take(:arrives), do: "503"
+  def audio_take(:track_change), do: "540"
+  def audio_take(:is_now_boarding), do: "544"
+  def audio_take(:in), do: "504"
+  def audio_take(:is), do: "533"
+  def audio_take(:stopped), do: "641"
+  def audio_take(:stop_away), do: "535"
+  def audio_take(:stops_away), do: "534"
+  def audio_take(:the_first), do: "866"
+  def audio_take(:scheduled_to_arrive_at), do: "865"
+  def audio_take(:upcoming_departures), do: "548"
+  def audio_take(:upcoming_arrivals), do: "550"
+  def audio_take(:is_now_arriving), do: "24055"
+  def audio_take(:upper_level_departures), do: "616"
+  def audio_take(:lower_level_departures), do: "617"
+  def audio_take(:board_routes_71_and_73_on_upper_level), do: "618"
+  def audio_take(:will_announce_platform_soon), do: "849"
+  def audio_take(:will_announce_platform_later), do: "857"
+  def audio_take(:departing), do: "530"
+  def audio_take(:arriving), do: "531"
+  def audio_take(:on_track_1), do: "541"
+  def audio_take(:on_track_2), do: "542"
+  def audio_take(:on_the), do: "851"
+  def audio_take(:platform), do: "529"
+  def audio_take(:on_the_ashmont_platform), do: "894"
+  def audio_take(:on_the_braintree_platform), do: "901"
+  def audio_take(:_), do: "21000"
+  def audio_take(:","), do: "21012"
+  def audio_take(:.), do: "21014"
+  def audio_take(:minute), do: "532"
+  def audio_take(:minutes), do: "505"
+  def audio_take(:no_service), do: "879"
+  def audio_take(:there_is_no), do: "880"
+  def audio_take(:there_is_no_), do: "861"
+  def audio_take(:bus_service_to), do: "877"
+  def audio_take(:no_bus_service), do: "878"
+  def audio_take(:service_at_this_station), do: "863"
+  def audio_take(:service_ended), do: "882"
+  def audio_take(:platform_closed), do: "884"
+  def audio_take(:boarding_button_message), do: "869"
+  # audio: "Attention passengers, the next", visual: ""
+  def audio_take(:attention_passengers_the_next), do: "896"
+  # audio: "Attention passengers, the next", visual: "Shorter 4 car"
+  def audio_take(:shorter_4_car), do: "923"
+  def audio_take(:is_now_approaching), do: "910"
+  # audio: "is now approaching", visual: "now approaching"
+  def audio_take(:now_approaching), do: "924"
+  def audio_take(:with_all_new_red_line_cars), do: "893"
 
-  @atom_take_lookup %{
-    the_next_bus_to: "543",
-    the_following_bus_to: "858",
-    the_next: "501",
-    the_following: "667",
-    train: "864",
-    bus_to: "859",
-    train_to: "507",
-    departs: "502",
-    arrives: "503",
-    is_now_boarding: "544",
-    in: "504",
-    is: "533",
-    stopped: "641",
-    stop_away: "535",
-    stops_away: "534",
-    upcoming_departures: "548",
-    upcoming_arrivals: "550",
-    is_now_arriving: "24055",
-    upper_level_departures: "616",
-    lower_level_departures: "617",
-    board_routes_71_and_73_on_upper_level: "618",
-    will_announce_platform_soon: "849",
-    will_announce_platform_later: "857",
-    four_car_train_message: "922",
-    departing: "530",
-    arriving: "531",
-    on_track_1: "541",
-    on_track_2: "542",
-    on_the: "851",
-    platform: "529",
-    _: "21000",
-    ",": "21012",
-    minute: "532",
-    minutes: "505",
-    no_service: "879",
-    there_is_no: "880",
-    bus_service_to: "877",
-    no_bus_service: "878",
-    b: "536",
-    c: "537",
-    d: "538",
-    e: "539"
-  }
+  # audio: "It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.", visual: "Please move to front of the train to board."
+  def audio_take(:four_car_train_message), do: "922"
+  # "Please stand back from the platform edge."
+  def audio_take(:stand_back_message), do: "925"
+  def audio_take(:b), do: "536"
+  def audio_take(:b_), do: "897"
+  def audio_take(:c), do: "537"
+  def audio_take(:c_), do: "903"
+  def audio_take(:d), do: "538"
+  def audio_take(:d_), do: "905"
+  def audio_take(:e), do: "539"
+  def audio_take(:e_), do: "906"
 
   def audio_take({:minutes, minutes}) do
     number_var(minutes, :english) || generic_number_var(minutes)
@@ -782,18 +740,104 @@ defmodule PaEss.Utilities do
     end)
   end
 
-  def audio_take({:destination, destination}) do
-    destination_var(destination)
-  end
+  def audio_take({:hour, hour}), do: time_hour_var(hour)
+  def audio_take({:minute, minute}), do: time_minutes_var(minute)
 
-  def audio_take({:route, route}), do: @route_take_lookup[route]
-  def audio_take(atom) when is_atom(atom), do: @atom_take_lookup[atom]
+  def audio_take({:route, "SL5"}), do: "587"
+  def audio_take({:route, "SL4"}), do: "586"
+  def audio_take({:route, "1"}), do: "573"
+  def audio_take({:route, "8"}), do: "574"
+  def audio_take({:route, "14"}), do: "575"
+  def audio_take({:route, "15"}), do: "576"
+  def audio_take({:route, "19"}), do: "577"
+  def audio_take({:route, "23"}), do: "578"
+  def audio_take({:route, "24"}), do: "622"
+  def audio_take({:route, "27"}), do: "623"
+  def audio_take({:route, "2427"}), do: "629"
+  def audio_take({:route, "28"}), do: "579"
+  def audio_take({:route, "29"}), do: "624"
+  def audio_take({:route, "30"}), do: "625"
+  def audio_take({:route, "31"}), do: "626"
+  def audio_take({:route, "33"}), do: "627"
+  def audio_take({:route, "34"}), do: "678"
+  def audio_take({:route, "34E"}), do: "679"
+  def audio_take({:route, "35"}), do: "680"
+  def audio_take({:route, "36"}), do: "681"
+  def audio_take({:route, "37"}), do: "682"
+  def audio_take({:route, "38"}), do: "683"
+  def audio_take({:route, "39"}), do: "684"
+  def audio_take({:route, "40"}), do: "685"
+  def audio_take({:route, "41"}), do: "580"
+  def audio_take({:route, "42"}), do: "581"
+  def audio_take({:route, "44"}), do: "582"
+  def audio_take({:route, "45"}), do: "583"
+  def audio_take({:route, "47"}), do: "584"
+  def audio_take({:route, "50"}), do: "686"
+  def audio_take({:route, "51"}), do: "687"
+  def audio_take({:route, "66"}), do: "585"
+  def audio_take({:route, "69"}), do: "590"
+  def audio_take({:route, "71"}), do: "591"
+  def audio_take({:route, "72"}), do: "592"
+  def audio_take({:route, "73"}), do: "594"
+  def audio_take({:route, "74"}), do: "595"
+  def audio_take({:route, "75"}), do: "596"
+  def audio_take({:route, "77"}), do: "597"
+  def audio_take({:route, "77A"}), do: "598"
+  def audio_take({:route, "78"}), do: "599"
+  def audio_take({:route, "80"}), do: "600"
+  def audio_take({:route, "86"}), do: "601"
+  def audio_take({:route, "87"}), do: "602"
+  def audio_take({:route, "88"}), do: "603"
+  def audio_take({:route, "89"}), do: "688"
+  def audio_take({:route, "90"}), do: "689"
+  def audio_take({:route, "94"}), do: "690"
+  def audio_take({:route, "96"}), do: "604"
+  def audio_take({:route, "109"}), do: "890"
+  def audio_take({:route, "170"}), do: "588"
+  def audio_take({:route, "171"}), do: "589"
+  def audio_take({:route, "226"}), do: "809"
+  def audio_take({:route, "230"}), do: "810"
+  def audio_take({:route, "236"}), do: "811"
+  def audio_take({:route, "245"}), do: "628"
+  def audio_take({:route, "716"}), do: "888"
+
+  def audio_take({:boarding, "Green-B", "70197", :boston_college}), do: "813"
+  def audio_take({:boarding, "Green-B", "70197", :kenmore}), do: "820"
+  def audio_take({:boarding, "Green-C", "70196", :cleveland_circle}), do: "814"
+  def audio_take({:boarding, "Green-C", "70196", :kenmore}), do: "823"
+  def audio_take({:boarding, "Green-D", "70199", :reservoir}), do: "815"
+  def audio_take({:boarding, "Green-D", "70199", :riverside}), do: "818"
+  def audio_take({:boarding, "Green-D", "70199", :kenmore}), do: "822"
+  def audio_take({:boarding, "Green-E", "70198", :heath_street}), do: "816"
+  def audio_take({:boarding, "Green-E", "70198", :kenmore}), do: "821"
+
+  def audio_take({:crowding, {:front, _}}), do: "870"
+  def audio_take({:crowding, {:back, _}}), do: "871"
+  def audio_take({:crowding, {:middle, _}}), do: "872"
+  def audio_take({:crowding, {:front_and_back, _}}), do: "873"
+  def audio_take({:crowding, {:train_level, :crowded}}), do: "876"
+  def audio_take({:crowding, _}), do: "21000"
+
+  def audio_take({:line, "Red"}), do: "3005"
+  def audio_take({:line, "Orange"}), do: "3006"
+  def audio_take({:line, "Blue"}), do: "3007"
+  def audio_take({:line, "Green"}), do: "3008"
+  def audio_take({:line, "Mattapan"}), do: "3009"
+  def audio_take({:line, _}), do: audio_take(:train)
+
+  def audio_take({:passthrough, :alewife, _}), do: "32114"
+  def audio_take({:passthrough, :southbound, "Red"}), do: "891"
+  def audio_take({:passthrough, :bowdoin, _}), do: "32111"
+  def audio_take({:passthrough, :wonderland, _}), do: "32110"
+  def audio_take({:passthrough, :forest_hills, _}), do: "32113"
+  def audio_take({:passthrough, :oak_grove, _}), do: "32112"
+
+  def audio_take(_), do: nil
 
   @spec audio_message([term()]) :: Content.Audio.canned_message()
-  def audio_message(items) do
+  def audio_message(items, av \\ :audio) do
     vars =
-      Enum.intersperse(items, :_)
-      |> Enum.map(fn item ->
+      Enum.map(items, fn item ->
         case audio_take(item) do
           nil ->
             Logger.error("No audio for: #{inspect(item)}")
@@ -803,8 +847,9 @@ defmodule PaEss.Utilities do
             take
         end
       end)
+      |> pad_takes()
 
-    {:canned, {take_message_id(vars), vars, :audio}}
+    {:canned, {take_message_id(vars), vars, av}}
   end
 
   @spec paginate_text(String.t(), integer()) :: Content.Message.pages()

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -605,7 +605,7 @@ defmodule PaEss.Utilities do
     {"Linden Sq", "889"}
   ]
 
-  @spec audio_take(term()) :: String.t() | nil
+  @spec audio_take(term()) :: String.t()
   # Tokens ending in underscores are newer Polly-generated clips
   def audio_take(:alewife), do: "4000"
   def audio_take(:alewife_), do: "892"

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -811,26 +811,26 @@ defmodule PaEss.Utilities do
   def audio_take({:boarding, "Green-E", "70198", :heath_street}), do: "816"
   def audio_take({:boarding, "Green-E", "70198", :kenmore}), do: "821"
 
-  def audio_take({:crowding, {:front, _}}), do: "870"
-  def audio_take({:crowding, {:back, _}}), do: "871"
-  def audio_take({:crowding, {:middle, _}}), do: "872"
-  def audio_take({:crowding, {:front_and_back, _}}), do: "873"
+  def audio_take({:crowding, {:front, _status}}), do: "870"
+  def audio_take({:crowding, {:back, _status}}), do: "871"
+  def audio_take({:crowding, {:middle, _status}}), do: "872"
+  def audio_take({:crowding, {:front_and_back, _status}}), do: "873"
   def audio_take({:crowding, {:train_level, :crowded}}), do: "876"
-  def audio_take({:crowding, _}), do: "21000"
+  def audio_take({:crowding, _crowding_description}), do: "21000"
 
   def audio_take({:line, "Red"}), do: "3005"
   def audio_take({:line, "Orange"}), do: "3006"
   def audio_take({:line, "Blue"}), do: "3007"
   def audio_take({:line, "Green"}), do: "3008"
   def audio_take({:line, "Mattapan"}), do: "3009"
-  def audio_take({:line, _}), do: audio_take(:train)
+  def audio_take({:line, _name}), do: audio_take(:train)
 
-  def audio_take({:passthrough, :alewife, _}), do: "32114"
+  def audio_take({:passthrough, :alewife, _route}), do: "32114"
   def audio_take({:passthrough, :southbound, "Red"}), do: "891"
-  def audio_take({:passthrough, :bowdoin, _}), do: "32111"
-  def audio_take({:passthrough, :wonderland, _}), do: "32110"
-  def audio_take({:passthrough, :forest_hills, _}), do: "32113"
-  def audio_take({:passthrough, :oak_grove, _}), do: "32112"
+  def audio_take({:passthrough, :bowdoin, _route}), do: "32111"
+  def audio_take({:passthrough, :wonderland, _route}), do: "32110"
+  def audio_take({:passthrough, :forest_hills, _route}), do: "32113"
+  def audio_take({:passthrough, :oak_grove, _route}), do: "32112"
 
   def audio_take(_), do: nil
 

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -606,6 +606,7 @@ defmodule PaEss.Utilities do
   ]
 
   @spec audio_take(term()) :: String.t() | nil
+  # Tokens ending in underscores are newer Polly-generated clips
   def audio_take(:alewife), do: "4000"
   def audio_take(:alewife_), do: "892"
   def audio_take(:ashmont), do: "4016"
@@ -832,23 +833,14 @@ defmodule PaEss.Utilities do
   def audio_take({:passthrough, :forest_hills, _route}), do: "32113"
   def audio_take({:passthrough, :oak_grove, _route}), do: "32112"
 
-  def audio_take(_), do: nil
+  def audio_take(item) do
+    Logger.error("No audio for: #{inspect(item)}")
+    "21000"
+  end
 
   @spec audio_message([term()]) :: Content.Audio.canned_message()
   def audio_message(items, av \\ :audio) do
-    vars =
-      Enum.map(items, fn item ->
-        case audio_take(item) do
-          nil ->
-            Logger.error("No audio for: #{inspect(item)}")
-            audio_take(:_)
-
-          take ->
-            take
-        end
-      end)
-      |> pad_takes()
-
+    vars = Enum.map(items, &audio_take/1) |> pad_takes()
     {:canned, {take_message_id(vars), vars, av}}
   end
 

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -954,13 +954,7 @@ defmodule Signs.Bus do
   # Turns a list of audio tokens into a list of audio messages, chunking as needed to stay under
   # the max var limit.
   defp paginate_audio(items) do
-    for item <- items do
-      PaEss.Utilities.audio_take(item) ||
-        (
-          Logger.error("No audio for: #{inspect(item)}")
-          PaEss.Utilities.audio_take(:",")
-        )
-    end
+    Stream.map(items, &PaEss.Utilities.audio_take/1)
     |> Stream.chunk_every(@var_max)
     |> Enum.map(fn vars ->
       {:canned, {PaEss.Utilities.take_message_id(vars), vars, :audio}}

--- a/test/content/audio/track_change_test.exs
+++ b/test/content/audio/track_change_test.exs
@@ -165,10 +165,11 @@ defmodule Content.Audio.TrackChangeTest do
 
       log =
         capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) == nil
+          assert Content.Audio.to_params(audio) ==
+                   {:canned, {"105", ["540", "21000", "21000"], :audio_visual}}
         end)
 
-      assert log =~ "unknown route, berth, destination"
+      assert log =~ "No audio for"
     end
   end
 end

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -25,38 +25,10 @@ defmodule Content.Audio.UtilitiesTest do
     assert countdown_minutes_var(10) == "5010"
   end
 
-  test "take_message/2" do
-    assert take_message(["1", "2", "3"], :audio_visual) ==
-             {:canned, {"107", ["1", "21000", "2", "21000", "3"], :audio_visual}}
-  end
-
   test "take_message_id/1" do
     assert take_message_id(["1", "2", "3"]) == "105"
     assert take_message_id(List.duplicate("1", 31)) == "220"
     assert take_message_id(List.duplicate("1", 40)) == "230"
-  end
-
-  test "destination_var/1" do
-    assert destination_var(:alewife) == "4000"
-    assert destination_var(:ashmont) == "4016"
-    assert destination_var(:boston_college) == "4202"
-    assert destination_var(:bowdoin) == "4055"
-    assert destination_var(:braintree) == "4021"
-    assert destination_var(:cleveland_circle) == "4203"
-    assert destination_var(:forest_hills) == "4043"
-    assert destination_var(:government_center) == "4061"
-    assert destination_var(:heath_street) == "4204"
-    assert destination_var(:kenmore) == "4070"
-    assert destination_var(:lechmere) == "4056"
-    assert destination_var(:mattapan) == "4100"
-    assert destination_var(:north_station) == "4027"
-    assert destination_var(:oak_grove) == "4022"
-    assert destination_var(:park_street) == "4007"
-    assert destination_var(:reservoir) == "4076"
-    assert destination_var(:riverside) == "4084"
-    assert destination_var(:wonderland) == "4044"
-    assert destination_var(:union_square) == "695"
-    assert destination_var(:medford_tufts) == "852"
   end
 
   test "headsign_to_destination/1" do


### PR DESCRIPTION
#### Summary of changes

This fully standardizes the handling of audio take ids. All take ids are now produced by the `audio_take` function, which maps a semantic-but-readable identifier to the corresponding numeric take id. The higher-level `audio_message` can now optionally produce `:audio_visual` messages, allowing it to take over the remaining cases that were not already using this pattern.