### PR TITLE
Use minimum alert status

### DIFF
--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -24,30 +24,16 @@ defmodule Engine.Alerts do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  @callback max_stop_status([Fetcher.stop_id()], [Fetcher.route_id()]) :: Fetcher.stop_status()
-  def max_stop_status(
+  @callback min_stop_status([Fetcher.stop_id()]) :: Fetcher.stop_status()
+  def min_stop_status(
         tables \\ %{stops_table: @stops_table, routes_table: @routes_table},
-        stop_ids,
-        route_ids
+        stop_ids
       ) do
-    overall_stop_status =
-      Enum.reduce(stop_ids, :none, fn stop_id, overall_status ->
-        stop_status(tables.stops_table, stop_id)
-        |> Fetcher.higher_priority_status(overall_status)
-      end)
-
-    route_states = Enum.map(route_ids, &route_status(tables.routes_table, &1))
-
-    overall_route_status =
-      Enum.reduce(route_states, :none, fn route_state, overall_status ->
-        Fetcher.higher_priority_status(route_state, overall_status)
-      end)
-
-    if Enum.all?(route_states, fn s -> s == overall_route_status end) do
-      Fetcher.higher_priority_status(overall_stop_status, overall_route_status)
-    else
-      overall_stop_status
-    end
+    stop_ids
+    |> Enum.map(&stop_status(tables.stops_table, &1))
+    |> Enum.reduce(fn current_status, overall_status ->
+      Fetcher.lower_priority_status(current_status, overall_status)
+    end)
   end
 
   @callback stop_status(Fetcher.stop_id()) :: Fetcher.stop_status()

--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -31,9 +31,7 @@ defmodule Engine.Alerts do
       ) do
     stop_ids
     |> Enum.map(&stop_status(tables.stops_table, &1))
-    |> Enum.reduce(fn current_status, overall_status ->
-      Fetcher.lower_priority_status(current_status, overall_status)
-    end)
+    |> Enum.min_by(&Fetcher.get_priority_level/1)
   end
 
   @callback stop_status(Fetcher.stop_id()) :: Fetcher.stop_status()

--- a/lib/engine/alerts/fetcher.ex
+++ b/lib/engine/alerts/fetcher.ex
@@ -25,13 +25,9 @@ defmodule Engine.Alerts.Fetcher do
     shuttles_closed_station: 5
   }
 
-  @spec lower_priority_status(stop_status(), stop_status()) :: stop_status()
-  def lower_priority_status(status1, status2) do
-    if @alert_priority_map[status1] <= @alert_priority_map[status2] do
-      status1
-    else
-      status2
-    end
+  @spec get_priority_level(stop_status()) :: number()
+  def get_priority_level(status) do
+    @alert_priority_map[status]
   end
 
   @spec higher_priority_status(stop_status(), stop_status()) :: stop_status()

--- a/lib/engine/alerts/fetcher.ex
+++ b/lib/engine/alerts/fetcher.ex
@@ -16,38 +16,30 @@ defmodule Engine.Alerts.Fetcher do
                }}
               | {:error, any()}
 
+  @alert_priority_map %{
+    none: 0,
+    suspension_transfer_station: 1,
+    shuttles_transfer_station: 2,
+    station_closure: 3,
+    suspension_closed_station: 4,
+    shuttles_closed_station: 5
+  }
+
+  @spec lower_priority_status(stop_status(), stop_status()) :: stop_status()
+  def lower_priority_status(status1, status2) do
+    if @alert_priority_map[status1] <= @alert_priority_map[status2] do
+      status1
+    else
+      status2
+    end
+  end
+
   @spec higher_priority_status(stop_status(), stop_status()) :: stop_status()
