### PR TITLE
Revert "Added logic for overnight period stopping certain messages (#…

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -85,13 +85,6 @@ defmodule Engine.ScheduledHeadways do
     |> min_time()
   end
 
-  @callback get_last_scheduled_departure([binary]) :: nil | DateTime.t()
-  def get_last_scheduled_departure(stop_ids) do
-    get_first_last_departures(stop_ids)
-    |> Enum.map(&elem(&1, 1))
-    |> max_time()
-  end
-
   @doc "Checks if the given time is after the first scheduled stop and before the last.
   A buffer of minutes (positive) is subtracted from the first time. so that headways are
   shown for a short time before the first train."
@@ -135,16 +128,6 @@ defmodule Engine.ScheduledHeadways do
     datetimes
     |> Enum.filter(& &1)
     |> Enum.min_by(&DateTime.to_unix/1, fn -> nil end)
-  end
-
-  @spec max_time([DateTime.t() | nil]) :: DateTime.t() | nil
-  defp max_time([]), do: nil
-  defp max_time([%DateTime{} = dt]), do: dt
-
-  defp max_time(datetimes) do
-    datetimes
-    |> Enum.filter(& &1)
-    |> Enum.max_by(&DateTime.to_unix/1, fn -> nil end)
   end
 
   @impl true

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -131,25 +131,10 @@ defmodule Signs.Realtime do
         )
       end)
 
-    last_scheduled_departures =
-      map_source_config(sign.source_config, fn config ->
-        RealtimeSigns.headway_engine().get_last_scheduled_departure(
-          SourceConfig.sign_stop_ids(config)
-        )
-      end)
-
     prev_predictions_lookup =
       for prediction <- sign.prev_predictions, into: %{} do
         {prediction_key(prediction), prediction}
       end
-
-    recent_departures =
-      map_source_config(sign.source_config, fn config ->
-        SourceConfig.sign_stop_ids(config)
-        |> Stream.flat_map(&RealtimeSigns.last_trip_engine().get_recent_departures(&1))
-        |> Enum.max_by(fn {_, dt} -> dt end, fn -> {nil, nil} end)
-        |> elem(1)
-      end)
 
     {predictions, all_predictions} =
       case sign.source_config do
@@ -177,8 +162,6 @@ defmodule Signs.Realtime do
         current_time,
         alert_status,
         first_scheduled_departures,
-        last_scheduled_departures,
-        recent_departures,
         service_end_statuses_per_source
       )
 

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -6,7 +6,6 @@ defmodule Signs.Utilities.Messages do
 
   @early_am_start ~T[03:29:00]
   @early_am_buffer -40
-  @overnight_buffer -30
 
   @spec get_messages(
           Signs.Realtime.predictions(),
@@ -16,8 +15,6 @@ defmodule Signs.Utilities.Messages do
           Engine.Alerts.Fetcher.stop_status()
           | {Engine.Alerts.Fetcher.stop_status(), Engine.Alerts.Fetcher.stop_status()},
           DateTime.t() | {DateTime.t(), DateTime.t()},
-          DateTime.t() | {DateTime.t(), DateTime.t()},
-          DateTime.t() | {DateTime.t(), DateTime.t()},
           boolean() | {boolean(), boolean()}
         ) :: [Message.t()]
   def get_messages(
@@ -26,25 +23,13 @@ defmodule Signs.Utilities.Messages do
         sign_config,
         current_time,
         alert_status,
-        first_scheduled_departures,
-        last_scheduled_departures,
-        most_recent_departure,
+        scheduled,
         service_status
       ) do
     cond do
       match?({:static_text, {_, _}}, sign_config) ->
-        if overnight_period?(
-             current_time,
-             first_scheduled_departures,
-             last_scheduled_departures,
-             most_recent_departure,
-             service_status
-           ) do
-          [%Message.Empty{}]
-        else
-          {:static_text, {line1, line2}} = sign_config
-          [%Message.Custom{top: line1, bottom: line2}]
-        end
+        {:static_text, {line1, line2}} = sign_config
+        [%Message.Custom{top: line1, bottom: line2}]
 
       sign_config == :off ->
         [%Message.Empty{}]
