### PR TITLE
add Chelsea outbound zone

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -8774,6 +8774,20 @@
     "max_minutes": 60
   },
   {
+    "id": "Silver_Line.Chelsea_OB",
+    "pa_ess_loc": "SCHS",
+    "scu_id": "SCHSSCU001",
+    "read_loop_interval": 360,
+    "read_loop_offset": 120,
+    "text_zone": "e",
+    "audio_zones": [
+      "e"
+    ],
+    "type": "bus",
+    "configs": [],
+    "max_minutes": 60
+  },
+  {
     "id": "bus.Nubian_Platform_A",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",


### PR DESCRIPTION
#### Summary of changes

This is a followup to the Chelsea SCU migration. Chelsea has a sign on the outbound platform, and although we don't want to show predictions there, we do want to show the time. This adds a sign process mapped to that zone, with empty configs. Because there is no corresponding mode flag in Signs UI, this sign will default to "off" and display an empty message (including the time).