### PR TITLE
Support short signs for paginated text in announcements

### DIFF
--- a/lib/content/audio.ex
+++ b/lib/content/audio.ex
@@ -21,8 +21,8 @@ defprotocol Content.Audio do
   @doc "Converts an audio struct to the mid/vars params for the PA system"
   @spec to_params(Content.Audio.t()) :: value()
   def to_params(audio)
-  @spec to_tts(Content.Audio.t()) :: tts_value()
-  def to_tts(audio)
+  @spec to_tts(Content.Audio.t(), integer()) :: tts_value()
+  def to_tts(audio, max_text_length \\ 24)
   @spec to_logs(Content.Audio.t()) :: keyword()
   def to_logs(audio)
 end

--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -62,7 +62,7 @@ defmodule Content.Audio.Approaching do
       |> Utilities.audio_message(:audio_visual)
     end
 
-    def to_tts(%Content.Audio.Approaching{} = audio) do
+    def to_tts(%Content.Audio.Approaching{} = audio, max_text_length) do
       prefix = if audio.four_cars?, do: "Shorter 4 car ", else: ""
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
       approaching = if audio.four_cars?, do: "now approaching", else: "is now approaching"
@@ -77,7 +77,8 @@ defmodule Content.Audio.Approaching do
 
       {tts_text(audio),
        PaEss.Utilities.paginate_text(
-         "#{prefix}#{train} #{approaching}#{platform}#{new_cars}.#{followup}#{crowding}"
+         "#{prefix}#{train} #{approaching}#{platform}#{new_cars}.#{followup}#{crowding}",
+         max_text_length
        )}
     end
 

--- a/lib/content/audio/boarding_button.ex
+++ b/lib/content/audio/boarding_button.ex
@@ -7,11 +7,11 @@ defmodule Content.Audio.BoardingButton do
       Utilities.audio_message([:boarding_button_message], :audio_visual)
     end
 
-    def to_tts(%Content.Audio.BoardingButton{}) do
+    def to_tts(%Content.Audio.BoardingButton{}, max_text_length) do
       text =
         "Attention Passengers: To board the next train, please push the button on either side of the door."
 
-      {text, PaEss.Utilities.paginate_text(text)}
+      {text, PaEss.Utilities.paginate_text(text, max_text_length)}
     end
 
     def to_logs(%Content.Audio.BoardingButton{}) do

--- a/lib/content/audio/custom.ex
+++ b/lib/content/audio/custom.ex
@@ -17,7 +17,7 @@ defmodule Content.Audio.Custom do
       {:ad_hoc, {message, :audio}}
     end
 
-    def to_tts(%Content.Audio.Custom{} = audio) do
+    def to_tts(%Content.Audio.Custom{} = audio, _max_text_length) do
       {audio.message, nil}
     end
 

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -21,7 +21,7 @@ defmodule Content.Audio.FirstTrainScheduled do
       ])
     end
 
-    def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do
+    def to_tts(%Content.Audio.FirstTrainScheduled{} = audio, _max_text_length) do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
       {"The first #{train} departs at #{time}", nil}

--- a/lib/content/audio/no_service.ex
+++ b/lib/content/audio/no_service.ex
@@ -30,7 +30,7 @@ defmodule Content.Audio.NoService do
       {:ad_hoc, {tts_text(audio), :audio}}
     end
 
-    def to_tts(%Content.Audio.NoService{} = audio) do
+    def to_tts(%Content.Audio.NoService{} = audio, _max_text_length) do
       {tts_text(audio), nil}
     end
 

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -24,9 +24,10 @@ defmodule Content.Audio.Passthrough do
       )
     end
 
-    def to_tts(%Content.Audio.Passthrough{} = audio) do
+    def to_tts(%Content.Audio.Passthrough{} = audio, max_text_length) do
       text = tts_text(audio)
-      {text, PaEss.Utilities.paginate_text(text)}
+
+      {text, PaEss.Utilities.paginate_text(text, max_text_length)}
     end
 
     def to_logs(%Content.Audio.Passthrough{}) do

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -105,7 +105,7 @@ defmodule Content.Audio.Predictions do
       |> PaEss.Utilities.audio_message()
     end
 
-    def to_tts(%Content.Audio.Predictions{prediction: prediction} = audio) do
+    def to_tts(%Content.Audio.Predictions{prediction: prediction} = audio, _max_text_length) do
       destination = Content.Utilities.destination_for_prediction(prediction)
       next_or_following = if(audio.next_or_following == :next, do: "next", else: "following")
       train = PaEss.Utilities.train_description(destination, prediction.route_id)