@@ -55,49 +40,24 @@ defmodule Signs.Utilities.Messages do
             Tuple.to_list(sign.source_config),
             Tuple.to_list(predictions),
             Tuple.to_list(alert_status),
-            Tuple.to_list(first_scheduled_departures),
-            Tuple.to_list(last_scheduled_departures),
-            Tuple.to_list(most_recent_departure),
+            Tuple.to_list(scheduled),
             Tuple.to_list(service_status)
           ])
         else
-          [
-            {sign.source_config, predictions, alert_status, first_scheduled_departures,
-             last_scheduled_departures, most_recent_departure, service_status}
-          ]
+          [{sign.source_config, predictions, alert_status, scheduled, service_status}]
         end
-        |> Enum.map(fn {config, predictions, alert_status, first_scheduled_departures,
-                        last_scheduled_departures, most_recent_departure, service_status} ->
+        |> Enum.map(fn {config, predictions, alert_status, scheduled, service_status} ->
           predictions =
-            filter_predictions(
-              predictions,
-              config,
-              sign_config,
-              current_time,
-              first_scheduled_departures
-            )
+            filter_predictions(predictions, config, sign_config, current_time, scheduled)
 
           alert_status = filter_alert_status(alert_status, sign_config)
 
-          if overnight_period?(
-               current_time,
-               first_scheduled_departures,
-               last_scheduled_departures,
-               most_recent_departure,
-               service_status
-             ) do
-            prediction_message(predictions, config, sign) ||
-              Signs.Utilities.Headways.headway_message(config, current_time) ||
-              early_am_message(current_time, first_scheduled_departures, config) ||
-              %Message.Empty{}
-          else
-            prediction_message(predictions, config, sign) ||
-              service_ended_message(service_status, config) ||
-              alert_message(alert_status, sign, config) ||
-              Signs.Utilities.Headways.headway_message(config, current_time) ||
-              early_am_message(current_time, first_scheduled_departures, config) ||
-              %Message.Empty{}
-          end
+          prediction_message(predictions, config, sign) ||
+            service_ended_message(service_status, config) ||
+            alert_message(alert_status, sign, config) ||
+            Signs.Utilities.Headways.headway_message(config, current_time) ||
+            early_am_message(current_time, scheduled, config) ||
+            %Message.Empty{}
         end)
     end
     |> transform_messages()
@@ -296,27 +256,6 @@ defmodule Signs.Utilities.Messages do
     if in_early_am?(current_time, scheduled_time) do
       %Message.FirstTrain{destination: config.headway_destination, scheduled: scheduled_time}
     end
-  end
-
-  defp overnight_period?(
-         current_time,
-         first_scheduled_departure,
-         last_scheduled_departure,
-         most_recent_departure,
-         service_ended
-       ) do
-    last_actual_departure = if service_ended, do: most_recent_departure
-
-    last_time_to_check =
-      if last_actual_departure &&
-           Timex.after?(last_actual_departure, last_scheduled_departure) do
-        last_actual_departure
-      else
-        last_scheduled_departure
-      end
-
-    Timex.after?(current_time, Timex.shift(last_time_to_check, minutes: @overnight_buffer)) &&
-      before_early_am_threshold?(current_time, first_scheduled_departure)
   end
 
   defp alert_message(alert_status, sign, config) do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -162,10 +162,6 @@ defmodule Signs.RealtimeTest do
         datetime(~T[05:00:00])
       end)
 
-      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
-        datetime(~D[2023-01-02], ~T[02:00:00])
-      end)
-
       :ok
     end
 
@@ -1918,10 +1914,6 @@ defmodule Signs.RealtimeTest do
         datetime(~T[05:00:00])
       end)
 
-      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
-        datetime(~D[2023-01-02], ~T[02:00:00])
-      end)
-
       :ok
     end
 
