### PR TITLE
Overnight period logic remerge with fixes to crashes

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -85,6 +85,13 @@ defmodule Engine.ScheduledHeadways do
     |> min_time()
   end
 
+  @callback get_last_scheduled_departure([binary]) :: nil | DateTime.t()
+  def get_last_scheduled_departure(stop_ids) do
+    get_first_last_departures(stop_ids)
+    |> Enum.map(&elem(&1, 1))
+    |> max_time()
+  end
+
   @doc "Checks if the given time is after the first scheduled stop and before the last.
   A buffer of minutes (positive) is subtracted from the first time. so that headways are
   shown for a short time before the first train."
@@ -128,6 +135,16 @@ defmodule Engine.ScheduledHeadways do
     datetimes
     |> Enum.filter(& &1)
     |> Enum.min_by(&DateTime.to_unix/1, fn -> nil end)
+  end
+
+  @spec max_time([DateTime.t() | nil]) :: DateTime.t() | nil
+  defp max_time([]), do: nil
+  defp max_time([%DateTime{} = dt]), do: dt
+
+  defp max_time(datetimes) do
+    datetimes
+    |> Enum.filter(& &1)
+    |> Enum.max_by(&DateTime.to_unix/1, fn -> nil end)
   end
 
   @impl true

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -131,10 +131,25 @@ defmodule Signs.Realtime do
         )
       end)
 
+    last_scheduled_departures =
+      map_source_config(sign.source_config, fn config ->
+        RealtimeSigns.headway_engine().get_last_scheduled_departure(
+          SourceConfig.sign_stop_ids(config)
+        )
+      end)
+
     prev_predictions_lookup =
       for prediction <- sign.prev_predictions, into: %{} do
         {prediction_key(prediction), prediction}
       end
+
+    recent_departures =
+      map_source_config(sign.source_config, fn config ->
+        SourceConfig.sign_stop_ids(config)
+        |> Stream.flat_map(&RealtimeSigns.last_trip_engine().get_recent_departures(&1))
+        |> Enum.max_by(fn {_, dt} -> dt end, fn -> {nil, nil} end)
+        |> elem(1)
+      end)
 
     {predictions, all_predictions} =
       case sign.source_config do
@@ -162,6 +177,8 @@ defmodule Signs.Realtime do
         current_time,
         alert_status,
         first_scheduled_departures,
+        last_scheduled_departures,
+        recent_departures,
         service_end_statuses_per_source
       )
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Fix and re-merge PA/ESS overnight mode](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210604891580461?focus=true)

Same as https://github.com/mbta/realtime_signs/pull/919 for the first commit. Second commit fixes crashes. 
- Pulled out the tuple zipping to before we check the sign config. This allows us to check if custom text should properly be in the overnight period, but otherwise just passes it normally to the regular handling.
- Adds some extra functions to guard for a `nil` `last_scheduled_departure` and `first_scheduled_departure`. The thought here being we don't know if we're in the overnight period if there isn't a schedule, but this maybe could be relaxed to just be `first_scheduled_departure`?
- Fixed the buffer time to go forward 30 minutes instead of back
- Added/modified tests to account for these three test cases, using a mezz sign, nil departures and checking explicitly for the thirty minute buffer. 

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [x] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
