### PR TITLE
chore: update Erlang and Elixir versions

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -13,7 +13,7 @@ export API_V3_URL=https://api-dev-green.mbtace.com
 #export API_V3_KEY=
 
 # Username and password for the Chelsea bridge API. Required. These values can be found in the shared
-# 1Password vault, in the "Cheslea St Drawbridge API" entry, in fields `username` and `password`.
+# 1Password vault, in the "Chelsea St Drawbridge API" entry, in fields `username` and `password`.
 #export CHELSEA_BRIDGE_USERNAME=
 #export CHELSEA_BRIDGE_PASSWORD=
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.0-otp-25
-erlang 25.0.4
+elixir 1.17.3-otp-27
+erlang 27.3.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ELIXIR_VERSION=1.14.0
-ARG ERLANG_VERSION=25.0.4
-ARG ALPINE_VERSION=3.18.0
+ARG ALPINE_VERSION=3.21.3
+ARG ELIXIR_VERSION=1.17.3
+ARG ERLANG_VERSION=27.3.4
 # See also: ERTS_VERSION in the from image below
 
-FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-alpine-${ALPINE_VERSION} as build
+FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-alpine-${ALPINE_VERSION} AS build
 
 ENV MIX_ENV=prod
 
@@ -29,11 +29,12 @@ COPY config/runtime.exs config/runtime.exs
 RUN mix release linux
 
 # The one the elixir image was built with
-FROM alpine:${ALPINE_VERSION}
+FROM hexpm/erlang:${ERLANG_VERSION}-alpine-${ALPINE_VERSION}
 
-RUN apk add --no-cache libssl1.1 dumb-init libstdc++ libgcc ncurses-libs && \
+RUN apk add --no-cache dumb-init && \
     mkdir /work /realtime_signs && \
-    adduser -D realtime_signs && chown realtime_signs /work
+    adduser -D realtime_signs && \
+    chown realtime_signs /work
 
 COPY --from=build /realtime_signs/_build/prod/rel/linux /realtime_signs
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,7 +85,7 @@ if config_env() == :prod and splunk_token != "" do
 
   config :logger, :splunk,
     connector: Logger.Backend.Splunk.Output.Http,
-    host: 'https://http-inputs-mbta.splunkcloud.com/services/collector/event',
+    host: "https://http-inputs-mbta.splunkcloud.com/services/collector/event",
     token: splunk_token,
     format: "$dateT$time [$level] node=$node $metadata$message\n",
     metadata: [:request_id],

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -14,7 +14,7 @@ defmodule Engine.Config do
           table_name_headways: term(),
           table_name_chelsea_bridge: term(),
           current_version: version_id,
-          time_fetcher: (() -> DateTime.t())
+          time_fetcher: (-> DateTime.t())
         }
 
   @type sign_config ::

--- a/lib/engine/health.ex
+++ b/lib/engine/health.ex
@@ -7,7 +7,7 @@ defmodule Engine.Health do
   @type t :: %__MODULE__{
           failed_requests: integer(),
           network_check_mod: module(),
-          restart_fn: (() -> :ok)
+          restart_fn: (-> :ok)
         }
 
   @hackney_pools [:default, :arinc_pool]
@@ -53,7 +53,7 @@ defmodule Engine.Health do
     |> Stream.map(&process_metrics/1)
     |> Enum.each(fn {name, supervisor, metrics} ->
       Logger.info([
-        'realtime_signs_process_health name="#{inspect(name)}" supervisor="#{inspect(supervisor)}" ',
+        "realtime_signs_process_health name=#{inspect(name)} supervisor=#{inspect(supervisor)} ",
         metrics
       ])
     end)

--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -16,7 +16,7 @@ defmodule Engine.ScheduledHeadways do
           fetch_chunk_size: integer(),
           headway_calc_ms: integer(),
           stop_ids: [String.t()],
