### PR TITLE
make predictions engine resilient to bad json

### DIFF
--- a/lib/predictions/predictions.ex
+++ b/lib/predictions/predictions.ex
@@ -114,14 +114,6 @@ defmodule Predictions.Predictions do
     }
   end
 
-  def parse_json_response("") do
-    %{"entity" => []}
-  end
-
-  def parse_json_response(body) do
-    Jason.decode!(body)
-  end
-
   def relevant_rail_route?(route_id) do
     route_id in [
       "Red",

--- a/test/predictions/predictions_test.exs
+++ b/test/predictions/predictions_test.exs
@@ -373,16 +373,4 @@ defmodule Predictions.PredictionsTest do
               }, _} = get_all(feed_message, @current_time)
     end
   end
-
-  describe "parse_pb_response/1" do
-    test "decodes a pb file" do
-      assert @feed_message
-             |> Jason.encode!()
-             |> parse_json_response == @feed_message
-    end
-
-    test "Gracefully handles an empty (e.g. 304) response" do
-      assert %{} = parse_json_response("")
-    end
-  end
 end


### PR DESCRIPTION
#### Summary of changes

`Engine.Predictions` occasionally crashes because the API returns a 200 response with a non-JSON body. This makes the code resilient against that case, so we'll just log a warning instead.