### PR TITLE
feat: JFK mezzanine does not show TBD platform when all upcoming predictions to Alewife are for the same platform

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -160,13 +160,23 @@ defmodule Content.Audio.Predictions do
       {minutes, _} = PaEss.Utilities.prediction_minutes(audio.prediction, audio.terminal?)
       platform = Content.Utilities.stop_platform(audio.prediction.stop_id)
       jfk_mezzanine? = audio.special_sign == :jfk_mezzanine
+      jfk_mezzanine_single_platform? = audio.special_sign == :jfk_mezzanine_single_platform
 
       cond do
-        !platform -> {nil, false, nil}
-        jfk_mezzanine? and minutes > @announce_platform_later_mins -> {nil, false, :later}
-        jfk_mezzanine? and minutes > @announce_platform_soon_mins -> {nil, false, :soon}
-        minutes == 1 or !jfk_mezzanine? -> {platform, true, nil}
-        true -> {platform, false, nil}
+        !platform ->
+          {nil, false, nil}
+
+        jfk_mezzanine? and minutes > @announce_platform_later_mins ->
+          {nil, false, :later}
+
+        jfk_mezzanine? and minutes > @announce_platform_soon_mins ->
+          {nil, false, :soon}
+
+        minutes == 1 or (!jfk_mezzanine? and !jfk_mezzanine_single_platform?) ->
+          {platform, true, nil}
+
+        true ->
+          {platform, false, nil}
       end
     end
 

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -11,16 +11,20 @@ defmodule Content.Audio.Predictions do
 
   @type t :: %__MODULE__{
           prediction: Predictions.Prediction.t(),
-          special_sign: :jfk_mezzanine | :bowdoin_eastbound | nil,
+          special_sign: special_sign(),
           terminal?: boolean(),
           multiple_messages?: boolean(),
           next_or_following: :next | :following,
           is_first?: boolean()
         }
 
