### PR TITLE
Added special four car boarding message for Braintree/Alewife

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -322,6 +322,10 @@ defmodule PaEss.Utilities do
     " It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge."
   end
 
+  def four_cars_boarding_text() do
+    " It is a shorter 4-car train. You may have to move to a different part of the platform to board."
+  end
+
   def time_hour_var(hour) when hour >= 0 and hour < 24 do
     adjusted_hour = rem(hour, 12)
 
@@ -519,6 +523,14 @@ defmodule PaEss.Utilities do
       do: true
 
   def prediction_four_cars?(_), do: false
+
+  def prediction_alewife_braintree?(%Predictions.Prediction{
+        stop_id: stop_id
+      })
+      when stop_id in ["70105", "70061"],
+      do: true
+
+  def prediction_alewife_braintree?(_), do: false
 
   def prediction_ashmont?(%Predictions.Prediction{
         stop_id: "70094"
@@ -721,6 +733,9 @@ defmodule PaEss.Utilities do
 
   # audio: "It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.", visual: "Please move to front of the train to board."
   def audio_take(:four_car_train_message), do: "922"
+
+  # audio: "It is a shorter 4-car train. You may have to move to a different part of the platform to board."
+  def audio_take(:four_car_train_boarding_message), do: "926"
   # "Please stand back from the platform edge."
   def audio_take(:stand_back_message), do: "925"
   def audio_take(:b), do: "536"


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Add a 4-car train piece to the "boarding" message at Alewife/Braintree](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209846410769747?focus=true)

- "It is a shorter 4-car train. You may have to move to a different part of the platform to board."
- Added four car special messaging specifically for Braintree and Alewife when passengers are boarding
- Waiting on the take ID from ARINC

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
