### PR TITLE
bugfix: Do not include platform stop_ids when finding min alert at terminal stations

### DIFF
--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -19,6 +19,22 @@ defmodule Engine.Alerts do
   @stops_table :alerts_by_stop
   @routes_table :alerts_by_route
 
+  # Platfrom stop IDs that don't receive Alerts
+  @platform_stop_ids MapSet.new([
+                       "Alewife-01",
+                       "Alewife-02",
+                       "Braintree-01",
+                       "Braintree-02",
+                       "Forest Hills-01",
+                       "Forest Hills-02",
+                       "Oak Grove-01",
+                       "Oak Grove-02",
+                       "Government Center-Brattle",
+                       "71199",
+                       "Union Square-01",
+                       "Union Square-02"
+                     ])
+
   def start_link(opts \\ []) do
     name = opts[:gen_server_name] || __MODULE__
     GenServer.start_link(__MODULE__, opts, name: name)
@@ -30,6 +46,7 @@ defmodule Engine.Alerts do
         stop_ids
       ) do
     stop_ids
+    |> Enum.reject(&MapSet.member?(@platform_stop_ids, &1))
     |> Enum.map(&stop_status(tables.stops_table, &1))
     |> Enum.min_by(&Fetcher.get_priority_level/1)
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [No Service Alert handling at Terminal ](https://app.asana.com/1/15492006741476/project/1208877354406742/task/1210060535858857?focus=true)

With the change to use the minimum alert status for all stop IDs at a station, a bug was introduced with terminal station `stop_ids` that do not receive Alerts. To get around this, added logic to filter these out before determining the minimum alert status for a station.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
