### PR TITLE
chore: switch to 4:00am service day boundary

### DIFF
--- a/lib/engine/last_trip.ex
+++ b/lib/engine/last_trip.ex
@@ -94,7 +94,7 @@ defmodule Engine.LastTrip do
 
     {:ok, current_time_est} = DateTime.utc_now() |> DateTime.shift_zone(@timezone)
 
-    if current_time_est.hour == 3 and current_time_est.minute >= 30 do
+    if current_time_est.hour == 4 and current_time_est.minute == 0 do
       clean_tables(state)
     end
 

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -4,7 +4,7 @@ defmodule Signs.Utilities.Messages do
   be displaying
   """
 
-  @early_am_start ~T[03:29:00]
+  @early_am_start ~T[04:00:00]
   @early_am_buffer -40
   @overnight_buffer 30
 
@@ -269,7 +269,12 @@ defmodule Signs.Utilities.Messages do
   defp in_early_am?(_, nil), do: false
 
   defp in_early_am?(current_time, scheduled) do
-    Timex.between?(DateTime.to_time(current_time), @early_am_start, DateTime.to_time(scheduled))
+    Timex.between?(
+      DateTime.to_time(current_time),
+      @early_am_start,
+      DateTime.to_time(scheduled),
+      inclusive: :start
+    )
   end
 
   defp before_early_am_threshold?(_, nil), do: false


### PR DESCRIPTION
Due to the addition of limited late-night service, 4:00am should now be considered the start/end of the service day.

This affects:

* the window of time in which we consider showing info about the first scheduled trip of the day
* when we clear data about whether the flagged "last train of the day" has passed through a stop

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] ~~If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project~~
- [x] This branch was deployed to dev-green and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [dev-green](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev-green%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211034769779823