### PR TITLE
fix: use appropriate comparison func for datetimes

### DIFF
--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -147,7 +147,7 @@ defmodule Signs.Realtime do
       map_source_config(sign.source_config, fn config ->
         SourceConfig.sign_stop_ids(config)
         |> Stream.flat_map(&RealtimeSigns.last_trip_engine().get_recent_departures(&1))
-        |> Enum.max_by(fn {_, dt} -> dt end, fn -> {nil, nil} end)
+        |> Enum.max_by(fn {_, dt} -> dt end, DateTime, fn -> {nil, nil} end)
         |> elem(1)
       end)
 


### PR DESCRIPTION
When determining "recent departures" for a sign (used as part of the criteria for "overnight mode" where alert and service-ended messages are suppressed), DateTimes were incorrectly compared using `>=` instead of the `DateTime.compare/2` function. This resulted in signs blanking too early, in some cases never showing "service ended" at all.

This branch was deployed to dev-green overnight. In the comparison below, which lists messages sent to signs at Back Bay station from 12:30am on, we can see that:

* the last Oak Grove train passes through at 12:40am, and the last Forest Hills train at 12:52am.
* in prod, NB signs say "Service ended" from 12:41am until 1:01am, then go blank; SB signs never say "Service ended", going blank immediately after the last Forest Hills train passes through
* in dev-green, NB signs say "Service ended" from 12:41am until **1:11am**; SB signs **do** say "Service ended", from 12:53am to 1:21am (not visible in screenshot)
* ⚠️ because NB content enters "overnight mode" before SB content, there is a period from 1:11am to 1:21am where mezzanine signs switch from saying "Service ended for night" to "Forest Hills service ended" (incorrectly implying Oak Grove service is running during this time). This seems like a separate bug with "overnight mode" that would exist regardless of this fix, and I'll enter it as a follow-up task for us.

| prod | dev-green |
| :--: | :--: |
| <img width="2008" height="4464" alt="Screen Shot 2025-08-15 at 10 35 19" src="https://github.com/user-attachments/assets/3fd3a921-2757-4ae0-a8d1-54f95467225d" /> | <img width="2008" height="4984" alt="Screen Shot 2025-08-15 at 10 35 43" src="https://github.com/user-attachments/assets/7e2424cf-ed5c-43d3-8e95-bb7bc7693d30" /> |