### PR TITLE
Don't announce 4 cars when following train

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -1,5 +1,12 @@
 defmodule Content.Audio.Predictions do
-  @enforce_keys [:prediction, :special_sign, :terminal?, :multiple_messages?, :next_or_following]
+  @enforce_keys [
+    :prediction,
+    :special_sign,
+    :terminal?,
+    :multiple_messages?,
+    :next_or_following,
+    :is_first?
+  ]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
@@ -7,7 +14,8 @@ defmodule Content.Audio.Predictions do
           special_sign: :jfk_mezzanine | :bowdoin_eastbound | nil,
           terminal?: boolean(),
           multiple_messages?: boolean(),
-          next_or_following: :next | :following
+          next_or_following: :next | :following,
+          is_first?: boolean()
         }
 
   @spec new(
@@ -15,14 +23,16 @@ defmodule Content.Audio.Predictions do
           :jfk_mezzanine | :bowdoin_eastbound | nil,
           boolean(),
           boolean(),
-          :next | :following
+          :next | :following,
+          boolean()
         ) :: [t()]
   def new(
         %Predictions.Prediction{} = prediction,
         special_sign,
         terminal?,
         multiple_messages?,
-        next_or_following
+        next_or_following,
+        is_first?
       ) do
     [
       %__MODULE__{
@@ -30,7 +40,8 @@ defmodule Content.Audio.Predictions do
         special_sign: special_sign,
         terminal?: terminal?,
         multiple_messages?: multiple_messages?,
-        next_or_following: next_or_following
+        next_or_following: next_or_following,
+        is_first?: is_first?
       }
     ]
   end
@@ -161,7 +172,8 @@ defmodule Content.Audio.Predictions do
 
     defp four_cars?(audio) do
       PaEss.Utilities.prediction_four_cars?(audio.prediction) and !audio.terminal? and
-        !audio.multiple_messages? and audio.next_or_following == :next
+        !audio.multiple_messages? and audio.next_or_following == :next and
+        audio.is_first?
     end
 
     defp platform_string(:ashmont), do: "Ashmont"

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -161,7 +161,7 @@ defmodule Content.Audio.Predictions do
 
     defp four_cars?(audio) do
       PaEss.Utilities.prediction_four_cars?(audio.prediction) and !audio.terminal? and
-        !audio.multiple_messages?
+        !audio.multiple_messages? and audio.next_or_following == :next
     end
 
     defp platform_string(:ashmont), do: "Ashmont"

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -61,13 +61,15 @@ defmodule Message.Predictions do
 
       Enum.take(message.predictions, if(multiple? or four_cars?, do: 1, else: 2))
       |> Enum.zip(if(same_destination?, do: [:next, :following], else: [:next, :next]))
-      |> Enum.map(fn {prediction, next_or_following} ->
+      |> Enum.with_index()
+      |> Enum.map(fn {{prediction, next_or_following}, index} ->
         %Content.Audio.Predictions{
           prediction: prediction,
           special_sign: message.special_sign,
           terminal?: message.terminal?,
           multiple_messages?: multiple?,
-          next_or_following: next_or_following
+          next_or_following: next_or_following,
+          is_first?: index == 0
         }
       end)
     end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -90,7 +90,8 @@ defmodule Signs.Utilities.Audio do
                  message.special_sign,
                  message.terminal?,
                  length(messages) > 1,
-                 :next
+                 :next,
+                 true
                ),
                update_in(
                  sign.announced_stalls,
@@ -106,7 +107,8 @@ defmodule Signs.Utilities.Audio do
                  message.special_sign,
                  message.terminal?,
                  length(messages) > 1,
-                 :next
+                 :next,
+                 true
                ), sign}
 
             true ->


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Only announce 4-car trains for next trains, not following trains](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1209554302146849)

Only include the 4-car messaging when the announcement is for the next train, not the following train.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
