### PR TITLE
fix: never show Park St departures at Park St

### DIFF
--- a/priv/signs.json
+++ b/priv/signs.json
@@ -7021,18 +7021,6 @@
       "terminal": false,
       "sources": [
         {
-          "stop_id": "71199",
-          "direction_id": 1,
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
-        {
           "stop_id": "70200",
           "direction_id": 1,
           "routes": [
@@ -7062,18 +7050,6 @@
       "headway_direction_name": "Eastbound",
       "terminal": false,
       "sources": [
-        {
-          "stop_id": "71199",
-          "direction_id": 1,
-          "routes": [
-            "Green-B",
-            "Green-C",
-            "Green-D",
-            "Green-E"
-          ],
-          "announce_arriving": true,
-          "announce_boarding": false
-        },
         {
           "stop_id": "70200",
           "direction_id": 1,


### PR DESCRIPTION
Stop 71199 is the Green Line eastbound fence track at Park Street. This platform can only be used by service terminating at Park Street, since the tracks physically do not allow continuing on to Government Center; passengers would never be allowed to board a train here. Despite this, due to an ongoing data issue, predictions will sometimes be published with a departure time for this stop (suggesting the train will accept passengers). This results in signs confusingly showing a "Park Street" departure *at* Park Street.

Prior to the underlying data issue being fixed, we can address this by removing the stop from sign configurations entirely.

**Asana Ticket:** https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211023799958882

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on Codecov)~~
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
