### PR TITLE
use Logger.warning instead of Logger.warn

### DIFF
--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -109,7 +109,7 @@ defmodule Engine.Alerts do
         )
 
       {:error, e} ->
-        Logger.warn("Engine.Alerts could not fetch stop statuses: #{inspect(e)}")
+        Logger.warning("Engine.Alerts could not fetch stop statuses: #{inspect(e)}")
     end
 
     {:noreply, state}

--- a/lib/engine/bus_predictions.ex
+++ b/lib/engine/bus_predictions.ex
@@ -131,7 +131,7 @@ defmodule Engine.BusPredictions do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("Engine.BusPredictions unknown_message: #{inspect(msg)}")
+    Logger.warning("Engine.BusPredictions unknown_message: #{inspect(msg)}")
     {:noreply, state}
   end
 

--- a/lib/engine/chelsea_bridge.ex
+++ b/lib/engine/chelsea_bridge.ex
@@ -51,7 +51,7 @@ defmodule Engine.ChelseaBridge do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("Engine.ChelseaBridge unknown_message: #{inspect(msg)}")
+    Logger.warning("Engine.ChelseaBridge unknown_message: #{inspect(msg)}")
     {:noreply, state}
   end
 end

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -142,7 +142,7 @@ defmodule Engine.Config do
         Logger.info("active_headend_ip: current: #{active_headend_ip}")
 
       {:error, e} ->
-        Logger.warn("active_headend_ip: unable to fetch: #{inspect(e)}")
+        Logger.warning("active_headend_ip: unable to fetch: #{inspect(e)}")
     end
 
     {:noreply, state}

--- a/lib/engine/locations.ex
+++ b/lib/engine/locations.ex
@@ -103,7 +103,7 @@ defmodule Engine.Locations do
         :error
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.warn("Could not fetch file from #{inspect(full_url)}: #{inspect(reason)}")
+        Logger.warning("Could not fetch file from #{inspect(full_url)}: #{inspect(reason)}")
         :error
     end
   end

--- a/lib/engine/network_check/hackney.ex
+++ b/lib/engine/network_check/hackney.ex
@@ -18,7 +18,7 @@ defmodule Engine.NetworkCheck.Hackney do
         :ok
 
       _ ->
-        Logger.warn("#{__MODULE__} check_network result=failure resp=#{inspect(response)}")
+        Logger.warning("#{__MODULE__} check_network result=failure resp=#{inspect(response)}")
         :error
     end
   end

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -80,7 +80,7 @@ defmodule Engine.Predictions do
           last_modified
 
         {_, response} ->
-          Logger.warn("Could not fetch predictions: #{inspect(response)}")
+          Logger.warning("Could not fetch predictions: #{inspect(response)}")
           last_modified
       end
 

--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -138,7 +138,7 @@ defmodule Engine.ScheduledHeadways do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("#{__MODULE__} unknown message: #{inspect(msg)}")
+    Logger.warning("#{__MODULE__} unknown message: #{inspect(msg)}")
     {:noreply, state}
   end
 

--- a/lib/headway/request.ex
+++ b/lib/headway/request.ex
@@ -41,14 +41,14 @@ defmodule Headway.Request do
         parse_body(body)
 
       {:ok, %HTTPoison.Response{status_code: status}} ->
