### PR TITLE
remove mezzanine announcements

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -22,7 +22,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -38,7 +38,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -149,7 +149,7 @@
               "Mattapan"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -165,7 +165,7 @@
               "Mattapan"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -464,7 +464,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -480,7 +480,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -671,7 +671,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -687,7 +687,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -770,7 +770,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -786,7 +786,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -977,7 +977,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -993,7 +993,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1076,7 +1076,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1092,7 +1092,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1175,7 +1175,7 @@
               "Blue"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1191,7 +1191,7 @@
               "Blue"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1463,7 +1463,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1479,7 +1479,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1508,7 +1508,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1524,7 +1524,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1553,7 +1553,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1569,7 +1569,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1661,7 +1661,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1677,7 +1677,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1760,7 +1760,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1776,7 +1776,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1859,7 +1859,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -1875,7 +1875,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2012,7 +2012,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2028,7 +2028,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2057,7 +2057,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2073,7 +2073,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2102,7 +2102,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2118,7 +2118,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2201,7 +2201,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2217,7 +2217,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2462,7 +2462,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2478,7 +2478,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2561,7 +2561,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2577,7 +2577,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2660,7 +2660,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2676,7 +2676,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2813,7 +2813,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2829,7 +2829,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2858,7 +2858,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2874,7 +2874,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2903,7 +2903,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -2919,7 +2919,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3002,7 +3002,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3018,7 +3018,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3101,7 +3101,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3117,7 +3117,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3200,7 +3200,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3216,7 +3216,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3434,7 +3434,7 @@
               "Orange"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3450,7 +3450,7 @@
               "Orange"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3569,7 +3569,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3585,7 +3585,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3668,7 +3668,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3684,7 +3684,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3767,7 +3767,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -3783,7 +3783,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4082,7 +4082,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4098,7 +4098,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4181,7 +4181,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4197,7 +4197,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4280,7 +4280,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4296,7 +4296,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4325,7 +4325,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4341,7 +4341,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4424,7 +4424,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4440,7 +4440,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4523,7 +4523,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4539,7 +4539,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4622,7 +4622,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4638,7 +4638,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4721,7 +4721,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4737,7 +4737,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4821,7 +4821,7 @@
             ],
             "direction_id": 1,
             "announce_arriving": false,
-            "announce_boarding": true
+            "announce_boarding": false
           }
         ]
       },
@@ -4836,8 +4836,8 @@
               "Mattapan"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
-            "announce_boarding": true
+            "announce_arriving": false,
+            "announce_boarding": false
           }
         ]
       }
@@ -4919,7 +4919,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -4935,7 +4935,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5018,7 +5018,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5034,7 +5034,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5117,7 +5117,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5133,7 +5133,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5216,7 +5216,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5232,7 +5232,7 @@
               "Red"
             ],
             "direction_id": 0,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5513,7 +5513,7 @@
             "routes": [
               "Red"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           },
           {
@@ -5522,7 +5522,7 @@
             "routes": [
               "Red"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -5538,7 +5538,7 @@
               "Red"
             ],
             "direction_id": 1,
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           },
           {
@@ -5547,7 +5547,7 @@
             "routes": [
               "Red"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6472,7 +6472,7 @@
               "Green-C",
               "Green-D"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           },
           {
@@ -6481,7 +6481,7 @@
             "routes": [
               "Green-B"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6498,7 +6498,7 @@
               "Green-C",
               "Green-D"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           },
           {
@@ -6507,7 +6507,7 @@
             "routes": [
               "Green-B"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6596,7 +6596,7 @@
               "Green-C",
               "Green-D"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6614,7 +6614,7 @@
               "Green-C",
               "Green-D"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6766,7 +6766,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6785,7 +6785,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6982,7 +6982,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -6998,7 +6998,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7246,7 +7246,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7265,7 +7265,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7408,7 +7408,7 @@
               "Green-E"
             ],
             "announce_arriving": false,
-            "announce_boarding": true
+            "announce_boarding": false
           }
         ]
       },
@@ -7425,7 +7425,7 @@
               "Green-E"
             ],
             "announce_arriving": false,
-            "announce_boarding": true
+            "announce_boarding": false
           }
         ]
       }
@@ -7510,7 +7510,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7527,7 +7527,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7613,7 +7613,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7630,7 +7630,7 @@
               "Green-D",
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7844,7 +7844,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7860,7 +7860,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7943,7 +7943,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -7959,7 +7959,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -8042,7 +8042,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -8058,7 +8058,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -8141,7 +8141,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]
@@ -8157,7 +8157,7 @@
             "routes": [
               "Green-E"
             ],
-            "announce_arriving": true,
+            "announce_arriving": false,
             "announce_boarding": false
           }
         ]

--- a/scripts/one_offs/mezzanine_announcements.exs
+++ b/scripts/one_offs/mezzanine_announcements.exs
@@ -1,0 +1,18 @@
+Mix.install([{:jason, "~> 1.4.0"}])
+
+signs =
+  File.read!("priv/signs.json")
+  |> Jason.decode!(keys: :atoms, objects: :ordered_objects)
+
+new_signs =
+  for sign <- signs do
+    if is_list(sign[:source_config]) do
+      sign
+      |> put_in([:source_config, Access.all(), :sources, Access.all(), :announce_arriving], false)
+      |> put_in([:source_config, Access.all(), :sources, Access.all(), :announce_boarding], false)
+    else
+      sign
+    end
+  end
+
+File.write!("priv/signs.json", Jason.encode!(new_signs, pretty: true) <> "\n")


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Only Play Approaching Messages on Platforms](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210643067506405?focus=true)

This reconfigures all mezzanine signs to not generate approaching or boarding announcements. The change was made via script, which is included for review.