### PR TITLE
adjust passthrough messaging

### DIFF
--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -16,7 +16,7 @@ defmodule Content.Audio.Passthrough do
 
   defimpl Content.Audio do
     def to_params(%Content.Audio.Passthrough{} = audio) do
-      train = PaEss.Utilities.train_description_tokens(audio.destination, audio.route_id, true)
+      train = PaEss.Utilities.train_description_tokens(audio.destination, nil, true)
 
       PaEss.Utilities.audio_message(
         [:the_next] ++ train ++ [:does_not_take_customers, :., :stand_back_message],
@@ -34,7 +34,7 @@ defmodule Content.Audio.Passthrough do
     end
 
     defp tts_text(%Content.Audio.Passthrough{} = audio) do
-      train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+      train = PaEss.Utilities.train_description(audio.destination, nil)
       "The next #{train} does not take customers. Please stand back from the platform edge."
     end
   end

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -127,7 +127,7 @@ defmodule Content.Utilities do
   def stop_platform_name("70086"), do: "Ashmont"
   def stop_platform_name("70096"), do: "Braintree"
 
-  @spec route_branch_letter(String.t()) :: green_line_branch() | nil
+  @spec route_branch_letter(String.t() | nil) :: green_line_branch() | nil
   def route_branch_letter("Green-B"), do: :b
   def route_branch_letter("Green-C"), do: :c
   def route_branch_letter("Green-D"), do: :d

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -304,8 +304,8 @@ defmodule PaEss.Utilities do
     end
   end
 
-  @spec train_description_tokens(PaEss.destination(), String.t()) :: [atom()]
-  @spec train_description_tokens(PaEss.destination(), String.t(), boolean()) :: [atom()]
+  @spec train_description_tokens(PaEss.destination(), String.t() | nil) :: [atom()]
+  @spec train_description_tokens(PaEss.destination(), String.t() | nil, boolean()) :: [atom()]
   def train_description_tokens(destination, route_id, use_polly_takes? \\ false) do
     branch = Content.Utilities.route_branch_letter(route_id)
     tokens = if branch, do: [branch, :train_to, destination], else: [destination, :train]

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -266,7 +266,7 @@ defmodule Signs.Realtime do
 
   @spec announce_passthrough_trains(Signs.Realtime.t(), predictions()) :: Signs.Realtime.t()
   defp announce_passthrough_trains(sign, predictions) do
-    Utilities.Predictions.get_passthrough_train_audio(predictions)
+    Utilities.Predictions.get_passthrough_train_audio(predictions, sign)
     |> Enum.reduce(sign, fn audio, sign ->
       if audio.trip_id not in sign.announced_passthroughs do
         Signs.Utilities.Audio.send_audio(sign, [audio])

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -205,14 +205,11 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_audios(
+        [{:canned, {"112", spaced(["501", "787", "920", "929", "21014", "925"]), :audio_visual}}],
         [
-          {:canned,
-           {"114", spaced(["501", "905", "919", "918", "929", "21014", "925"]), :audio_visual}}
-        ],
-        [
-          {"The next D train to Riverside does not take customers. Please stand back from the platform edge.",
+          {"The next Southbound train does not take customers. Please stand back from the platform edge.",
            [
-             {"The next D train to", "Riverside does not take", 3},
+             {"The next Southbound", "train does not take", 3},
              {"customers. Please stand", "back from the platform", 3},
              {"edge.", "", 3}
            ]}
@@ -268,7 +265,11 @@ defmodule Signs.RealtimeTest do
         ]
       )
 
-      Signs.Realtime.handle_info(:run_loop, @mezzanine_sign)
+      Signs.Realtime.handle_info(:run_loop, %{
+        @jfk_mezzanine_sign
+        | current_content_top: "Red line trains",
+          current_content_bottom: "Every 11 to 13 min"
+      })
     end
 
     test "announces passthrough audio for 'Southbound' headsign" do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Fix PA/ESS GL pass-through destination announcements](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1210661130574832?focus=true)

This modifies passthrough announcements to always use the config's "headway destination" instead of the prediction destination, which will result in directional destinations being used at all trunk stops where there isn't an unambiguous anchor station. We also skip announcing GL branch letters, mostly to avoid improper phrases like "The next D train to Eastbound". As a result, even places where we do have an anchor will now say e.g. "The next Riverside train" for passthrough messages, which seems fine since the branch letter is irrelevant if you can't board the train.