### PR TITLE
switch to PCM audio generation

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -48,4 +48,4 @@ jobs:
         run: mix format --check-formatted
       - name: Run tests
         run: mix test
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -172,10 +172,14 @@ defmodule PaEss.Updater do
 
     text = ~s(<speak><amazon:effect name="drc">#{text}</amazon:effect></speak>)
 
-    http_poster.post("#{watts_url}/tts", %{text: text, voice_id: voice_id} |> Jason.encode!(), [
-      {"Content-type", "application/json"},
-      {"x-api-key", watts_api_key}
-    ])
+    http_poster.post(
+      "#{watts_url}/tts",
+      %{text: text, voice_id: voice_id, output_format: "pcm"} |> Jason.encode!(),
+      [
+        {"Content-type", "application/json"},
+        {"x-api-key", watts_api_key}
+      ]
+    )
     |> case do
       {:ok, %HTTPoison.Response{status_code: status, body: body}} when status in 200..299 ->
         body

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -174,7 +174,7 @@ defmodule PaEss.Updater do
 
     http_poster.post(
       "#{watts_url}/tts",
-      %{text: text, voice_id: voice_id, output_format: "pcm"} |> Jason.encode!(),
+      Jason.encode!(%{text: text, voice_id: voice_id, output_format: "pcm"}),
       [
         {"Content-type", "application/json"},
         {"x-api-key", watts_api_key}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [SCU audio and visual fixes](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209953188678181?focus=true)

This changes the audio generation from `mp3` to `pcm`, to go with the corresponding change in Scully.