--- a/lib/content/audio/service_ended.ex
+++ b/lib/content/audio/service_ended.ex
@@ -23,7 +23,7 @@ defmodule Content.Audio.ServiceEnded do
       Utilities.audio_message([destination, :service_ended])
     end
 
-    def to_tts(%Content.Audio.ServiceEnded{} = audio) do
+    def to_tts(%Content.Audio.ServiceEnded{} = audio, _max_text_length) do
       {tts_text(audio), nil}
     end
 

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -42,7 +42,7 @@ defmodule Content.Audio.TrackChange do
       )
     end
 
-    def to_tts(%Content.Audio.TrackChange{} = audio) do
+    def to_tts(%Content.Audio.TrackChange{} = audio, max_text_length) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
 
       platform =
@@ -54,7 +54,8 @@ defmodule Content.Audio.TrackChange do
         end
 
       text = "Track change: The next #{train} is now boarding on the #{platform} platform"
-      {text, PaEss.Utilities.paginate_text(text)}
+
+      {text, PaEss.Utilities.paginate_text(text, max_text_length)}
     end
 
     def to_logs(%Content.Audio.TrackChange{}) do

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -67,7 +67,7 @@ defmodule Content.Audio.TrainIsBoarding do
       )
     end
 
-    def to_tts(%Content.Audio.TrainIsBoarding{} = audio) do
+    def to_tts(%Content.Audio.TrainIsBoarding{} = audio, _max_text_length) do
       {tts_text(audio), nil}
     end
 

--- a/lib/content/audio/vehicles_to_destination.ex
+++ b/lib/content/audio/vehicles_to_destination.ex
@@ -34,7 +34,7 @@ defmodule Content.Audio.VehiclesToDestination do
       end
     end
 
-    def to_tts(%Content.Audio.VehiclesToDestination{} = audio) do
+    def to_tts(%Content.Audio.VehiclesToDestination{} = audio, _max_text_length) do
       {tts_text(audio), nil}
     end
 

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -9,6 +9,9 @@ defmodule PaEss.Utilities do
   @comma "21012"
   @period "21014"
   @stopped_regex ~r/Stopped (\d+) stops? away/
+  @short_sign_scu_ids ["SCOUSCU001"]
+  @width 24
+  @short_width 18
 
   @abbreviation_replacements [
     {~r"\bOL\b", "Orange Line"},
@@ -947,4 +950,10 @@ defmodule PaEss.Utilities do
         end
       end)
   end
+
+  def sign_length(scu_id) when scu_id in @short_sign_scu_ids, do: :short
+  def sign_length(_), do: :long
+
+  def max_text_length(scu_id) when scu_id in @short_sign_scu_ids, do: @short_width
+  def max_text_length(_), do: @width
 end

--- a/lib/pa_messages/pa_message.ex
+++ b/lib/pa_messages/pa_message.ex
@@ -20,8 +20,11 @@ defmodule PaMessages.PaMessage do
       {:ad_hoc, {visual_text, :audio_visual}}
     end
 
-    def to_tts(%PaMessages.PaMessage{visual_text: visual_text, audio_text: audio_text}) do
-      {audio_text, PaEss.Utilities.paginate_text(visual_text)}
+    def to_tts(
+          %PaMessages.PaMessage{visual_text: visual_text, audio_text: audio_text},
+          max_text_length
+        ) do
+      {audio_text, PaEss.Utilities.paginate_text(visual_text, max_text_length)}
     end
 
     def to_logs(%PaMessages.PaMessage{id: id, priority: priority, interval_in_ms: interval_in_ms}) do

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -187,10 +187,12 @@ defmodule Signs.Utilities.Audio do
 
   @spec send_audio(Signs.Realtime.t() | Signs.Bus.t(), [Content.Audio.t()]) :: :ok
   def send_audio(sign, audios) do
+    max_text_length = PaEss.Utilities.max_text_length(sign.scu_id)
+
     RealtimeSigns.sign_updater().play_message(
       sign,
       Enum.map(audios, &Content.Audio.to_params(&1)),
-      Enum.map(audios, &Content.Audio.to_tts(&1)),
+      Enum.map(audios, &Content.Audio.to_tts(&1, max_text_length)),
       case audios do
         [%PaMessages.PaMessage{priority: priority}] -> priority
         _ -> 2


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Announcement messages on short displays in new PA/ESS MW](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211262872771663?focus=true)

- Added support for short signs in cases we have short SCUs by explicitly paginating text in our TTS audio
- In announcements where we were paginating previously, now we have a text_length parameter that is :short or :long depending on if the sign is part of a list of short signs. :short announcements are paginated based on a smaller length (18) as opposed to the default 24
- Added tests and a helper module to define sign lengths

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
