### PR TITLE
Return proper message when error while fetching bus schedules

### DIFF
--- a/lib/engine/bus_stops.ex
+++ b/lib/engine/bus_stops.ex
@@ -96,7 +96,7 @@ defmodule Engine.BusStops do
 
       err ->
         Logger.error("Error getting bus schedules: #{inspect(err)}")
-        []
+        {:noreply, state}
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Easier configuration for bus PA/ESS](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208977593203660?focus=true)

Quick fix for a bug in #913. When there's an error while fetching from the v3 API, we should return `{:noreply, state}` and not just an empty list.
