### PR TITLE
feat: shorten busway audio readout intervals

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -8247,7 +8247,7 @@
     "id": "Silver_Line.South_Station_EB",
     "pa_ess_loc": "SSOU",
     "scu_id": "RSOUSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 0,
     "text_zone": "e",
     "audio_zones": [
@@ -8300,8 +8300,8 @@
     "id": "Silver_Line.Courthouse_WB",
     "pa_ess_loc": "SCOU",
     "scu_id": "SCOUSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "w",
     "audio_zones": [
       "w"
@@ -8340,8 +8340,8 @@
     "id": "Silver_Line.Courthouse_EB",
     "pa_ess_loc": "SCOU",
     "scu_id": "SCOUSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 80,
     "text_zone": "e",
     "audio_zones": [
       "e"
@@ -8392,8 +8392,8 @@
     "id": "Silver_Line.Courthouse_mezz",
     "pa_ess_loc": "SCOU",
     "scu_id": "SCOUSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 160,
     "text_zone": "m",
     "audio_zones": [
       "m"
@@ -8432,7 +8432,7 @@
     "id": "Silver_Line.World_Trade_Ctr_WB",
     "pa_ess_loc": "SWTC",
     "scu_id": "SWTCSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 120,
     "text_zone": "w",
     "audio_zones": [
@@ -8472,8 +8472,8 @@
     "id": "Silver_Line.World_Trade_Ctr_EB",
     "pa_ess_loc": "SWTC",
     "scu_id": "SWTCSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 120,
+    "read_loop_interval": 240,
+    "read_loop_offset": 200,
     "text_zone": "e",
     "audio_zones": [
       "e"
@@ -8524,8 +8524,8 @@
     "id": "Silver_Line.World_Trade_Ctr_mezz",
     "pa_ess_loc": "SWTC",
     "scu_id": "SWTCSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 120,
+    "read_loop_interval": 240,
+    "read_loop_offset": 40,
     "text_zone": "m",
     "audio_zones": [
       "m"
@@ -8602,7 +8602,7 @@
     "id": "Silver_Line.Eastern_Ave_OB",
     "pa_ess_loc": "SEAV",
     "scu_id": "SEAVSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 60,
     "text_zone": "e",
     "audio_zones": [
@@ -8627,8 +8627,8 @@
     "id": "Silver_Line.Eastern_Ave_IB",
     "pa_ess_loc": "SEAV",
     "scu_id": "SEAVSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 180,
     "text_zone": "w",
     "audio_zones": [
       "w"
@@ -8652,7 +8652,7 @@
     "id": "Silver_Line.Box_District_OB",
     "pa_ess_loc": "SBOX",
     "scu_id": "SBOXSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 120,
     "text_zone": "e",
     "audio_zones": [
@@ -8677,8 +8677,8 @@
     "id": "Silver_Line.Box_District_IB",
     "pa_ess_loc": "SBOX",
     "scu_id": "SBOXSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 120,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "w",
     "audio_zones": [
       "w"
@@ -8702,7 +8702,7 @@
     "id": "Silver_Line.Bellingham_Square_OB",
     "pa_ess_loc": "SBSQ",
     "scu_id": "SBSQSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 180,
     "text_zone": "e",
     "audio_zones": [
@@ -8727,8 +8727,8 @@
     "id": "Silver_Line.Bellingham_Square_IB",
     "pa_ess_loc": "SBSQ",
     "scu_id": "SBSQSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 180,
+    "read_loop_interval": 240,
+    "read_loop_offset": 60,
     "text_zone": "w",
     "audio_zones": [
       "w"
@@ -8752,8 +8752,8 @@
     "id": "Silver_Line.Chelsea_IB",
     "pa_ess_loc": "SCHS",
     "scu_id": "SCHSSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 240,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "w",
     "audio_zones": [
       "w"
@@ -8777,7 +8777,7 @@
     "id": "Silver_Line.Chelsea_OB",
     "pa_ess_loc": "SCHS",
     "scu_id": "SCHSSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 120,
     "text_zone": "e",
     "audio_zones": [
@@ -8791,8 +8791,8 @@
     "id": "bus.Nubian_Platform_A",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 180,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "w",
     "audio_zones": [
       "c"
@@ -8835,8 +8835,8 @@
     "id": "bus.Nubian_Platform_C",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 240,
+    "read_loop_interval": 240,
+    "read_loop_offset": 90,
     "text_zone": "s",
     "audio_zones": [
       "c"
@@ -8886,8 +8886,8 @@
     "id": "bus.Nubian_Platform_D",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 0,
+    "read_loop_interval": 240,
+    "read_loop_offset": 45,
     "text_zone": "e",
     "audio_zones": [
       "n"
@@ -8928,8 +8928,8 @@
     "id": "bus.Nubian_Platform_E_east",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 135,
     "text_zone": "c",
     "audio_zones": [
       "w"
@@ -9026,8 +9026,8 @@
     "id": "bus.Nubian_Platform_E_west",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "m",
     "audio_zones": [],
     "type": "bus",
@@ -9084,8 +9084,8 @@
     "id": "bus.Nubian_Platform_F",
     "pa_ess_loc": "SDUD",
     "scu_id": "SDUDSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 120,
+    "read_loop_interval": 240,
+    "read_loop_offset": 180,
     "text_zone": "n",
     "audio_zones": [
       "e"
@@ -9153,7 +9153,7 @@
     "id": "bus.Lechmere_inner",
     "pa_ess_loc": "SLEC",
     "scu_id": "GLECSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 180,
     "text_zone": "m",
     "audio_zones": [
@@ -9206,8 +9206,8 @@
     "id": "bus.Lechmere_outer",
     "pa_ess_loc": "SLEC",
     "scu_id": "GLECSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 0,
+    "read_loop_interval": 240,
+    "read_loop_offset": 60,
     "text_zone": "c",
     "audio_zones": [],
     "type": "bus",
@@ -9237,8 +9237,8 @@
     "id": "bus.Harvard_upper",
     "pa_ess_loc": "SHAR",
     "scu_id": "RHARSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 240,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "n",
     "audio_zones": [
       "n"
@@ -9333,8 +9333,8 @@
     "id": "bus.Harvard_lower",
     "pa_ess_loc": "SHAR",
     "scu_id": "RHARSCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 60,
+    "read_loop_interval": 240,
+    "read_loop_offset": 120,
     "text_zone": "m",
     "audio_zones": [
       "m"
@@ -9366,7 +9366,7 @@
     "id": "bus.Mattapan_north",
     "pa_ess_loc": "MMAT",
     "scu_id": "MMATSCU001",
-    "read_loop_interval": 420,
+    "read_loop_interval": 240,
     "read_loop_offset": 60,
     "text_zone": "s",
     "audio_zones": [
@@ -9462,8 +9462,8 @@
     "id": "bus.Mattapan_south",
     "pa_ess_loc": "MMAT",
     "scu_id": "MMATSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 0,
+    "read_loop_interval": 240,
+    "read_loop_offset": 180,
     "text_zone": "n",
     "audio_zones": [
       "n"
@@ -9504,7 +9504,7 @@
     "id": "bus.Davis",
     "pa_ess_loc": "SDAV",
     "scu_id": "RDAVSCU001",
-    "read_loop_interval": 360,
+    "read_loop_interval": 240,
     "read_loop_offset": 120,
     "text_zone": "m",
     "audio_zones": [
@@ -9582,7 +9582,7 @@
     "id": "bus.Forest_Hills_upper_island",
     "pa_ess_loc": "SFOR",
     "scu_id": "OFORSCU001",
-    "read_loop_interval": 420,
+    "read_loop_interval": 240,
     "read_loop_offset": 180,
     "text_zone": "s",
     "audio_zones": [
@@ -9642,8 +9642,8 @@
     "id": "bus.Forest_Hills_upper_fence",
     "pa_ess_loc": "SFOR",
     "scu_id": "OFORSCU001",
-    "read_loop_interval": 420,
-    "read_loop_offset": 0,
+    "read_loop_interval": 240,
+    "read_loop_offset": 60,
     "text_zone": "n",
     "audio_zones": [
       "n"
@@ -9711,8 +9711,8 @@
     "id": "bus.Braintree",
     "pa_ess_loc": "RBRA",
     "scu_id": "RBRASCU001",
-    "read_loop_interval": 360,
-    "read_loop_offset": 240,
+    "read_loop_interval": 240,
+    "read_loop_offset": 0,
     "text_zone": "n",
     "audio_zones": [
       "n"


### PR DESCRIPTION
**Asana Ticket:** https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209896617242906

Bus signs were previously given a read loop of 6 minutes, or 7 minutes for Nubian station. For better accessibility we'd like to reduce this to 4 minutes (240 seconds) across the board, the same as subway signs.

This also adjusts read loop offsets to avoid playing overlapping audio within the same busway.

* With two readouts, offsets are 120 seconds apart.
* With three readouts, offsets are 80 seconds apart.
* For Nubian, which has 5 distinct readouts, offsets are 45 seconds apart (sacrifices a bit of airtime to create more "round" numbers; exact division would be 48 seconds). The two readouts which share the same audio zone (`c`, for platforms A and C) are 90 seconds apart.

I tried to preserve the existing "distribution" of offsets on the assumption there was a reason for them to be spread out (e.g. rather than the two-readout case always being 0/120, sometimes it is 60/180).

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on Codecov)~~
- [ ] ~~If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project~~
  - This does change `signs.json`, but only fields that are not used by `signs_ui`
- [x] This branch was deployed to dev-green ~~and is currently running~~ with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [dev-green](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev-green%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
