### PR TITLE
fix: spell JFK/UMass consistently

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -114,7 +114,7 @@ defmodule PaEss.Utilities do
     {~r"\bDownt'?n Xng\b", "Downtown Crossing"},
     {~r"\bSouth Sta\b", "South Station"},
     {~r"\bPark St\b", "Park Street"},
-    {~r"\bJFK/Umass\b", "JFK Umass"},
+    {~r"\bJFK/UMass\b", "JFK UMass"},
     {~r"\bQuincy Ctr\b", "Quincy Center"},
     {~r"\bTufts Med\b", "Tufts Medical Center"},
     {~r"\bMalden Ctr\b", "Malden Center"},
@@ -288,7 +288,7 @@ defmodule PaEss.Utilities do
   def destination_to_sign_string("place-hwsst"), do: "Hawes St"
   def destination_to_sign_string("place-hymnl"), do: "Hynes"
   def destination_to_sign_string("place-jaksn"), do: "Jackson Sq"
-  def destination_to_sign_string("place-jfk"), do: "JFK/Umass"
+  def destination_to_sign_string("place-jfk"), do: "JFK/UMass"
   def destination_to_sign_string("place-kencl"), do: "Kenmore"
   def destination_to_sign_string("place-knncl"), do: "Kendall/MIT"
   def destination_to_sign_string("place-kntst"), do: "Kent St"

--- a/priv/stops.json
+++ b/priv/stops.json
@@ -163,7 +163,7 @@
     "route_ids": ["Red"],
     "stations":  [
       {"station": "R Andrew southbound", "stop_ids": ["70083"]},
-      {"station": "R JFK/Umass-Ashmont southbound", "stop_ids": ["70085"]},
+      {"station": "R JFK/UMass-Ashmont southbound", "stop_ids": ["70085"]},
       {"station": "R Savin Hill southbound", "stop_ids": ["70087"]},
       {"station": "R Fields Corner southbound", "stop_ids": ["70089"]},
       {"station": "R Shawmut southbound", "stop_ids": ["70091"]},
@@ -171,7 +171,7 @@
       {"station": "R Shawmut northbound", "stop_ids": ["70092"]},
       {"station": "R Fields Corner northbound", "stop_ids": ["70090"]},
       {"station": "R Savin Hill northbound", "stop_ids": ["70088"]},
-      {"station": "R JFK/Umass-Ashmont northbound", "stop_ids": ["70086"]},
+      {"station": "R JFK/UMass-Ashmont northbound", "stop_ids": ["70086"]},
       {"station": "R Andrew northbound", "stop_ids": ["70084"]}
     ]
   },
@@ -179,7 +179,7 @@
     "route_ids": ["Red"],
     "stations": [
       {"station": "R Andrew southbound", "stop_ids": ["70083"]},
-      {"station": "R JFK/Umass-Braintree southbound", "stop_ids": ["70095"]},
+      {"station": "R JFK/UMass-Braintree southbound", "stop_ids": ["70095"]},
       {"station": "R North Quincy southbound", "stop_ids": ["70097"]},
       {"station": "R Wollaston southbound", "stop_ids": ["70099"]},
       {"station": "R Quincy Center southbound", "stop_ids": ["70101"]},
@@ -189,7 +189,7 @@
       {"station": "R Quincy Center northbound", "stop_ids": ["70102"]},
       {"station": "R Wollaston northbound", "stop_ids": ["70100"]},
       {"station": "R North Quincy northbound", "stop_ids": ["70098"]},
-      {"station": "R JFK/Umass-Braintree northbound", "stop_ids": ["70096"]}
+      {"station": "R JFK/UMass-Braintree northbound", "stop_ids": ["70096"]}
     ]
   },
   "Orange":{


### PR DESCRIPTION
The occurrence in `destination_to_sign_string/1` is the one causing the issue Jim reported in Slack. However, I changed all other instances I was able to find to use the same consistent capitalization. (In particular the one in `@abbreviation_replacements` assumes OIOs will also be spelling it this way, though this detail will become less relevant once we update SignsUI to allow for custom audio equivalence.)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213878080964110