### PR TITLE
Update track change

### DIFF
--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -23,8 +23,6 @@ defmodule Content.Audio.TrackChange do
 
   defimpl Content.Audio do
     def to_params(%{route_id: route_id, berth: berth, destination: destination}) do
-      branch = Content.Utilities.route_branch_letter(route_id)
-
       platform =
         case berth do
           "70196" -> :b

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -15,16 +15,36 @@ defmodule Content.Audio.TrackChange do
         }
 
   @spec park_track_change?(Predictions.Prediction.t()) :: boolean()
-  def park_track_change?(%{route_id: "Green-B", stop_id: "70197"}), do: true
-  def park_track_change?(%{route_id: "Green-C", stop_id: "70196"}), do: true
-  def park_track_change?(%{route_id: "Green-D", stop_id: "70199"}), do: true
-  def park_track_change?(%{route_id: "Green-E", stop_id: "70198"}), do: true
+  def park_track_change?(%{route_id: "Green-B", stop_id: "70198"}), do: true
+  def park_track_change?(%{route_id: "Green-C", stop_id: "70199"}), do: true
+  def park_track_change?(%{route_id: "Green-D", stop_id: "70196"}), do: true
+  def park_track_change?(%{route_id: "Green-E", stop_id: "70197"}), do: true
   def park_track_change?(_prediction), do: false
 
   defimpl Content.Audio do
     def to_params(%{route_id: route_id, berth: berth, destination: destination}) do
+      branch = Content.Utilities.route_branch_letter(route_id)
+
+      platform =
+        case berth do
+          "70196" -> :b
+          "70197" -> :c
+          "70198" -> :d
+          "70199" -> :e
+        end
+
       PaEss.Utilities.audio_message(
-        [:track_change, {:boarding, route_id, berth, destination}],
+        [
+          :track_change,
+          :the_next,
+          branch,
+          :train_to,
+          destination,
+          :is_now_boarding,
+          :on_the,
+          platform,
+          :platform
+        ],
         :audio_visual
       )
     end

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -36,15 +36,10 @@ defmodule Content.Audio.TrackChange do
       PaEss.Utilities.audio_message(
         [
           :track_change,
-          :the_next,
-          branch,
-          :train_to,
-          destination,
-          :is_now_boarding,
-          :on_the,
-          platform,
-          :platform
-        ],
+          :the_next
+        ] ++
+          PaEss.Utilities.train_description_tokens(destination, route_id) ++
+          [:is_now_boarding, :on_the, platform, :platform],
         :audio_visual
       )
     end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -824,16 +824,6 @@ defmodule PaEss.Utilities do
   def audio_take({:route, "245"}), do: "628"
   def audio_take({:route, "716"}), do: "888"
 
-  def audio_take({:boarding, "Green-B", "70197", :boston_college}), do: "813"
-  def audio_take({:boarding, "Green-B", "70197", :kenmore}), do: "820"
-  def audio_take({:boarding, "Green-C", "70196", :cleveland_circle}), do: "814"
-  def audio_take({:boarding, "Green-C", "70196", :kenmore}), do: "823"
-  def audio_take({:boarding, "Green-D", "70199", :reservoir}), do: "815"
-  def audio_take({:boarding, "Green-D", "70199", :riverside}), do: "818"
-  def audio_take({:boarding, "Green-D", "70199", :kenmore}), do: "822"
-  def audio_take({:boarding, "Green-E", "70198", :heath_street}), do: "816"
-  def audio_take({:boarding, "Green-E", "70198", :kenmore}), do: "821"
-
   def audio_take({:crowding, {:front, _status}}), do: "870"
   def audio_take({:crowding, {:back, _status}}), do: "871"
   def audio_take({:crowding, {:middle, _status}}), do: "872"

--- a/test/content/audio/track_change_test.exs
+++ b/test/content/audio/track_change_test.exs
@@ -1,175 +1,284 @@
 defmodule Content.Audio.TrackChangeTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   describe "to_params/1" do
-    test "correctly changes berths from b to c" do
+    test "correctly changes berths from b to d" do
       audio = %Content.Audio.TrackChange{
         destination: :boston_college,
         route_id: "Green-B",
-        berth: "70197"
+        berth: "70198"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"105",
+                {"119",
                  [
                    "540",
                    "21000",
-                   "813"
+                   "501",
+                   "21000",
+                   "536",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4202",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "538",
+                   "21000",
+                   "529"
                  ], :audio_visual}}
     end
 
-    test "correctly changes berths from c to b" do
+    test "correctly changes berths from c to e" do
       audio = %Content.Audio.TrackChange{
         destination: :cleveland_circle,
         route_id: "Green-C",
+        berth: "70199"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"119",
+                 [
+                   "540",
+                   "21000",
+                   "501",
+                   "21000",
+                   "537",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4203",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "539",
+                   "21000",
+                   "529"
+                 ], :audio_visual}}
+    end
+
+    test "correctly changes berths from d to b (reservoir)" do
+      audio = %Content.Audio.TrackChange{
+        destination: :reservoir,
+        route_id: "Green-D",
         berth: "70196"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"105",
+                {"119",
                  [
                    "540",
                    "21000",
-                   "814"
-                 ], :audio_visual}}
-    end
-
-    test "correctly changes berths from d to e (reservoir)" do
-      audio = %Content.Audio.TrackChange{
-        destination: :reservoir,
-        route_id: "Green-D",
-        berth: "70199"
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:canned,
-                {"105",
-                 [
-                   "540",
+                   "501",
                    "21000",
-                   "815"
+                   "538",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4076",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "536",
+                   "21000",
+                   "529"
                  ], :audio_visual}}
     end
 