-        Logger.warn(
+        Logger.warning(
           "Could not load schedules. Response returned with status code #{inspect(status)}"
         )
 
         :error
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.warn("Could not load schedules: #{inspect(reason)}")
+        Logger.warning("Could not load schedules: #{inspect(reason)}")
         :error
     end
   end
@@ -60,7 +60,7 @@ defmodule Headway.Request do
         Map.get(response, "data")
 
       {:error, reason} ->
-        Logger.warn("Could not decode response for scheduled headways: #{inspect(reason)}")
+        Logger.warning("Could not decode response for scheduled headways: #{inspect(reason)}")
         []
     end
   end

--- a/lib/message_queue.ex
+++ b/lib/message_queue.ex
@@ -72,7 +72,7 @@ defmodule MessageQueue do
   def handle_call({:queue_update, msg}, _from, state) do
     {queue, length} =
       if state.length >= @max_size do
-        Logger.warn(["Message queue too full; dropping ", inspect(@too_full_drop)])
+        Logger.warning(["Message queue too full; dropping ", inspect(@too_full_drop)])
         {_, queue} = :queue.split(@too_full_drop, state.queue)
         {queue, state.length - @too_full_drop}
       else

--- a/lib/monitoring/headend.ex
+++ b/lib/monitoring/headend.ex
@@ -8,7 +8,7 @@ defmodule Monitoring.Headend do
 
     cond do
       not valid? ->
-        Logger.warn("active_headend_ip: invalid ip provided: #{ip}")
+        Logger.warning("active_headend_ip: invalid ip provided: #{ip}")
         {:bad_request, "bad request"}
 
       change? ->

--- a/lib/monitoring/uptime.ex
+++ b/lib/monitoring/uptime.ex
@@ -11,7 +11,7 @@ defmodule Monitoring.Uptime do
           log([date_time: date_time] ++ log_fields)
 
         :error ->
-          Logger.warn("unknown_node: #{inspect(node)}")
+          Logger.warning("unknown_node: #{inspect(node)}")
       end
     end)
   end

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -253,11 +253,11 @@ defmodule PaEss.HttpUpdater do
           {:ok, :sent}
 
         {:ok, %HTTPoison.Response{status_code: status}} ->
-          Logger.warn("head_end_post_error: response had status code: #{inspect(status)}")
+          Logger.warning("head_end_post_error: response had status code: #{inspect(status)}")
           {:error, :bad_status}
 
         {:error, %HTTPoison.Error{reason: reason}} ->
-          Logger.warn("head_end_post_error: #{inspect(reason)}")
+          Logger.warning("head_end_post_error: #{inspect(reason)}")
           {:error, :post_error}
       end
     else
@@ -284,7 +284,7 @@ defmodule PaEss.HttpUpdater do
           {:ok, :sent}
 
         {:ok, %HTTPoison.Response{status_code: status}} ->
-          Logger.warn("sign_ui_post_error: response had status code: #{inspect(status)}")
+          Logger.warning("sign_ui_post_error: response had status code: #{inspect(status)}")
           {:error, :bad_status}
 
         {:error, %HTTPoison.Error{reason: reason}} ->

--- a/lib/pa_ess/scu_updater.ex
+++ b/lib/pa_ess/scu_updater.ex
@@ -51,11 +51,11 @@ defmodule PaEss.ScuUpdater do
           :ok
 
         {:ok, %HTTPoison.Response{status_code: status}} ->
-          Logger.warn("scu_error: status=#{inspect(status)}")
+          Logger.warning("scu_error: status=#{inspect(status)}")
           :error
 
         {:error, %HTTPoison.Error{reason: reason}} ->
-          Logger.warn("scu_error: #{inspect(reason)}")
+          Logger.warning("scu_error: #{inspect(reason)}")
           :error
       end
     else
@@ -84,10 +84,10 @@ defmodule PaEss.ScuUpdater do
           nil
 
         {:ok, %HTTPoison.Response{status_code: status}} ->
-          Logger.warn("signs_ui_error: status=#{inspect(status)}")
+          Logger.warning("signs_ui_error: status=#{inspect(status)}")
 
         {:error, %HTTPoison.Error{reason: reason}} ->
-          Logger.warn("signs_ui_error: #{inspect(reason)}")
+          Logger.warning("signs_ui_error: #{inspect(reason)}")
       end
     end
   end

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -241,7 +241,7 @@ defmodule Signs.Bus do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("Signs.Bus unknown_message: #{inspect(msg)}")
+    Logger.warning("Signs.Bus unknown_message: #{inspect(msg)}")
     {:noreply, state}
   end
 
@@ -782,7 +782,7 @@ defmodule Signs.Bus do
     [headsign | PaEss.Utilities.headsign_abbreviations(headsign)]
     |> Enum.filter(&(String.length(&1) <= max_size))
     |> Enum.max_by(&String.length/1, fn ->
-      Logger.warn("No abbreviation for headsign: #{inspect(headsign)}")
+      Logger.warning("No abbreviation for headsign: #{inspect(headsign)}")
       headsign
     end)
   end

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -182,7 +182,7 @@ defmodule Signs.Realtime do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("Signs.Realtime unknown_message: #{inspect(msg)}")
+    Logger.warning("Signs.Realtime unknown_message: #{inspect(msg)}")
     {:noreply, state}
   end
 

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -212,7 +212,7 @@ defmodule Signs.Utilities.Audio do
       Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
       {update_in(sign.pa_message_plays, &Map.put(&1, pa_message.id, now)), true}
     else
