### PR TITLE
fix: Configure Courthouse mezz sign to show both inbound + outbound stops

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -8405,7 +8405,7 @@
       "m"
     ],
     "type": "bus",
-    "configs": [
+    "top_configs": [
       {
         "sources": [
           {
@@ -8431,6 +8431,34 @@
         ],
         "headway_group": "silver_seaport",
         "headway_direction_name": "South Station"
+      }
+    ],
+    "bottom_configs": [
+      {
+        "sources": [
+          {
+            "stop_id": "74612",
+            "route_id": "741",
+            "direction_id": 0
+          },
+          {
+            "stop_id": "74612",
+            "route_id": "742",
+            "direction_id": 0
+          },
+          {
+            "stop_id": "74612",
+            "route_id": "743",
+            "direction_id": 0
+          },
+          {
+            "stop_id": "74612",
+            "route_id": "746",
+            "direction_id": 0
+          }
+        ],
+        "headway_group": "silver_seaport",
+        "headway_direction_name": "Seaport"
       }
     ],
     "chelsea_bridge": "audio",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Fix: Courthouse Mezzanine Sign only shows inbound predictions/headway](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210891029468366?focus=true)

This is deployed to dev-green, so you can see this configuration working in Signs UI there: https://signs-dev-green.mbtace.com/viewer

<img width="334" height="85" alt="image" src="https://github.com/user-attachments/assets/beb9e9a7-da5e-4506-b270-fa96be494cd8" />

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
