### PR TITLE
send single zone to scully

### DIFF
--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -41,7 +41,7 @@ defmodule PaEss.Updater do
         scu_id,
         {:background, scu_id,
          %{
-           visual_zones: [text_zone],
+           zones: ["#{pa_ess_loc}-#{text_zone}"],
            visual_data: visual,
            expiration: 180,
            tag: tag
@@ -107,9 +107,8 @@ defmodule PaEss.Updater do
             scu_id,
             {:message, scu_id,
              %{
-               visual_zones: audio_zones,
+               zones: Enum.map(audio_zones, &"#{pa_ess_loc}-#{&1}"),
                visual_data: format_pages(pages),
-               audio_zones: audio_zones,
                audio_data: [Base.encode64(file)],
                expiration: 30,
                priority: priority,

--- a/priv/signs.json
+++ b/priv/signs.json
@@ -1031,7 +1031,7 @@
     "id": "state_blue_eastbound",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
-    "scu_id": "OSTASCU001",
+    "scu_id": "BSTASCU001",
     "read_loop_offset": 30,
     "text_zone": "e",
     "audio_zones": [
@@ -1058,7 +1058,7 @@
     "id": "state_blue_mezzanine",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
-    "scu_id": "OSTASCU001",
+    "scu_id": "BSTASCU001",
     "read_loop_offset": 120,
     "text_zone": "m",
     "audio_zones": [
@@ -1103,7 +1103,7 @@
     "id": "state_blue_westbound",
     "type": "realtime",
     "pa_ess_loc": "BSTA",
-    "scu_id": "OSTASCU001",
+    "scu_id": "BSTASCU001",
     "read_loop_offset": 90,
     "text_zone": "w",
     "audio_zones": [


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Middleware: Batch encode sign and device data](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210475118985495?focus=true)

This switches to the new API format for Scully, and sends a single zone list including the station code. Also fixes a few incorrect SCU references, noticed during hardware encoding.

This change will need to be deployed simultaneously with mbta/scully#98