-      Logger.warn("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
+      Logger.warning("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
       {sign, false}
     end
   end

--- a/scripts/latency_analysis/analyze.exs
+++ b/scripts/latency_analysis/analyze.exs
@@ -72,7 +72,7 @@ defmodule HTTPLogs do
   defp sign_updates_from_command("t" <> rest, _, _, _) do
     # Currently we never use this feature, so unsure if RTD_OK would be logged at the time the
     # message is received, or the time it is first displayed
-    Logger.warn("not handling command with effective time: t#{rest}")
+    Logger.warning("not handling command with effective time: t#{rest}")
     []
   end
 
@@ -127,7 +127,7 @@ defmodule SCULogs do
     end
   rescue
     error ->
-      Logger.warn(
+      Logger.warning(
         [
           "failed to parse SCU log line, skipping",
           "line: #{inspect(log_line)}",
@@ -253,7 +253,7 @@ defmodule Analyze do
           timings
 
         %{signs_received_at: %{^number => _}} ->
-          Logger.warn("sign #{number} received update more than once: #{inspect(update)}")
+          Logger.warning("sign #{number} received update more than once: #{inspect(update)}")
           timings
 
         %{signs_received_at: signs_received_at} = timing ->
@@ -276,7 +276,7 @@ defmodule Analyze do
         true
 
       {update, _timestamps} ->
-        Logger.warn("skipping multiple updates with same fields: #{inspect(update)}")
+        Logger.warning("skipping multiple updates with same fields: #{inspect(update)}")
         false
     end)
     |> Stream.map(fn {update, [timestamp]} -> {update, timestamp} end)

--- a/test/engine/locations_test.exs
+++ b/test/engine/locations_test.exs
@@ -18,7 +18,7 @@ defmodule Engine.LocationsTest do
       end)
 
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :warning], fn ->
           {:noreply, updated_state} = Engine.Locations.handle_info(:update, @state)
           assert @state == updated_state
         end)

--- a/test/engine/predictions_test.exs
+++ b/test/engine/predictions_test.exs
@@ -29,7 +29,7 @@ defmodule Engine.PredictionsTest do
       existing_state = %Engine.Predictions{}
 
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :warning], fn ->
           {:noreply, ^existing_state} = handle_info(:update, existing_state)
         end)
 

--- a/test/engine/scheduled_headways_test.exs
+++ b/test/engine/scheduled_headways_test.exs
@@ -18,7 +18,7 @@ defmodule Engine.ScheduledHeadwaysTest do
       assert Process.alive?(pid)
 
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :warning], fn ->
           send(pid, :unknown_message)
           Process.sleep(50)
         end)

--- a/test/headway/request_test.exs
+++ b/test/headway/request_test.exs
@@ -7,7 +7,7 @@ defmodule Headway.RequestTest do
   describe "get_schedules/1" do
     test "gracefully handles bad responses and logs warning" do
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :warning], fn ->
           assert get_schedules(["500_error"]) == :error
           assert get_schedules(["unknown_error"]) == :error
         end)
@@ -30,7 +30,7 @@ defmodule Headway.RequestTest do
 
   test "Logs warning when json data cannot be parsed" do
     log =
-      capture_log([level: :warn], fn ->
+      capture_log([level: :warning], fn ->
         assert get_schedules(["parse_error"]) == []
       end)
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -140,7 +140,7 @@ defmodule Signs.RealtimeTest do
       assert {:ok, pid} = GenServer.start_link(Signs.Realtime, @sign)
 
       log =
-        capture_log([level: :warn], fn ->
+        capture_log([level: :warning], fn ->
           send(pid, :foo)
           Process.sleep(50)
         end)


### PR DESCRIPTION
#### Summary of changes

This switches to `Logger.warning` instead of the deprecated `Logger.warn`