@@ -1958,10 +1950,6 @@ defmodule Signs.RealtimeTest do
 
       stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
         datetime(~T[05:00:00])
-      end)
-
-      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
-        datetime(~T[02:00:00])
       end)
 
       :ok
@@ -2030,14 +2018,6 @@ defmodule Signs.RealtimeTest do
         %{"b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => ~U[2023-01-01 00:00:00.000Z]}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "2" ->
-        %{"b" => ~U[2023-01-01 00:00:00.000Z]}
-      end)
-
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> false end)
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "b" -> true end)
 
@@ -2082,14 +2062,6 @@ defmodule Signs.RealtimeTest do
         %{"b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => ~U[2023-01-01 00:00:00.000Z]}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "70086" ->
-        %{"b" => ~U[2023-01-01 00:00:00.000Z]}
-      end)
-
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> true end)
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "b" -> false end)
 
@@ -2124,7 +2096,7 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Red line trunk service ends after two last trips" do
-      expect(Engine.LastTrip.Mock, :get_recent_departures, 2, fn _ ->
+      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
         %{"a" => ~U[2023-01-01 00:00:00.000Z], "b" => ~U[2023-01-01 00:00:00.000Z]}
       end)
 
@@ -2149,7 +2121,7 @@ defmodule Signs.RealtimeTest do
       stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
 
       stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
-        DateTime.new!(~D[2022-12-31], ~T[05:00:00], "Etc/UTC")
+        datetime(~T[05:00:00])
       end)
 
       :ok
@@ -2192,70 +2164,6 @@ defmodule Signs.RealtimeTest do
 
       assert {:reply, {_, false}, _} =
                Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
-    end
-  end
-
-  describe "Overnight Period" do
-    setup do
-      stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
-      stub(Engine.Config.Mock, :headway_config, fn _, _ -> @headway_config end)
-      stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
-      stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
-      stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> true end)
-      stub(Engine.Locations.Mock, :for_vehicle, fn _ -> nil end)
-      stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> false end)
-      stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
-
-      stub(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
-        datetime(~D[2023-01-02], ~T[05:00:00])
-      end)
-
-      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ ->
-        datetime(~D[2023-01-02], ~T[02:00:00])
-      end)
-
-      :ok
-    end
-
-    test "does not play alerts when in the overnight period" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
-      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
-
-      expect_messages({"Southbound trains", "Every 11 to 13 min"})
-      expect(PaEss.Updater.Mock, :play_message, 0, fn _, _, _, _, _ -> :ok end)
-
-      Signs.Realtime.handle_info(:run_loop, %{
-        @sign
-        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
-      })
-    end
-
-    test "still shows predictions if they exist during overnight period" do
-      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(arrival: 180, destination: :ashmont)]
-      end)
-
-      expect_messages({"Ashmont      3 min", ""})
-
-      Signs.Realtime.handle_info(:run_loop, %{
-        @sign
-        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
-      })
-    end
-
-    test "does not show custom text during overnight period" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"custom", "message"}}
-      end)
-
-      expect_messages({"", ""})
-      expect(PaEss.Updater.Mock, :play_message, 0, fn _, _, _, _, _ -> :ok end)
-
-      Signs.Realtime.handle_info(:run_loop, %{
-        @sign
-        | current_time_fn: fn -> datetime(~D[2023-01-02], ~T[03:00:00]) end
-      })
     end
   end
 
@@ -2367,7 +2275,6 @@ defmodule Signs.RealtimeTest do
   end
 
   defp datetime(time), do: DateTime.new!(~D[2023-01-01], time, "America/New_York")
-  defp datetime(date, time), do: DateTime.new!(date, time, "America/New_York")
 
   defp spaced(list), do: PaEss.Utilities.pad_takes(list)
 


### PR DESCRIPTION
…919)"

This reverts commit 43a2b71636bf92980415667a84f41568f282104a.

There's an issue where setting custom mode on a mezzanine sign causes the sign process to crash, and a separate issue where all sign processes can crash once on startup if schedules are slow to load. Backing this out for now until we can implement fixes.
