### PR TITLE
Fixed Headway Timezone bug for Bus Times

### DIFF
--- a/lib/engine/config/headway.ex
+++ b/lib/engine/config/headway.ex
@@ -5,6 +5,7 @@ defmodule Engine.Config.Headway do
   @type headway_group :: String.t()
   @type time_period :: :peak | :off_peak | :saturday | :sunday
   @type headway_id :: {headway_group(), time_period()}
+  @time_zone Application.compile_env!(:realtime_signs, :time_zone)
 
   @type t :: %__MODULE__{
           headway_id: headway_id(),
@@ -33,12 +34,14 @@ defmodule Engine.Config.Headway do
 
   @spec current_time_period(DateTime.t()) :: time_period()
   def current_time_period(dt) do
-    # Subtract 3 hours, since the service day ends at 3 AM
-    day_of_week = DateTime.add(dt, -3, :hour) |> Date.day_of_week()
+    local_dt = DateTime.shift_zone!(dt, @time_zone)
+
+    # Subtract 4 hours, since the service day ends at 4 AM
+    day_of_week = DateTime.add(local_dt, -4, :hour) |> Date.day_of_week()
 
     rush_hour? =
-      (dt.hour >= 7 and dt.hour < 9) or (dt.hour >= 16 and dt.hour < 18) or
-        (dt.hour == 18 and dt.minute <= 30)
+      (local_dt.hour >= 7 and local_dt.hour < 9) or (local_dt.hour >= 16 and local_dt.hour < 18) or
+        (local_dt.hour == 18 and local_dt.minute <= 30)
 
     case {day_of_week, rush_hour?} do
       {6, _} -> :saturday

--- a/test/engine/config/headway_test.exs
+++ b/test/engine/config/headway_test.exs
@@ -28,7 +28,7 @@ defmodule Engine.Config.HeadwayTest do
       assert DateTime.new!(~D[2020-03-21], ~T[08:00:00], "America/New_York")
              |> Headway.current_time_period() == :saturday
 
-      assert DateTime.new!(~D[2020-03-22], ~T[12:00:00], "America/New_York")
+      assert DateTime.new!(~D[2020-03-23], ~T[03:30:00], "America/New_York")
              |> Headway.current_time_period() == :sunday
     end
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [RTS Timezone Offset = Inconsistent Headway Values on SL DUPs + PA/ESS](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211228746535321?focus=true)

Fixed a bug where the Bus Headways was using UTC to grab the Headway values instead of the correct EST/EDT timezone.
Also switched the `current_time_period` function to be a 4am service day end rather than 3am. 

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