-  def higher_priority_status(status1, status2)
-      when status1 == :suspension_closed_station or status2 == :suspension_closed_station do
-    :suspension_closed_station
-  end
-
-  def higher_priority_status(status1, status2)
-      when status1 == :shuttles_closed_station or status2 == :shuttles_closed_station do
-    :shuttles_closed_station
-  end
-
-  def higher_priority_status(status1, status2)
-      when status1 == :suspension_transfer_station or status2 == :suspension_transfer_station do
-    :suspension_transfer_station
-  end
-
-  def higher_priority_status(status1, status2)
-      when status1 == :shuttles_transfer_station or status2 == :shuttles_transfer_station do
-    :shuttles_transfer_station
-  end
-
-  def higher_priority_status(status1, status2)
-      when status1 == :station_closure or status2 == :station_closure do
-    :station_closure
-  end
-
-  def higher_priority_status(status1, status2)
-      when status1 == :alert_along_route or status2 == :alert_along_route do
-    :alert_along_route
-  end
-
-  def higher_priority_status(_status1, _status2) do
-    :none
+  def higher_priority_status(status1, status2) do
+    if @alert_priority_map[status1] >= @alert_priority_map[status2] do
+      status1
+    else
+      status2
+    end
   end
 end

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -121,8 +121,7 @@ defmodule Signs.Realtime do
     alert_status =
       map_source_config(sign.source_config, fn config ->
         stop_ids = SourceConfig.sign_stop_ids(config)
-        routes = SourceConfig.sign_routes(config)
-        RealtimeSigns.alert_engine().max_stop_status(stop_ids, routes)
+        RealtimeSigns.alert_engine().min_stop_status(stop_ids)
       end)
 
     first_scheduled_departures =

--- a/test/engine/alerts_test.exs
+++ b/test/engine/alerts_test.exs
@@ -83,28 +83,13 @@ defmodule Engine.AlertsTest do
       assert Engine.Alerts.stop_status(stops_ets_table_name, "234") == :shuttles_transfer_station
       assert Engine.Alerts.stop_status(stops_ets_table_name, "n/a") == :none
 
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "n/a-2"], ["n/a-3"]) == :none
+      assert Engine.Alerts.min_stop_status(tables, ["n/a-1", "n/a-2"]) == :none
 
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "123"], ["n/a-2"]) ==
-               :shuttles_closed_station
+      assert Engine.Alerts.min_stop_status(tables, ["n/a-1", "123"]) ==
+               :none
 
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "123", "234"], [
-               "n/a-2"
-             ]) == :shuttles_closed_station
-
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "234"], ["n/a-2"]) ==
+      assert Engine.Alerts.min_stop_status(tables, ["123", "234"]) ==
                :shuttles_transfer_station
-
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "234"], ["Red"]) ==
-               :suspension_closed_station
-
-      assert Engine.Alerts.max_stop_status(tables, ["n/a-1", "234"], ["Orange"]) ==
-               :shuttles_transfer_station
-
-      assert Engine.Alerts.max_stop_status(tables, ["n/a"], ["Green-B"]) ==
-               :suspension_closed_station
-
-      assert Engine.Alerts.max_stop_status(tables, ["n/a"], ["Green-B", "Green-C"]) == :none
 
       assert Engine.Alerts.route_status(routes_ets_table_name, "Red") ==
                :suspension_closed_station

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -140,7 +140,7 @@ defmodule Signs.RealtimeTest do
     setup do
       stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
       stub(Engine.Config.Mock, :headway_config, fn _, _ -> @headway_config end)
-      stub(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> true end)
       stub(Engine.Locations.Mock, :for_vehicle, fn _ -> nil end)
@@ -250,7 +250,7 @@ defmodule Signs.RealtimeTest do
         {:static_text, {"custom", "message"}}
       end)
 
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_closed_station end)
       expect_messages({"custom", "message"})
       expect_audios([{:ad_hoc, {"custom message", :audio}}], [{"custom message", nil}])
 
