### PR TITLE
feat: pass-through announcements for light rail

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -44,12 +44,7 @@ defmodule Content.Audio.Approaching do
   defimpl Content.Audio do
     def to_params(%Content.Audio.Approaching{} = audio) do
       prefix = if audio.four_cars?, do: [:shorter_4_car], else: [:attention_passengers_the_next]
-
-      train =
-        if branch = Content.Utilities.route_branch_letter(audio.route_id),
-          do: [branch_token(branch), :train_to_, destination_token(audio.destination)],
-          else: [destination_token(audio.destination), :train_]
-
+      train = PaEss.Utilities.train_description_tokens(audio.destination, audio.route_id, true)
       approaching = if audio.four_cars?, do: [:now_approaching], else: [:is_now_approaching]
       platform = if audio.platform, do: [platform_token(audio.platform)], else: []
 
@@ -63,8 +58,7 @@ defmodule Content.Audio.Approaching do
       crowding =
         if audio.crowding_description, do: [{:crowding, audio.crowding_description}], else: []
 
-      (prefix ++
-         train ++ approaching ++ platform ++ new_cars ++ [:.] ++ followup ++ crowding)
+      (prefix ++ train ++ approaching ++ platform ++ new_cars ++ [:.] ++ followup ++ crowding)
       |> Utilities.audio_message(:audio_visual)
     end
 
@@ -105,34 +99,8 @@ defmodule Content.Audio.Approaching do
       "Attention passengers: The next #{train} is now approaching#{platform}#{new_cars}.#{followup}#{crowding}"
     end
 
-    defp destination_token(:alewife), do: :alewife_
-    defp destination_token(:ashmont), do: :ashmont_
-    defp destination_token(:braintree), do: :braintree_
-    defp destination_token(:mattapan), do: :mattapan_
-    defp destination_token(:bowdoin), do: :bowdoin_
-    defp destination_token(:wonderland), do: :wonderland_
-    defp destination_token(:oak_grove), do: :oak_grove_
-    defp destination_token(:forest_hills), do: :forest_hills_
-    defp destination_token(:lechmere), do: :lechmere_
-    defp destination_token(:north_station), do: :north_station_
-    defp destination_token(:government_center), do: :government_center_
-    defp destination_token(:park_street), do: :park_street_
-    defp destination_token(:kenmore), do: :kenmore_
-    defp destination_token(:boston_college), do: :boston_college_
-    defp destination_token(:cleveland_circle), do: :cleveland_circle_
-    defp destination_token(:reservoir), do: :reservoir_
-    defp destination_token(:riverside), do: :riverside_
-    defp destination_token(:heath_street), do: :heath_street_
-    # Fall back to original takes
-    defp destination_token(destination), do: destination
-
     defp platform_token(:ashmont), do: :on_the_ashmont_platform
     defp platform_token(:braintree), do: :on_the_braintree_platform
-
-    defp branch_token(:b), do: :b_
-    defp branch_token(:c), do: :c_
-    defp branch_token(:d), do: :d_
-    defp branch_token(:e), do: :e_
 
     defp platform_string(:ashmont), do: " on the Ashmont platform"
     defp platform_string(:braintree), do: " on the Braintree platform"

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -15,14 +15,11 @@ defmodule Content.Audio.Passthrough do
         }
 
   defimpl Content.Audio do
-    def to_params(%Content.Audio.Passthrough{route_id: route_id} = audio)
-        when route_id in ["Mattapan", "Green-B", "Green-C", "Green-D", "Green-E"] do
-      handle_unknown_destination(audio)
-    end
+    def to_params(%Content.Audio.Passthrough{} = audio) do
+      train = PaEss.Utilities.train_description_tokens(audio.destination, audio.route_id, true)
 
-    def to_params(audio) do
       PaEss.Utilities.audio_message(
-        [{:passthrough, audio.destination, audio.route_id}],
+        [:the_next] ++ train ++ [:does_not_take_customers, :., :stand_back_message],
         :audio_visual
       )
     end