-          time_fetcher: (() -> DateTime.t())
+          time_fetcher: (-> DateTime.t())
         }
 
   def start_link(opts \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule RealtimeSigns.Mixfile do
     [
       app: :realtime_signs,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: LcovEx],
@@ -22,10 +22,16 @@ defmodule RealtimeSigns.Mixfile do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
+    apps = [:logger]
+
+    apps =
+      case Mix.env() do
+        :test -> [:inets | apps]
+        _ -> apps
+      end
+
     [
-      extra_applications: [
-        :logger
-      ],
+      extra_applications: apps,
       mod: {RealtimeSigns, []}
     ]
   end

--- a/test/engine/health_test.exs
+++ b/test/engine/health_test.exs
@@ -87,8 +87,8 @@ defmodule Engine.HealthTest do
 
     assert log =~ ~r/
       realtime_signs_process_health
-      \ name="Engine.Config"
-      \ supervisor="RealtimeSigns"
+      \ name=Engine.Config
+      \ supervisor=RealtimeSigns
       \ memory=\d+
       \ binary_memory=\d+
       \ heap_size=\d+

--- a/test/engine/locations_test.exs
+++ b/test/engine/locations_test.exs
@@ -47,8 +47,8 @@ defmodule Engine.LocationsTest do
       assert updated_state == @state
 
       assert :ets.tab2list(:test_vehicle_locations) == [
-               {"vehicle_2", :none},
-               {"vehicle_1", :none}
+               {"vehicle_1", :none},
+               {"vehicle_2", :none}
              ]
     end
   end

--- a/test/engine/network_check/hackney_test.exs
+++ b/test/engine/network_check/hackney_test.exs
@@ -3,15 +3,15 @@ defmodule Engine.NetworkCheck.HackneyTest do
   alias Test.Support.Helpers
 
   defmodule MockBadNetwork do
-    def unquote(:do)(_data), do: {:proceed, [response: {500, 'Not OK'}]}
+    def unquote(:do)(_data), do: {:proceed, [response: {500, ~c"Not OK"}]}
   end
 
   defmodule MockGoodNetwork200 do
-    def unquote(:do)(_data), do: {:proceed, [response: {200, 'OK'}]}
+    def unquote(:do)(_data), do: {:proceed, [response: {200, ~c"OK"}]}
   end
 
   defmodule MockGoodNetwork204 do
-    def unquote(:do)(_data), do: {:proceed, [response: {204, 'OK'}]}
+    def unquote(:do)(_data), do: {:proceed, [response: {204, ~c"OK"}]}
   end
 
   describe "check/0" do

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,4 +1,6 @@
 defmodule Test.Support.Helpers do
+  require :httpd
+
   defmacro reassign_env(var) do
     quote do
       old_value = Application.get_env(:realtime_signs, unquote(var))
@@ -25,9 +27,9 @@ defmodule Test.Support.Helpers do
   def start_server(module) do
     {:ok, pid} =
       :inets.start(:httpd,
-        server_name: 'TmpServer',
-        server_root: '/tmp',
-        document_root: '/tmp',
+        server_name: ~c"TmpServer",
+        server_root: ~c"/tmp",
+        document_root: ~c"/tmp",
         port: 0,
         modules: [module]
       )

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
-Application.ensure_all_started(:inets)
 ExUnit.start(capture_log: true)
 
 Mox.defmock(Engine.NetworkCheck.Mock, for: Engine.NetworkCheck)


### PR DESCRIPTION
#### Summary of changes

* Address warnings regarding charlist syntax. In some cases these could have just been binaries; in others (Erlang APIs) chars are necessary.

* Address test failures from not having `inets` loaded. This now needs to be in `extra_applications` for certain `httpd` functions to exist; starting it "manually" in `test_helper.exs` no longer works.

* Use Erlang Alpine image as the base for the runtime container instead of plain Alpine, so it already has the proper packages installed and we don't have to maintain the list ourselves.

#### Reviewer Checklist

- [x] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
