### PR TITLE
Use departs at instead of scheduled to arrive at

### DIFF
--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -15,8 +15,7 @@ defmodule Content.Audio.FirstTrainScheduled do
         :the_first,
         destination,
         :train,
-        :is,
-        :scheduled_to_arrive_at,
+        :departs_at,
         {:hour, scheduled_time.hour},
         {:minute, scheduled_time.minute}
       ])
@@ -25,7 +24,7 @@ defmodule Content.Audio.FirstTrainScheduled do
     def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
-      {"The first #{train} is scheduled to arrive at #{time}", nil}
+      {"The first #{train} departs at #{time}", nil}
     end
 
     def to_logs(%Content.Audio.FirstTrainScheduled{}) do

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -691,7 +691,7 @@ defmodule PaEss.Utilities do
   def audio_take(:stop_away), do: "535"
   def audio_take(:stops_away), do: "534"
   def audio_take(:the_first), do: "866"
-  def audio_take(:scheduled_to_arrive_at), do: "865"
+  def audio_take(:departs_at), do: "927"
   def audio_take(:upcoming_departures), do: "548"
   def audio_take(:upcoming_arrivals), do: "550"
   def audio_take(:is_now_arriving), do: "24055"

--- a/test/content/audio/first_train_scheduled_test.exs
+++ b/test/content/audio/first_train_scheduled_test.exs
@@ -2,7 +2,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
   use ExUnit.Case, async: true
 
   describe "Content.Audio.to_params protocol" do
-    test "First train to Ashmont scheduled to arrive at 5 o'clock" do
+    test "First train to Ashmont departs at 5 o'clock" do
       audio = %Content.Audio.FirstTrainScheduled{
         destination: :ashmont,
         scheduled_time: ~U[2023-07-19 05:00:00Z]
@@ -10,7 +10,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"115",
+                {"113",
                  [
                    "866",
                    "21000",
@@ -18,9 +18,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
                    "21000",
                    "864",
                    "21000",
-                   "533",
-                   "21000",
-                   "865",
+                   "927",
                    "21000",
                    "8004",
                    "21000",
@@ -28,7 +26,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
                  ], :audio}}
     end
 
-    test "First train to Ashmont scheduled to arrive at 5 oh 5" do
+    test "First train to Ashmont departs at 5 oh 5" do
       audio = %Content.Audio.FirstTrainScheduled{
         destination: :ashmont,
         scheduled_time: ~U[2023-07-19 05:05:00Z]
@@ -36,7 +34,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"115",
+                {"113",
                  [
                    "866",
                    "21000",
@@ -44,9 +42,7 @@ defmodule Content.Audio.FirstTrainScheduledTest do
                    "21000",
                    "864",
                    "21000",
-                   "533",
-                   "21000",
-                   "865",
+                   "927",
                    "21000",
                    "8004",
                    "21000",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Early AM language - use "departs" instead of "arrives" at terminals](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209805150516630?focus=true)

Use "departs at" instead of "scheduled to arrive at" for any early AM audio announcements.

This makes more sense at terminals and also generally since the time that we show/announce to riders is the first scheduled _departure_, not arrival.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