@@ -39,15 +36,6 @@ defmodule Content.Audio.Passthrough do
     defp tts_text(%Content.Audio.Passthrough{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
       "The next #{train} does not take customers. Please stand back from the platform edge."
-    end
-
-    @spec handle_unknown_destination(Content.Audio.Passthrough.t()) :: nil
-    defp handle_unknown_destination(audio) do
-      Logger.info(
-        "unknown_passthrough_audio: destination=#{audio.destination} route_id=#{audio.route_id}"
-      )
-
-      nil
     end
   end
 end

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -302,10 +302,41 @@ defmodule PaEss.Utilities do
     end
   end
 
-  def train_description_tokens(destination, route_id) do
+  @spec train_description_tokens(PaEss.destination(), String.t()) :: [atom()]
+  @spec train_description_tokens(PaEss.destination(), String.t(), boolean()) :: [atom()]
+  def train_description_tokens(destination, route_id, use_polly_takes? \\ false) do
     branch = Content.Utilities.route_branch_letter(route_id)
-    if branch, do: [branch, :train_to, destination], else: [destination, :train]
+    tokens = if branch, do: [branch, :train_to, destination], else: [destination, :train]
+    if use_polly_takes?, do: Enum.map(tokens, &to_polly_take/1), else: tokens
   end
+
+  defp to_polly_take(:alewife), do: :alewife_
+  defp to_polly_take(:ashmont), do: :ashmont_
+  defp to_polly_take(:braintree), do: :braintree_
+  defp to_polly_take(:mattapan), do: :mattapan_
+  defp to_polly_take(:bowdoin), do: :bowdoin_
+  defp to_polly_take(:wonderland), do: :wonderland_
+  defp to_polly_take(:oak_grove), do: :oak_grove_
+  defp to_polly_take(:forest_hills), do: :forest_hills_
+  defp to_polly_take(:lechmere), do: :lechmere_
+  defp to_polly_take(:north_station), do: :north_station_
+  defp to_polly_take(:government_center), do: :government_center_
+  defp to_polly_take(:park_street), do: :park_street_
+  defp to_polly_take(:kenmore), do: :kenmore_
+  defp to_polly_take(:boston_college), do: :boston_college_
+  defp to_polly_take(:cleveland_circle), do: :cleveland_circle_
+  defp to_polly_take(:reservoir), do: :reservoir_
+  defp to_polly_take(:riverside), do: :riverside_
+  defp to_polly_take(:heath_street), do: :heath_street_
+  defp to_polly_take(:b), do: :b_
+  defp to_polly_take(:c), do: :c_
+  defp to_polly_take(:d), do: :d_
+  defp to_polly_take(:e), do: :e_
+  defp to_polly_take(:train), do: :train_
+  defp to_polly_take(:train_to), do: :train_to_
+  defp to_polly_take(:there_is_no), do: :there_is_no_
+  # Use token as-is when there is no Polly take or the Polly take is the only one
+  defp to_polly_take(token), do: token
 
   def crowding_text(crowding_description) do
     case crowding_description do
@@ -710,6 +741,7 @@ defmodule PaEss.Utilities do
   def audio_take(:upcoming_departures), do: "548"
   def audio_take(:upcoming_arrivals), do: "550"
   def audio_take(:is_now_arriving), do: "24055"
+  def audio_take(:does_not_take_customers), do: "929"
   def audio_take(:upper_level_departures), do: "616"
   def audio_take(:lower_level_departures), do: "617"
   def audio_take(:board_routes_71_and_73_on_upper_level), do: "618"
@@ -852,13 +884,6 @@ defmodule PaEss.Utilities do
   def audio_take({:line, "Green"}), do: "3008"
   def audio_take({:line, "Mattapan"}), do: "3009"
   def audio_take({:line, _name}), do: audio_take(:train)
-
-  def audio_take({:passthrough, :alewife, _route}), do: "1006"
-  def audio_take({:passthrough, :southbound, "Red"}), do: "1010"
-  def audio_take({:passthrough, :bowdoin, _route}), do: "1007"
-  def audio_take({:passthrough, :wonderland, _route}), do: "1011"
-  def audio_take({:passthrough, :forest_hills, _route}), do: "1008"
-  def audio_take({:passthrough, :oak_grove, _route}), do: "1009"
 
   def audio_take(item) do
     Logger.error("No audio for: #{inspect(item)}")

--- a/test/content/audio/passthrough_test.exs
+++ b/test/content/audio/passthrough_test.exs
@@ -1,24 +1,25 @@
 defmodule Content.Audio.PassthroughTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   alias Content.Audio.Passthrough
 
   describe "to_params/1" do
     test "Returns params" do
-      audio = %Passthrough{destination: :alewife, route_id: "Red"}
-      assert Content.Audio.to_params(audio) == {:canned, {"103", ["1006"], :audio_visual}}
-    end
-
-    test "Returns nil for Green Line trips" do
-      audio = %Passthrough{destination: :riverside, route_id: "Green-D"}
-      log = capture_log([level: :info], fn -> assert Content.Audio.to_params(audio) == nil end)
-      assert log =~ "unknown_passthrough_audio"
-    end
-
-    test "Returns nil when destination is Ashmont on the Mattapan line" do
-      audio = %Passthrough{destination: :ashmont, route_id: "Mattapan"}
-      assert Content.Audio.to_params(audio) == nil
+      assert Content.Audio.to_params(%Passthrough{destination: :alewife, route_id: "Red"}) ==
+               {:canned,
+                {"112",
+                 [
+                   "501",
+                   "21000",
+                   "892",
+                   "21000",
+                   "920",
+                   "21000",
+                   "929",
+                   "21014",
+                   "21000",
+                   "925"
+                 ], :audio_visual}}
     end
   end
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -192,19 +192,25 @@ defmodule Signs.RealtimeTest do
     test "announces train passing through station" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [
-          prediction(destination: :braintree, seconds_until_passthrough: 30, trip_id: "123"),
-          prediction(destination: :braintree, seconds_until_passthrough: 30, trip_id: "124")
+          prediction(destination: :riverside, seconds_until_passthrough: 30, trip_id: "123"),
+          prediction(destination: :riverside, seconds_until_passthrough: 30, trip_id: "124")
         ]
       end)
 
-      expect_audios([{:canned, {"103", ["1010"], :audio_visual}}], [
-        {"The next Southbound train does not take customers. Please stand back from the platform edge.",
-         [
-           {"The next Southbound", "train does not take", 3},
-           {"customers. Please stand", "back from the platform", 3},
-           {"edge.", "", 3}
-         ]}
-      ])
+      expect_audios(
+        [
+          {:canned,
+           {"114", spaced(["501", "905", "919", "918", "929", "21014", "925"]), :audio_visual}}
+        ],
+        [
+          {"The next D train to Riverside does not take customers. Please stand back from the platform edge.",
+           [
+             {"The next D train to", "Riverside does not take", 3},
+             {"customers. Please stand", "back from the platform", 3},
+             {"edge.", "", 3}
+           ]}
+        ]
+      )
 
       assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, @sign)
       assert sign.announced_passthroughs == ["123"]
