### PR TITLE
Silver Line Headways

### DIFF
--- a/lib/engine/scheduled_headways.ex
+++ b/lib/engine/scheduled_headways.ex
@@ -27,7 +27,8 @@ defmodule Engine.ScheduledHeadways do
       Keyword.put_new(
         opts,
         :stop_ids,
-        Signs.Utilities.SignsConfig.all_train_stop_ids()
+        Signs.Utilities.SignsConfig.all_train_stop_ids() ++
+          Signs.Utilities.SignsConfig.all_bus_stop_ids()
       ),
       name: name
     )

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -247,6 +247,7 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string(:inbound), do: "Inbound"
   def destination_to_sign_string(:outbound), do: "Outbound"
   def destination_to_sign_string(:medford_tufts), do: "Medfd/Tufts"
+  def destination_to_sign_string(:silver_line), do: "Silver Line"
 
   @spec destination_to_ad_hoc_string(PaEss.destination()) :: String.t()
   def destination_to_ad_hoc_string(:alewife), do: "Alewife"
@@ -277,6 +278,7 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:inbound), do: "Inbound"
   def destination_to_ad_hoc_string(:outbound), do: "Outbound"
   def destination_to_ad_hoc_string(:medford_tufts), do: "Medford/Tufts"
+  def destination_to_ad_hoc_string(:silver_line), do: "Silver Line"
 
   def directional_destination?(destination),
     do: destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound]
@@ -783,6 +785,10 @@ defmodule PaEss.Utilities do
   # audio: "is now approaching", visual: "now approaching"
   def audio_take(:now_approaching), do: "924"
   def audio_take(:with_all_new_red_line_cars), do: "893"
+  def audio_take(:arrives_every), do: "666"
+  def audio_take(:to), do: "511"
+  def audio_take(:silver_line), do: "931"
+  def audio_take(:buses), do: "932"
 
   # audio: "It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.", visual: "Please move to front of the train to board."
   def audio_take(:four_car_train_message), do: "922"

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -1,14 +1,18 @@
 defmodule Signs.Utilities.Headways do
   @moduledoc """
   Given a sign with a SourceConfig, fetches headways and
-  geneartes the top and bottom lines for the sign
+  generates the top and bottom lines for the sign
   """
   alias Signs.Utilities.SourceConfig
   require Logger
 
   @spec headway_message(SourceConfig.config(), DateTime.t()) :: Message.t() | nil
   def headway_message(config, current_time) do
-    case fetch_headways(config.headway_group, config.sources, current_time) do
+    case fetch_headways(
+           config.headway_group,
+           Enum.map(config.sources, & &1.stop_id),
+           current_time
+         ) do
       nil ->
         nil
 
@@ -21,9 +25,22 @@ defmodule Signs.Utilities.Headways do
     end
   end
 
-  defp fetch_headways(headway_group, sources, current_time) do
-    stop_ids = Enum.map(sources, & &1.stop_id)
+  # Process headways for Silver Line differently b/c of its different config shape
+  def headway_message_sl(headway_group, headway_destination, stop_ids, current_time) do
+    case fetch_headways(headway_group, stop_ids, current_time) do
+      nil ->
+        nil
 
+      headways ->
+        %Message.Headway{
+          destination: headway_destination,
+          range: {headways.range_low, headways.range_high},
+          route: "Silver"
+        }
+    end
+  end
+
+  defp fetch_headways(headway_group, stop_ids, current_time) do
     with headways when not is_nil(headways) <-
            RealtimeSigns.config_engine().headway_config(headway_group, current_time),
          true <-

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -8263,7 +8263,9 @@
             "route_id": "741",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "Seaport"
       },
       {
         "sources": [
@@ -8330,7 +8332,9 @@
             "route_id": "746",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio",
@@ -8355,7 +8359,9 @@
             "route_id": "741",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "Seaport"
       },
       {
         "sources": [
@@ -8422,7 +8428,9 @@
             "route_id": "746",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio",
@@ -8462,7 +8470,9 @@
             "route_id": "746",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio",
@@ -8487,7 +8497,9 @@
             "route_id": "741",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "Seaport"
       },
       {
         "sources": [
@@ -8554,7 +8566,9 @@
             "route_id": "746",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "South Station"
       }
     ],
     "bottom_configs": [
@@ -8565,7 +8579,9 @@
             "route_id": "741",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "Seaport"
       },
       {
         "sources": [
@@ -8617,7 +8633,9 @@
             "route_id": "743",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "Chelsea"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8642,7 +8660,9 @@
             "route_id": "743",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8667,7 +8687,9 @@
             "route_id": "743",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "Chelsea"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8692,7 +8714,9 @@
             "route_id": "743",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8717,7 +8741,9 @@
             "route_id": "743",
             "direction_id": 0
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "Chelsea"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8742,7 +8768,9 @@
             "route_id": "743",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio_visual",
@@ -8767,7 +8795,9 @@
             "route_id": "743",
             "direction_id": 1
           }
-        ]
+        ],
+        "headway_group": "silver_chelsea",
+        "headway_direction_name": "South Station"
       }
     ],
     "chelsea_bridge": "audio_visual",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Actual headway mode on Silver Line signs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1207891972773461?focus=true)

Building off of @robbie-sundstrom PR here: https://github.com/mbta/realtime_signs/pull/933
- Added headway mode for Silver Line buses for platform/mezzanine modes
- For headways on the silver line, we'll now show "Silver Line Buses/Every x to y min" and "Buses to [dest]/Every x to y min".
- Mezzanine (currently seems like just to WTC) will show headways separately until both configs are in headway mode in which case we'll display the "Silver Line Buses" messaging (n.b. currently, at least in my dev-green configuration there doesn't seem to be predictions for WTC Mezz sign to begin with. Will look into)
- Chelsea Bridge paginates with Headways when both need to be shown.
- All audios and tts_audios have been updated to use the headway messaging and audios

<img width="1094" height="207" alt="Screenshot 2025-07-15 at 9 02 00 AM" src="https://github.com/user-attachments/assets/2d7fb3bb-e1cf-493d-ae86-16ddb73882eb" />
<img width="1123" height="181" alt="Screenshot 2025-07-15 at 9 02 42 AM" src="https://github.com/user-attachments/assets/b1ae049f-e7d2-4bef-a055-f67f4d96d869" />
<img width="1116" height="216" alt="Screenshot 2025-07-15 at 9 03 34 AM" src="https://github.com/user-attachments/assets/37fee526-1854-495a-93f3-1ce5b6ccb19f" />
<img width="1119" height="219" alt="Screenshot 2025-07-15 at 9 08 50 AM" src="https://github.com/user-attachments/assets/94f8e487-0943-4819-93ad-61d481bae382" />
<img width="1113" height="749" alt="Screenshot 2025-07-15 at 9 11 57 AM" src="https://github.com/user-attachments/assets/b2018a40-335c-48c1-8cb1-f7d48e749ef5" />
<img width="1133" height="604" alt="Screenshot 2025-07-15 at 11 46 18 AM" src="https://github.com/user-attachments/assets/fb5fcc2d-9f77-4b5b-90d4-123b5261e248" />


#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
