### PR TITLE
Changed Silver Line to SL Outbound for PA/ESS message/audio

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -247,7 +247,7 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string(:inbound), do: "Inbound"
   def destination_to_sign_string(:outbound), do: "Outbound"
   def destination_to_sign_string(:medford_tufts), do: "Medfd/Tufts"
-  def destination_to_sign_string(:silver_line), do: "Silver Line"
+  def destination_to_sign_string(:silver_line), do: "SL Outbound"
 
   @spec destination_to_ad_hoc_string(PaEss.destination()) :: String.t()
   def destination_to_ad_hoc_string(:alewife), do: "Alewife"
@@ -278,7 +278,7 @@ defmodule PaEss.Utilities do
   def destination_to_ad_hoc_string(:inbound), do: "Inbound"
   def destination_to_ad_hoc_string(:outbound), do: "Outbound"
   def destination_to_ad_hoc_string(:medford_tufts), do: "Medford/Tufts"
-  def destination_to_ad_hoc_string(:silver_line), do: "Silver Line"
+  def destination_to_ad_hoc_string(:silver_line), do: "Silver Line Outbound"
 
   def directional_destination?(destination),
     do: destination in [:eastbound, :westbound, :southbound, :northbound, :inbound, :outbound]

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -1008,15 +1008,19 @@ defmodule Signs.Bus do
           }},
          _
        ) do
-    [
-      destination,
-      :buses,
-      :arrives_every,
-      {:number, range_low},
-      :to,
-      {:number, range_high},
-      :minutes
-    ]
+    if destination == :silver_line do
+      [destination, :outbound]
+    else
+      [destination]
+    end ++
+      [
+        :buses,
+        :arrives_every,
+        {:number, range_low},
+        :to,
+        {:number, range_high},
+        :minutes
+      ]
   end
 
   defp message_tts_audio({:predictions, [prediction | _]}, current_time) do

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -298,14 +298,15 @@ defmodule Signs.BusTest do
     end
 
     test "SL dual headway mode with headways set on mezzanine sign" do
-      expect_messages(["Silver Line buses", "Every 11 to 13 min"])
+      expect_messages(["SL Outbound buses", "Every 11 to 13 min"])
 
       expect_audios(
         [
           canned:
-            {"111", ["548", "21012", "931", "932", "666", "5011", "511", "5013", "505"], :audio}
+            {"112", ["548", "21012", "931", "33004", "932", "666", "5011", "511", "5013", "505"],
+             :audio}
         ],
-        [{"Upcoming departures: Silver Line buses every 11 to 13 minutes.", nil}]
+        [{"Upcoming departures: Silver Line Outbound buses every 11 to 13 minutes.", nil}]
       )
 
       state =


### PR DESCRIPTION
#### Summary of changes
"SIlver Line" text for Seaport/Silver Line Outbound buses have been changed to be "SL Outbound". The audio will still be "Silver Line" but added an "Outbound" after it. 

**Asana Ticket:** [Add "Outbound" to SL MZ/Platform Signs ](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1210728892258435?focus=true)

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
