### PR TITLE
chore: remove support for headway mode

### DIFF
--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -18,7 +18,7 @@ defmodule Engine.Config do
         }
 
   @type sign_config ::
-          :auto | :headway | :off | :temporary_terminal | {:static_text, {String.t(), String.t()}}
+          :auto | :off | :temporary_terminal | {:static_text, {String.t(), String.t()}}
 
   @table_signs :config_engine_signs
   @table_headways :config_engine_headways
@@ -191,9 +191,6 @@ defmodule Engine.Config do
 
       config_json["mode"] == "auto" ->
         :auto
-
-      config_json["mode"] == "headway" ->
-        :headway
 
       config_json["mode"] == "temporary_terminal" ->
         :temporary_terminal

--- a/lib/fake/ex_aws.ex
+++ b/lib/fake/ex_aws.ex
@@ -27,7 +27,7 @@ defmodule Fake.ExAws do
   def request({_bucket, _path, _opts}) do
     {:ok,
      %{
-       body: "{\"chelsea_inbound\":{\"mode\":\"headway\"}}",
+       body: "{\"chelsea_inbound\":{\"mode\":\"auto\"}}",
        headers: [
          {"x-amz-id-2", "id1235"},
          {"x-amz-request-id", "REQUEST1235"},

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -44,9 +44,7 @@ defmodule Fake.ExternalConfig.Local do
            "expires" => "2017-07-04T12:00:00Z"
          },
          "off_test" => %{"mode" => "off"},
-         "auto_test" => %{"mode" => "auto"},
-         "headway_test" => %{"mode" => "headway"},
-         "MVAL0" => %{"mode" => "auto"}
+         "auto_test" => %{"mode" => "auto"}
        }
      }}
   end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -75,13 +75,7 @@ defmodule Signs.Utilities.Messages do
         Enum.map(config, fn {config, predictions, alert_status, first_scheduled_departures,
                              last_scheduled_departures, most_recent_departure, service_status} ->
           filtered_predictions =
-            filter_predictions(
-              predictions,
-              config,
-              sign_config,
-              current_time,
-              first_scheduled_departures
-            )
+            filter_predictions(predictions, config, current_time, first_scheduled_departures)
 
           alert_status = filter_alert_status(alert_status, sign_config)
 
@@ -184,11 +178,10 @@ defmodule Signs.Utilities.Messages do
   @spec filter_predictions(
           [Predictions.Prediction.t()],
           Signs.Utilities.SourceConfig.config(),
-          Engine.Config.sign_config(),
           DateTime.t(),
           DateTime.t()
         ) :: [Predictions.Prediction.t()]
-  defp filter_predictions(predictions, config, sign_config, current_time, scheduled) do
+  defp filter_predictions(predictions, config, current_time, scheduled) do
     predictions
     |> Enum.filter(fn p -> p.seconds_until_departure && p.schedule_relationship != :skipped end)
     |> Enum.sort_by(fn prediction ->
@@ -198,7 +191,6 @@ defmodule Signs.Utilities.Messages do
          true -> 1
        end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
-    |> then(fn predictions -> if(sign_config == :headway, do: [], else: predictions) end)
     |> filter_early_am_predictions(current_time, scheduled)
     |> filter_large_red_line_gaps()
     |> get_unique_destination_predictions(Signs.Utilities.SourceConfig.single_route(config))

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -49,8 +49,8 @@ defmodule Signs.Utilities.SourceConfig do
     ranges, and must match the values set by signs-ui. Most mezzanine signs show both directions
     of the same headway group, and so will have the same value for both configs. A notable
     exception is Ashmont, which handles both the Ashmont and Mattapan headway groups.
-  * headway_direction_name: The headsign used to generate the "trains every X minutes" message in
-    headway mode. Must be a value recognized by `PaEss.Utilities.headsign_to_destination/1`.
+  * headway_direction_name: The headsign used to generate the "trains every X minutes" headway
+    message. Must be a value recognized by `PaEss.Utilities.headsign_to_destination/1`.
   * terminal: whether this is a "terminal", and should use arrival or departure times in its
     countdown.
   * sources: A list of source objects (see below for details). The sources determine which

--- a/priv/config.json
+++ b/priv/config.json
@@ -1,13 +1,10 @@
 {
   "signs": {
     "chelsea_inbound": {
-      "mode": "headway"
+      "mode": "auto"
     },
     "chelsea_outbound": {
       "mode": "off"
-    },
-    "MVAL0": {
-      "mode": "auto"
     }
   }
 }

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -6,8 +6,7 @@ defmodule Engine.ConfigTest do
     test "is the provided default value when the sign is unspecified" do
       state = initialize_test_state(%{})
 
-      assert Engine.Config.sign_config(state.table_name_signs, "unspecified_sign", :headway) ==
-               :headway
+      assert Engine.Config.sign_config(state.table_name_signs, "unspecified_sign", :off) == :off
     end
 
     test "returns custom text when it's not expired" do
@@ -75,12 +74,6 @@ defmodule Engine.ConfigTest do
       initialize_test_state(%{table_name_signs: :config_test_auto})
 
       assert Engine.Config.sign_config(:config_test_auto, "auto_test", :off) == :auto
-    end
-
-    test "correctly loads config for a sign with a mode of \"headway\"" do
-      initialize_test_state(%{table_name_signs: :config_test_headway})
-
-      assert Engine.Config.sign_config(:config_test_headway, "headway_test", :off) == :headway
     end
 
     test "loads chelsea bridge config" do

--- a/test/external_config/local_test.exs
+++ b/test/external_config/local_test.exs
@@ -4,18 +4,17 @@ defmodule ExternalConfig.LocalTest do
   describe "get/1" do
     test "loads config from a local json file" do
       assert ExternalConfig.Local.get("version") ==
-               {"29027168",
+               {"92201010",
                 %{
                   "signs" => %{
-                    "chelsea_inbound" => %{"mode" => "headway"},
-                    "chelsea_outbound" => %{"mode" => "off"},
-                    "MVAL0" => %{"mode" => "auto"}
+                    "chelsea_inbound" => %{"mode" => "auto"},
+                    "chelsea_outbound" => %{"mode" => "off"}
                   }
                 }}
     end
 
     test "if the file is unchanged, returns :unchanged" do
-      assert ExternalConfig.Local.get("29027168") == :unchanged
+      assert ExternalConfig.Local.get("92201010") == :unchanged
     end
   end
 end

--- a/test/external_config/s3_test.exs
+++ b/test/external_config/s3_test.exs
@@ -4,7 +4,7 @@ defmodule ExternalConfig.S3Test do
   describe "get/1" do
     test "loads config from an external http request" do
       assert ExternalConfig.S3.get("version") ==
-               {"deadbeef1234", %{"chelsea_inbound" => %{"mode" => "headway"}}}
+               {"deadbeef1234", %{"chelsea_inbound" => %{"mode" => "auto"}}}
     end
 
     test "when it fails to get the config, uses an empty config" do

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -105,7 +105,6 @@ defmodule Signs.BusTest do
       stub(Engine.Config.Mock, :sign_config, fn
         "auto_sign", _default -> :auto
         "off_sign", _default -> :off
-        "headway", _default -> :headway
         "static_sign", _default -> {:static_text, {"custom", "message"}}
       end)
 
@@ -267,7 +266,7 @@ defmodule Signs.BusTest do
 
       state =
         Map.merge(@sign_state, %{
-          id: "headway",
+          id: "auto_sign",
           configs: [%{sources: [%{stop_id: "stop1", route_id: "741", direction_id: 0}]}]
         })
 
@@ -284,7 +283,7 @@ defmodule Signs.BusTest do
 
       state =
         Map.merge(@sign_state, %{
-          id: "headway",
+          id: "auto_sign",
           configs: [
             %{
               sources: [%{stop_id: "stop1", route_id: "741", direction_id: 0}],
@@ -311,7 +310,7 @@ defmodule Signs.BusTest do
 
       state =
         Map.merge(@sign_state, %{
-          id: "headway",
+          id: "auto_sign",
           top_configs: [
             %{
               sources: [%{stop_id: "stop1", route_id: "741", direction_id: 0}],
@@ -366,7 +365,7 @@ defmodule Signs.BusTest do
 
       state =
         Map.merge(@sign_state, %{
-          id: "headway",
+          id: "auto_sign",
           top_configs: [
             %{
               sources: [%{stop_id: "stop1", route_id: "741", direction_id: 0}],

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -446,38 +446,6 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
-    test "when sign is forced into headway mode but no alerts are present, displays headways" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
-      expect(Engine.Config.Mock, :headway_config, fn _, _ ->
-        %{@headway_config | range_high: 14}
-      end)
-
-      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :ashmont, arrival: 120)]
-      end)
-
-      expect_messages({"Southbound trains", "Every 11 to 14 min"})
-      Signs.Realtime.handle_info(:run_loop, @sign)
-    end
-
-    test "when sign is forced into headway mode but alerts are present, alert takes precedence" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
-      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
-        [prediction(destination: :ashmont, arrival: 120)]
-      end)
-
-      expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
-      expect_messages({"No Southbound svc", ""})
-
-      expect_audios([{:ad_hoc, {"No Southbound service.", :audio}}], [
-        {"No Southbound service.", nil}
-      ])
-
-      Signs.Realtime.handle_info(:run_loop, @sign)
-    end
-
     test "generates empty messages if no headway is configured for some reason" do
       expect(Engine.Config.Mock, :headway_config, fn _, _ -> nil end)
       expect_messages({"", ""})
@@ -1849,7 +1817,6 @@ defmodule Signs.RealtimeTest do
     end
 
     test "mezzanine sign, headways and shuttle alert" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
 
@@ -2333,8 +2300,6 @@ defmodule Signs.RealtimeTest do
         nil
       end)
 
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
 
       expect_messages({"No Southbound svc", ""})
@@ -2347,8 +2312,6 @@ defmodule Signs.RealtimeTest do
     end
 
     test "is not overnight period if in the thirty minute buffer" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
 
       expect_messages({"No Southbound svc", ""})
@@ -2361,8 +2324,6 @@ defmodule Signs.RealtimeTest do
     end
 
     test "does not play alerts when in the overnight period" do
-      expect(Engine.Config.Mock, :sign_config, fn _, _ -> :headway end)
-
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :station_closure end)
 
       expect_messages({"Southbound trains", "Every 11 to 13 min"})


### PR DESCRIPTION
It's no longer possible to set a sign to this mode in Signs UI. The previous use of this mode, to suppress the display of predictions, is now fulfilled by the Prediction Suppression tool in Screenplay.

**Asana Ticket:** https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210858867684207

#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] ~~Any new or changed functions have typespecs~~
- [ ] ~~Tests were added for any new functionality (don't just rely on Codecov)~~
- [ ] ~~If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project~~
- [x] This branch was deployed to dev-green and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [dev-green](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev-green%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
