### PR TITLE
feat: Adjust Approaching/Passthrough announcement timing for Green Line

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -545,8 +545,15 @@ defmodule PaEss.Utilities do
 
   @spec prediction_approaching?(Predictions.Prediction.t(), boolean()) :: boolean()
   def prediction_approaching?(prediction, terminal?) do
+    secs_to_announce = secs_to_announce_approaching(prediction.route_id)
+
     !terminal? and !prediction.stopped_at_predicted_stop? and
-      prediction_seconds(prediction, terminal?) in 0..45
+      prediction_seconds(prediction, terminal?) in 0..secs_to_announce
+  end
+
+  @spec secs_to_announce_approaching(String.t()) :: integer()
+  defp secs_to_announce_approaching(route_id) do
+    if String.starts_with?(route_id, "Green"), do: 30, else: 45
   end
 
   @spec prediction_stopped?(Predictions.Prediction.t(), boolean()) :: boolean()

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -19,7 +19,9 @@ defmodule Signs.Utilities.Predictions do
   defp prediction_passthrough_audios(predictions) do
     predictions
     |> Enum.filter(fn prediction ->
-      prediction.seconds_until_passthrough && prediction.seconds_until_passthrough <= 60
+      prediction.seconds_until_passthrough &&
+        prediction.seconds_until_passthrough <=
+          secs_to_announce_passthrough(prediction.route_id)
     end)
     |> Enum.sort_by(fn prediction -> prediction.seconds_until_passthrough end)
     |> Enum.flat_map(fn prediction ->
@@ -38,5 +40,10 @@ defmodule Signs.Utilities.Predictions do
       ]
     end)
     |> Enum.take(1)
+  end
+
+  @spec secs_to_announce_passthrough(String.t()) :: integer()
+  defp secs_to_announce_passthrough(route_id) do
+    if String.starts_with?(route_id, "Green"), do: 30, else: 45
   end
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -216,6 +216,15 @@ defmodule Signs.RealtimeTest do
       assert sign.announced_passthroughs == ["123"]
     end
 
+    test "does not announce train passing through when arrival is above threshold" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(destination: :riverside, seconds_until_passthrough: 31, trip_id: "123")]
+      end)
+
+      assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, @sign)
+      assert sign.announced_passthroughs == []
+    end
+
     test "announces passthrough trains for mezzanine signs" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :braintree, seconds_until_passthrough: 30, trip_id: "123")]

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -797,10 +797,10 @@ defmodule Signs.RealtimeTest do
 
     test "announces approaching for Green Line" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :cleveland_circle, arrival: 45)]
+        [prediction(destination: :cleveland_circle, arrival: 30)]
       end)
 
-      expect_messages({"Clvlnd Cir   1 min", ""})
+      expect_messages({"Clvlnd Cir     ARR", ""})
 
       expect_audios(
         [
@@ -815,6 +815,16 @@ defmodule Signs.RealtimeTest do
            ]}
         ]
       )
+
+      Signs.Realtime.handle_info(:run_loop, @sign)
+    end
+
+    test "does not announce approaching for Green Line when >30 secs away" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(destination: :cleveland_circle, arrival: 31)]
+      end)
+
+      expect_messages({"Clvlnd Cir   1 min", ""})
 
       Signs.Realtime.handle_info(:run_loop, @sign)
     end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Reduce lead time for Approaching messages on GL](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210643067506408?focus=true)

This change adjusts the announcement timings for passthrough and approaching messages for all Green Line trains. 

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