+  # To track signs with special audio conditions
+  # For JFK platform, track if Alewife-bound trains are using a single platform, indicated by true.
+  @type special_sign :: {:jfk_mezzanine, true | false} | :bowdoin_eastbound | nil
+
   @spec new(
           Predictions.Prediction.t(),
-          :jfk_mezzanine | :bowdoin_eastbound | nil,
+          special_sign(),
           boolean(),
           boolean(),
           :next | :following,
@@ -159,8 +163,8 @@ defmodule Content.Audio.Predictions do
     defp platform_status(audio) do
       {minutes, _} = PaEss.Utilities.prediction_minutes(audio.prediction, audio.terminal?)
       platform = Content.Utilities.stop_platform(audio.prediction.stop_id)
-      jfk_mezzanine? = audio.special_sign == :jfk_mezzanine
-      jfk_mezzanine_single_platform? = audio.special_sign == :jfk_mezzanine_single_platform
+      jfk_mezzanine? = audio.special_sign == {:jfk_mezzanine, false}
+      jfk_mezzanine_single_platform? = audio.special_sign == {:jfk_mezzanine, true}
 
       cond do
         !platform ->

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -105,6 +105,8 @@ defmodule Message.Predictions do
           match?({:jfk_mezzanine, _}, special_sign) and destination == :alewife ->
             platform_name = Content.Utilities.stop_platform_name(prediction.stop_id)
 
+            # {_, false} in special_sign indicates both stop_ids for Alewife-bound trains are active
+            # In this case, predicted platform is still subject to change when it's 5+ minutes away
             {headsign_message, platform_message} =
               if is_integer(minutes) and minutes > 5 and special_sign == {:jfk_mezzanine, false} do
                 {headsign, " (Platform TBD)"}

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -5,7 +5,7 @@ defmodule Message.Predictions do
   @type t :: %__MODULE__{
           predictions: [Predictions.Prediction.t()],
           terminal?: boolean(),
-          special_sign: :jfk_mezzanine | :jfk_mezzanine_single_platform | :bowdoin_eastbound | nil
+          special_sign: {:jfk_mezzanine, true | false} | :bowdoin_eastbound | nil
         }
 
   defimpl Message do
@@ -18,7 +18,8 @@ defmodule Message.Predictions do
     def to_single_line(%Message.Predictions{}, :short), do: nil
 
     def to_full_page(
-          %Message.Predictions{predictions: [top | _], special_sign: :jfk_mezzanine} = message
+          %Message.Predictions{predictions: [top | _], special_sign: {:jfk_mezzanine, _}} =
+            message
         ) do
       {minutes, _} = PaEss.Utilities.prediction_minutes(top, message.terminal?)
       platform_name = Content.Utilities.stop_platform_name(top.stop_id)
@@ -101,12 +102,11 @@ defmodule Message.Predictions do
         track_number = Content.Utilities.stop_track_number(prediction.stop_id)
 
         cond do
-          special_sign in [:jfk_mezzanine, :jfk_mezzanine_single_platform] and
-              destination == :alewife ->
+          match?({:jfk_mezzanine, _}, special_sign) and destination == :alewife ->
             platform_name = Content.Utilities.stop_platform_name(prediction.stop_id)
 
             {headsign_message, platform_message} =
-              if is_integer(minutes) and minutes > 5 and special_sign == :jfk_mezzanine do
+              if is_integer(minutes) and minutes > 5 and special_sign == {:jfk_mezzanine, false} do
                 {headsign, " (Platform TBD)"}
               else
                 {"#{headsign} (#{String.slice(platform_name, 0..0)})", " (#{platform_name} plat)"}

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -5,7 +5,7 @@ defmodule Message.Predictions do
   @type t :: %__MODULE__{
           predictions: [Predictions.Prediction.t()],
           terminal?: boolean(),
-          special_sign: :jfk_mezzanine | :bowdoin_eastbound | nil
+          special_sign: :jfk_mezzanine | :jfk_mezzanine_single_platform | :bowdoin_eastbound | nil
         }
 
   defimpl Message do
@@ -101,11 +101,12 @@ defmodule Message.Predictions do
         track_number = Content.Utilities.stop_track_number(prediction.stop_id)
 
         cond do
-          special_sign == :jfk_mezzanine and destination == :alewife ->
+          special_sign in [:jfk_mezzanine, :jfk_mezzanine_single_platform] and
+              destination == :alewife ->
             platform_name = Content.Utilities.stop_platform_name(prediction.stop_id)
 
             {headsign_message, platform_message} =
-              if is_integer(minutes) and minutes > 5 do
+              if is_integer(minutes) and minutes > 5 and special_sign == :jfk_mezzanine do
                 {headsign, " (Platform TBD)"}
               else
                 {"#{headsign} (#{String.slice(platform_name, 0..0)})", " (#{platform_name} plat)"}

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -249,7 +249,7 @@ defmodule Signs.Utilities.Messages do
               :bowdoin_eastbound
 
             %{pa_ess_loc: "RJFK", text_zone: "m"} ->
-              {:jfk_mezzanine, jfk_to_alewife_is_single_platform?(all_predictions)}
+              {:jfk_mezzanine, all_same_stop_id?(all_predictions)}
 
             _ ->
               nil
@@ -258,8 +258,8 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
-  @spec jfk_to_alewife_is_single_platform?([Predictions.Prediction.t()]) :: boolean()
-  defp jfk_to_alewife_is_single_platform?(all_predictions) do
+  @spec all_same_stop_id?([Predictions.Prediction.t()]) :: boolean()
+  defp all_same_stop_id?(all_predictions) do
     length(Enum.uniq_by(all_predictions, & &1.stop_id)) == 1
   end
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1202,7 +1202,7 @@ defmodule Signs.RealtimeTest do
 
     test "JFK mezzanine platform TBD soon" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :ashmont, arrival: 120)]
+        [prediction(destination: :ashmont, arrival: 380)]
       end)
 
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
@@ -1214,17 +1214,17 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_messages(
-        {"Ashmont      2 min", [{"Alewife      7 min", 6}, {"Alewife (Platform TBD)", 6}]}
+        {"Ashmont      6 min", [{"Alewife      7 min", 6}, {"Alewife (Platform TBD)", 6}]}
       )
 
       expect_audios(
         [
-          {:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5002", "505"]), :audio}},
+          {:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5006", "505"]), :audio}},
           {:canned,
            {"117", spaced(["501", "4000", "864", "503", "504", "5007", "505", "849"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
+          {"The next Ashmont train arrives in 6 minutes.", nil},
           {"The next Alewife train arrives in 7 minutes. We will announce the platform for boarding soon.",
            nil}
         ]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Don't say "Platform TBD" when one branch is shut down](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209896617242902?focus=true)

Changes behavior for the JFK/UMass mezzanine to only show an Alewife prediction as (TBD) when we have at least one prediction for each platform AND the prediction in question is >5 minutes away. If we only have predictions for one of the two platforms, this now shows the platform regardless of the time.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