@@ -219,22 +225,32 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :alewife, seconds_until_passthrough: 30, trip_id: "124")]
       end)
 
-      expect_audios([{:canned, {"103", ["1010"], :audio_visual}}], [
-        {"The next Southbound train does not take customers. Please stand back from the platform edge.",
-         [
-           {"The next Southbound", "train does not take", 3},
-           {"customers. Please stand", "back from the platform", 3},
-           {"edge.", "", 3}
-         ]}
-      ])
+      expect_audios(
+        [
+          {:canned, {"112", spaced(["501", "787", "920", "929", "21014", "925"]), :audio_visual}}
+        ],
+        [
+          {"The next Southbound train does not take customers. Please stand back from the platform edge.",
+           [
+             {"The next Southbound", "train does not take", 3},
+             {"customers. Please stand", "back from the platform", 3},
+             {"edge.", "", 3}
+           ]}
+        ]
+      )
 
-      expect_audios([{:canned, {"103", ["1006"], :audio_visual}}], [
-        {"The next Alewife train does not take customers. Please stand back from the platform edge.",
-         [
-           {"The next Alewife train", "does not take customers.", 3},
-           {"Please stand back from", "the platform edge.", 3}
-         ]}
-      ])
+      expect_audios(
+        [
+          {:canned, {"112", spaced(["501", "892", "920", "929", "21014", "925"]), :audio_visual}}
+        ],
+        [
+          {"The next Alewife train does not take customers. Please stand back from the platform edge.",
+           [
+             {"The next Alewife train", "does not take customers.", 3},
+             {"Please stand back from", "the platform edge.", 3}
+           ]}
+        ]
+      )
 
       Signs.Realtime.handle_info(:run_loop, @mezzanine_sign)
     end
@@ -244,14 +260,19 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :southbound, seconds_until_passthrough: 30)]
       end)
 
-      expect_audios([{:canned, {"103", ["1010"], :audio_visual}}], [
-        {"The next Southbound train does not take customers. Please stand back from the platform edge.",
-         [
-           {"The next Southbound", "train does not take", 3},
-           {"customers. Please stand", "back from the platform", 3},
-           {"edge.", "", 3}
-         ]}
-      ])
+      expect_audios(
+        [
+          {:canned, {"112", spaced(["501", "787", "920", "929", "21014", "925"]), :audio_visual}}
+        ],
+        [
+          {"The next Southbound train does not take customers. Please stand back from the platform edge.",
+           [
+             {"The next Southbound", "train does not take", 3},
+             {"customers. Please stand", "back from the platform", 3},
+             {"edge.", "", 3}
+           ]}
+        ]
+      )
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end


### PR DESCRIPTION
**Asana Ticket:** https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210392853396718

Pass-through announcements ("the next train does not take customers") are now assembled from mostly-existing pieces rather than being full canned messages. As a result, trains with any otherwise announce-able destination, including those on the Green and Mattapan Lines, can now be announced as pass-through.

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] ~~If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project~~
- [x] This branch was deployed to dev-green and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [dev-green](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev-green%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
