### PR TITLE
Omit new cars message when 4 car train

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -22,7 +22,7 @@ defmodule Content.Audio.Approaching do
           trip_id: Predictions.Prediction.trip_id() | nil,
           platform: Content.platform() | nil,
           route_id: String.t() | nil,
-          new_cars?: boolean,
+          new_cars?: boolean(),
           four_cars?: boolean(),
           crowding_description: {atom(), atom()} | nil
         }
@@ -52,7 +52,12 @@ defmodule Content.Audio.Approaching do
 
       approaching = if audio.four_cars?, do: [:now_approaching], else: [:is_now_approaching]
       platform = if audio.platform, do: [platform_token(audio.platform)], else: []
-      new_cars = if audio.new_cars?, do: [:",", :with_all_new_red_line_cars], else: []
+
+      new_cars =
+        if audio.new_cars? and not audio.four_cars?,
+          do: [:",", :with_all_new_red_line_cars],
+          else: []
+
       followup = if audio.four_cars?, do: [:four_car_train_message], else: [:stand_back_message]
 
       crowding =
@@ -69,7 +74,7 @@ defmodule Content.Audio.Approaching do
       approaching = if audio.four_cars?, do: "now approaching", else: "is now approaching"
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
       platform = platform_string(audio.platform)
-      new_cars = new_cars_string(audio.new_cars?)
+      new_cars = new_cars_string(audio.new_cars? and not audio.four_cars?)
 
       followup =
         if audio.four_cars?,
@@ -90,7 +95,7 @@ defmodule Content.Audio.Approaching do
       train = Utilities.train_description(audio.destination, audio.route_id)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
       platform = platform_string(audio.platform)
-      new_cars = new_cars_string(audio.new_cars?)
+      new_cars = new_cars_string(audio.new_cars? and not audio.four_cars?)
 
       followup =
         if audio.four_cars?,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Omit the "all new Red Line cars" portion of the message if it is a 4-car train](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1209554302146846)

Don't announce "All new Red Line cars" if it's a 4-car train.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
