### PR TITLE
Added logic for overnight period stopping certain messages

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -85,6 +85,13 @@ defmodule Engine.ScheduledHeadways do
     |> min_time()
   end
 
+  @callback get_last_scheduled_departure([binary]) :: nil | DateTime.t()
+  def get_last_scheduled_departure(stop_ids) do
+    get_first_last_departures(stop_ids)
+    |> Enum.map(&elem(&1, 1))
+    |> min_time()
+  end
+
   @doc "Checks if the given time is after the first scheduled stop and before the last.
   A buffer of minutes (positive) is subtracted from the first time. so that headways are
   shown for a short time before the first train."

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -3,9 +3,11 @@ defmodule Signs.Utilities.Messages do
   Helper functions for deciding which message a sign should
   be displaying
   """
+  alias Signs.Utilities.SourceConfig
 
   @early_am_start ~T[03:29:00]
   @early_am_buffer -40
+  @overnight_buffer -30
 
   @spec get_messages(
           Signs.Realtime.predictions(),
@@ -52,12 +54,19 @@ defmodule Signs.Utilities.Messages do
 
           alert_status = filter_alert_status(alert_status, sign_config)
 
-          prediction_message(predictions, config, sign) ||
-            service_ended_message(service_status, config) ||
-            alert_message(alert_status, sign, config) ||
-            Signs.Utilities.Headways.headway_message(config, current_time) ||
-            early_am_message(current_time, scheduled, config) ||
-            %Message.Empty{}
+          if overnight_period?(current_time, sign.source_config, service_status) do
+            prediction_message(predictions, config, sign) ||
+              service_ended_message(service_status, config) ||
+              early_am_message(current_time, scheduled, config) ||
+              %Message.Empty{}
+          else
+            prediction_message(predictions, config, sign) ||
+              service_ended_message(service_status, config) ||
+              alert_message(alert_status, sign, config) ||
+              Signs.Utilities.Headways.headway_message(config, current_time) ||
+              early_am_message(current_time, scheduled, config) ||
+              %Message.Empty{}
+          end
         end)
     end
     |> transform_messages()
@@ -256,6 +265,42 @@ defmodule Signs.Utilities.Messages do
     if in_early_am?(current_time, scheduled_time) do
       %Message.FirstTrain{destination: config.headway_destination, scheduled: scheduled_time}
     end
+  end
+
+  defp overnight_period?(current_time, config, service_ended) do
+    first_departure =
+      RealtimeSigns.headway_engine().get_first_scheduled_departure(
+        SourceConfig.sign_stop_ids(config)
+      )
+
+    last_scheduled_departure =
+      RealtimeSigns.headway_engine().get_last_scheduled_departure(
+        SourceConfig.sign_stop_ids(config)
+      )
+
+    last_actual_departure =
+      if service_ended do
+        SourceConfig.sign_stop_ids(config)
+        |> Stream.flat_map(&RealtimeSigns.last_trip_engine().get_recent_departures(&1))
+        |> Enum.max_by(fn {_key, datetime} -> datetime end, fn -> nil end)
+        |> case do
+          {_key, dt} -> dt
+          nil -> nil
+        end
+      else
+        nil
+      end
+
+    last_time_to_check =
+      if last_actual_departure != nil &&
+           Timex.after?(last_actual_departure, last_scheduled_departure) do
+        last_actual_departure
+      else
+        last_scheduled_departure
+      end
+
+    Timex.after?(Timex.shift(current_time, minutes: @overnight_buffer), last_time_to_check) ||
+      before_early_am_threshold?(current_time, first_departure)
   end
 
   defp alert_message(alert_status, sign, config) do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -162,6 +162,10 @@ defmodule Signs.RealtimeTest do
         datetime(~T[05:00:00])
       end)
 
+      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
+        datetime(~D[2023-01-02], ~T[02:00:00])
+      end)
+
       :ok
     end
 
@@ -1227,7 +1231,7 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_messages({"Southbound train", "due 5:00"})
-      expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
+      expect(Engine.ScheduledHeadways.Mock, :display_headways?, 0, fn _, _, _ -> false end)
 
       Signs.Realtime.handle_info(:run_loop, %{
         @sign
@@ -1305,7 +1309,7 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
-      expect(Engine.ScheduledHeadways.Mock, :display_headways?, 2, fn _, _, _ -> false end)
+      expect(Engine.ScheduledHeadways.Mock, :display_headways?, 0, fn _, _, _ -> false end)
 
       expect_messages(
         {[{"Northbound train", 6}, {"Southbound train", 6}], [{"due 5:00", 6}, {"due 5:00", 6}]}
@@ -1330,7 +1334,7 @@ defmodule Signs.RealtimeTest do
 
       expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
 
-      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
+      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, 3, fn _ ->
         datetime(~T[05:00:00])
       end)
 
@@ -1470,6 +1474,14 @@ defmodule Signs.RealtimeTest do
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :alewife, arrival: 240, stop_id: "70086")]
+      end)
+
+      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
+        datetime(~T[04:30:00])
+      end)
+
+      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
+        datetime(~T[05:00:00])
       end)
 
       expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
@@ -1868,6 +1880,10 @@ defmodule Signs.RealtimeTest do
         datetime(~T[05:00:00])
       end)
 
+      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
+        datetime(~D[2023-01-02], ~T[02:00:00])
+      end)
+
       :ok
     end
 
@@ -1904,6 +1920,10 @@ defmodule Signs.RealtimeTest do
 
       stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
         datetime(~T[05:00:00])
+      end)
+
+      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
+        datetime(~T[02:00:00])
       end)
 
       :ok
@@ -1972,6 +1992,14 @@ defmodule Signs.RealtimeTest do
         %{"b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
+      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
+        %{"a" => ~U[2023-01-01 00:00:00.000Z]}
+      end)
+
+      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "2" ->
+        %{"b" => ~U[2023-01-01 00:00:00.000Z]}
+      end)
+
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> false end)
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "b" -> true end)
 
@@ -2016,6 +2044,14 @@ defmodule Signs.RealtimeTest do
         %{"b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
+      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
+        %{"a" => ~U[2023-01-01 00:00:00.000Z]}
+      end)
+
+      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "70086" ->
+        %{"b" => ~U[2023-01-01 00:00:00.000Z]}
+      end)
+
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> true end)
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "b" -> false end)
 
@@ -2050,7 +2086,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Red line trunk service ends after two last trips" do
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
+      expect(Engine.LastTrip.Mock, :get_recent_departures, 2, fn _ ->
         %{"a" => ~U[2023-01-01 00:00:00.000Z], "b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
@@ -2075,7 +2111,7 @@ defmodule Signs.RealtimeTest do
       stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
 
       stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
-        datetime(~T[05:00:00])
+        DateTime.new!(~D[2022-12-31], ~T[05:00:00], "Etc/UTC")
       end)
 
       :ok
@@ -2118,6 +2154,69 @@ defmodule Signs.RealtimeTest do
 
       assert {:reply, {_, false}, _} =
                Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
+    end
+  end
+
+  describe "Overnight Period" do
+    setup do
+      stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
+      stub(Engine.Config.Mock, :headway_config, fn _, _ -> @headway_config end)
+      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
+      stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
+      stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> true end)
+      stub(Engine.Locations.Mock, :for_vehicle, fn _ -> nil end)
+      stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> false end)
+      stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
+
+      stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
+        datetime(~T[05:00:00])
+      end)
+
+      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
+        datetime(~D[2023-01-02], ~T[02:00:00])
+      end)
+
+      :ok
+    end
+
+    test "does not play alerts when in the overnight period" do
+      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
+
+      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
+
+      expect_messages({"", ""})
+      expect(PaEss.Updater.Mock, :play_message, 0, fn _, _, _, _, _ -> :ok end)
+
+      Signs.Realtime.handle_info(:run_loop, %{
+        @sign
+        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
+      })
+    end
+
+    test "does not show headways when in the overnight period" do
+      expect(Engine.Config.Mock, :headway_config, 0, fn _, _ ->
+        %{@headway_config | range_high: 14}
+      end)
+
+      expect_messages({"", ""})
+
+      Signs.Realtime.handle_info(:run_loop, %{
+        @sign
+        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
+      })
+    end
+
+    test "still shows predictions if they exist during overnight period" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(arrival: 180, destination: :ashmont)]
+      end)
+
+      expect_messages({"Ashmont      3 min", ""})
+
+      Signs.Realtime.handle_info(:run_loop, %{
+        @sign
+        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
+      })
     end
   end
 
@@ -2229,6 +2328,7 @@ defmodule Signs.RealtimeTest do
   end
 
   defp datetime(time), do: DateTime.new!(~D[2023-01-01], time, "America/New_York")
+  defp datetime(date, time), do: DateTime.new!(date, time, "America/New_York")
 
   defp spaced(list), do: PaEss.Utilities.pad_takes(list)
 


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [Suppress some passive content on PA/ESS overnight](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209393352927336?focus=true)
- During this period, alerts and headways will not be displayed or announced
- Predictions, service ended messages and early am messages will still continue to display
- Tests added and modified to adjust to logic, display_headway expected to be called 0 times with the new logic flow

#### Reviewer Checklist

- [X] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