-    test "correctly changes berths from d to e (riverside)" do
+    test "correctly changes berths from d to b (riverside)" do
       audio = %Content.Audio.TrackChange{
         destination: :riverside,
         route_id: "Green-D",
-        berth: "70199"
+        berth: "70196"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"105",
+                {"119",
                  [
                    "540",
                    "21000",
-                   "818"
+                   "501",
+                   "21000",
+                   "538",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4084",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "536",
+                   "21000",
+                   "529"
                  ], :audio_visual}}
     end
 
-    test "correctly changes berths from e to d" do
+    test "correctly changes berths from e to c" do
       audio = %Content.Audio.TrackChange{
         destination: :heath_street,
         route_id: "Green-E",
-        berth: "70198"
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:canned,
-                {"105",
-                 [
-                   "540",
-                   "21000",
-                   "816"
-                 ], :audio_visual}}
-    end
-
-    test "correctly announces Kenmore B track changes to the C platform" do
-      audio = %Content.Audio.TrackChange{
-        destination: :kenmore,
-        route_id: "Green-B",
         berth: "70197"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"105",
+                {"119",
                  [
                    "540",
                    "21000",
-                   "820"
-                 ], :audio_visual}}
-    end
-
-    test "correctly announces Kenmore C track changes to the B platform" do
-      audio = %Content.Audio.TrackChange{
-        destination: :kenmore,
-        route_id: "Green-C",
-        berth: "70196"
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:canned,
-                {"105",
-                 [
-                   "540",
+                   "501",
                    "21000",
-                   "823"
-                 ], :audio_visual}}
-    end
-
-    test "correctly announces Kenmore D track changes to the E platform" do
-      audio = %Content.Audio.TrackChange{
-        destination: :kenmore,
-        route_id: "Green-D",
-        berth: "70199"
-      }
-
-      assert Content.Audio.to_params(audio) ==
-               {:canned,
-                {"105",
-                 [
-                   "540",
+                   "539",
                    "21000",
-                   "822"
+                   "507",
+                   "21000",
+                   "4204",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "537",
+                   "21000",
+                   "529"
                  ], :audio_visual}}
     end
 
-    test "correctly announces Kenmore E track changes to the D platform" do
+    test "correctly announces Kenmore B track changes to the D platform" do
       audio = %Content.Audio.TrackChange{
         destination: :kenmore,
-        route_id: "Green-E",
+        route_id: "Green-B",
         berth: "70198"
       }
 
       assert Content.Audio.to_params(audio) ==
                {:canned,
-                {"105",
+                {"119",
                  [
                    "540",
                    "21000",
-                   "821"
+                   "501",
+                   "21000",
+                   "536",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4070",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "538",
+                   "21000",
+                   "529"
                  ], :audio_visual}}
     end
 
-    test "Handles unknown destination gracefully" do
+    test "correctly announces Kenmore C track changes to the E platform" do
       audio = %Content.Audio.TrackChange{
-        destination: :unknown,
-        route_id: "Green-E",
-        berth: "00000"
+        destination: :kenmore,
+        route_id: "Green-C",
+        berth: "70199"
       }
 
-      log =
-        capture_log([level: :error], fn ->
-          assert Content.Audio.to_params(audio) ==
-                   {:canned, {"105", ["540", "21000", "21000"], :audio_visual}}
-        end)
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"119",
+                 [
+                   "540",
+                   "21000",
+                   "501",
+                   "21000",
+                   "537",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4070",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "539",
+                   "21000",
+                   "529"
+                 ], :audio_visual}}
+    end
 
-      assert log =~ "No audio for"
+    test "correctly announces Kenmore D track changes to the B platform" do
+      audio = %Content.Audio.TrackChange{
+        destination: :kenmore,
+        route_id: "Green-D",
+        berth: "70196"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"119",
+                 [
+                   "540",
+                   "21000",
+                   "501",
+                   "21000",
+                   "538",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4070",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "536",
+                   "21000",
+                   "529"
+                 ], :audio_visual}}
+    end
+
+    test "correctly announces Kenmore E track changes to the C platform" do
+      audio = %Content.Audio.TrackChange{
+        destination: :kenmore,
+        route_id: "Green-E",
+        berth: "70197"
+      }
+
+      assert Content.Audio.to_params(audio) ==
+               {:canned,
+                {"119",
+                 [
+                   "540",
+                   "21000",
+                   "501",
+                   "21000",
+                   "539",
+                   "21000",
+                   "507",
+                   "21000",
+                   "4070",
+                   "21000",
+                   "544",
+                   "21000",
+                   "851",
+                   "21000",
+                   "537",
+                   "21000",
+                   "529"
+                 ], :audio_visual}}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [RTS: Review/update Park St track change info](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210238696309072?focus=true)

Update track change logic so that:
1. B and D are considered opposite platforms
2. C and E are considered opposite platforms
3. Track change audio uses the "piecemeal" approach

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