@@ -274,19 +274,19 @@ defmodule Signs.RealtimeTest do
     end
 
     test "when sign is at a transfer station from a shuttle, and there are no predictions it's empty" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_transfer_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_transfer_station end)
       expect_messages({"", ""})
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
     test "when sign is at a transfer station from a suspension, and there are no predictions it's empty" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_transfer_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_transfer_station end)
       expect_messages({"", ""})
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
     test "when sign is at a station closed by shuttles and there are no predictions, it says so" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
       expect_messages({"No Southbound svc", "Use shuttle bus"})
 
       expect_audios([{:ad_hoc, {"No Southbound service. Use shuttle.", :audio}}], [
@@ -297,7 +297,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "when sign is at a station closed and there are no predictions, but shuttles do not run at this station" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
       expect_messages({"No Southbound svc", ""})
 
       expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
@@ -308,7 +308,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "when sign is at a station closed due to suspension and there are no predictions, it says so" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_closed_station end)
       expect_messages({"No Southbound svc", ""})
 
       expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
@@ -319,7 +319,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "when sign is at a closed station and there are no predictions, it says so" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
       expect_messages({"No Southbound svc", ""})
 
       expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
@@ -330,8 +330,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "mezzanine sign with alert" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
       expect_messages({"No Red Line", ""})
 
       expect_audios([{:canned, {"107", spaced(["861", "3005", "863"]), :audio}}], [
@@ -342,8 +342,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "multi-route mezzanine sign with alert" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
       expect_messages({"No train service", ""})
 
       expect_audios([{:canned, {"107", spaced(["861", "864", "863"]), :audio}}], [
@@ -354,7 +354,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "predictions take precedence over alerts" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_closed_station end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :ashmont, arrival: 120)]
@@ -419,7 +419,7 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :ashmont, arrival: 120)]
       end)
 
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :station_closure end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
       expect_messages({"No Southbound svc", ""})
 
       expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
@@ -977,7 +977,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "reads alerts" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
       expect_messages({"No Southbound svc", "Use shuttle bus"})
 
       expect_audios([{:ad_hoc, {"No Southbound service. Use shuttle.", :audio}}], [
@@ -1684,8 +1684,8 @@ defmodule Signs.RealtimeTest do
 
     test "mezzanine sign, headways and shuttle alert" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
 
       expect_messages({
         [{"Northbound trains", 6}, {"No Southbound svc", 6}],
@@ -1700,8 +1700,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "mezzanine sign, non-shuttle alert and headways" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :suspension_closed_station end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
 
       expect_messages(
         {"Northbound  no svc", [{"Southbound  trains every", 6}, {"Southbound  11 to 13 min", 6}]}
@@ -1728,8 +1728,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "mezzanine sign, shuttle alert flips to bottom" do
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_closed_station end)
-      expect(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
 
@@ -1813,7 +1813,7 @@ defmodule Signs.RealtimeTest do
   describe "Union Sq alert messaging" do
     setup do
       stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
-      stub(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :shuttles_transfer_station end)
+      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_transfer_station end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> false end)
       stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
@@ -1845,7 +1845,7 @@ defmodule Signs.RealtimeTest do
   describe "Last Trip of the Day" do
     setup do
       stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
-      stub(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> true end)
 
@@ -2021,7 +2021,7 @@ defmodule Signs.RealtimeTest do
     setup do
       stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
       stub(Engine.Config.Mock, :headway_config, fn _, _ -> @headway_config end)
-      stub(Engine.Alerts.Mock, :max_stop_status, fn _, _ -> :none end)
+      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> true end)
       stub(Engine.Locations.Mock, :for_vehicle, fn _ -> nil end)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [All destinations must be in alert mode to trigger alert status](https://app.asana.com/0/1185117109217413/1208776052650234/f)

This change makes it so that instead of using a sign's "maximum alert status", we use the "minimum alert status". This effectively makes it so that we prefer to show less information rather than more in cases where there are > 1 alert statuses for a given sign.

A couple nuances to the change:
- We should be able to remove the consideration of `overall_route_status` when calculating the minimum alert status. Based on the logic in `lib/engine/alerts/api_fetcher.ex`, routes only receive the status `:alert_along_route` and that alert status isn't useful to us.
- I reordered the alert status priorities based on the principal that more information = higher priority level
- Not a change, but note that alert statuses on a single stop_id granularity will still use a "maximum alert status" since at a single stop level, there is no ambiguity on what information should be displayed.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
