### PR TITLE
add SL eastbound abbreviations

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -458,7 +458,8 @@ defmodule PaEss.Utilities do
     {"Adams & Gallivan", ["Gallivn", "Gallivan"]},
     {"Waltham", ["Waltham"]},
     {"Haymarket", ["Haymrkt", "Haymarkt", "Haymarket"]},
-    {"Silver Line Way", ["Slvr Ln Way"]},
+    {"Design Center", ["Design Ctr"]},
+    {"Silver Line Way", ["SL Way"]},
     {"Gallivan Blvd", ["Gallivn", "Gallivan"]},
     {"Cobbs Corner Canton", ["Canton"]},
     {"Linden Square", ["Linden", "Linden Sq"]}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Add SL Eastbound Transitway headsigns to RTS](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208484126045844?focus=true)

This adds the missing `Design Ctr` abbreviation, and updates the `SL Way` one.