### PR TITLE
chore: remove otp notice, windows from readme

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -36,6 +36,6 @@ export SCREENPLAY_BASE_URL=https://screenplay-dev.mbtace.com
 #export TRIP_UPDATE_URL="https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/TripUpdates_enhanced.json"
 #export VEHICLE_POSITIONS_URL="https://s3.amazonaws.com/mbta-gtfs-s3/concentrate/VehiclePositions_enhanced.json"
 
-# Comma seprated list of sign ids to run for debugging purposes. If specified, these signs processes
+# Comma separated list of sign ids to run for debugging purposes. If specified, these signs processes
 # will be run in isolation to reduce log noise.
 #export ONLY_SIGN_IDS=lab_test_1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RealtimeSigns
 
-Here's a general overview of the realtime_signs application which should be helpful for getting oriented to how things work. Please keep this up to date -- if you change something major in the code (build process, renaming modules, significant functionality changes, new configuration, etc.) document it here!
+Here's a general overview of the realtime_signs (RTS) application which should be helpful for getting oriented to how things work. Please keep this up to date -- if you change something major in the code (build process, renaming modules, significant functionality changes, new configuration, etc.) document it here!
 
 ## Prerequisites
 
@@ -11,8 +11,6 @@ Here's a general overview of the realtime_signs application which should be help
 
 * If it's your first time using asdf, run `asdf plugin add erlang && asdf plugin add elixir`.
 * Run `asdf install` from the repository root.
-  <!-- Remove this if upgrading the Erlang/OTP version beyond 25 -->
-  * Note: If running macOS Sonoma on an Apple Silicon (ARM) machine, use `KERL_CONFIGURE_OPTIONS="--disable-jit" asdf install`[^1]
 * `mix deps.get` to fetch dependencies.
 * At this point you should be able to run `mix test` and get a clean build.
 * Copy `.envrc.template` to `.envrc`, then edit `.envrc` and make sure all required environment variables are set. When finished, run `direnv allow` to activate them.
@@ -26,28 +24,20 @@ First, ensure you have a basic working environment as described above, and in th
 3. Start realtime_signs.
 4. Open up http://localhost:5000 and you should see the signs data being populated by your local app.
 
-### Running locally in a docker container
-If you need to run realtime signs in a local docker container, there are a few extra steps you'll need to take.
-
-1. Follow the instructions in [this notion doc](https://www.notion.so/mbta-downtown-crossing/Creating-debugging-a-Windows-Docker-container-2f21af809c894aab8038d12ae9c54361) for your OS to set up docker
-2. Once docker is running on either your Windows machine or your Windows VM, run `docker build .` in the root directory of realtime_signs.
-3. In order to run the image, you'll need a number of env variables. It's probably easiest to add a env.list file to your local repo containing the neeed values. You can read about setting env variables in a container [here](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
-4. Run the image in a container with `docker run --env-file env.list [IMAG TAG]`
-
 ## Environment variables
 
 The application needs several environment variables to access external services. See `.envrc.template` for documentation. When running locally, these variables are provided by `direnv`. In deployed environments, they are provided by AWS Secrets Manager. When adding new environment variables, make sure to add them to both locations, as appropriate.
 
 ## Deploying
 
-Realtime Signs (dev and prod) runs as a Docker Swarm service in the MBTA's data center. Deployments happen from GitHub Actions (the Deploy to Dev and Deploy to Prod actions).
+Realtime Signs runs on on-prem servers. Deployments are managed with ECS Anywhere, which allows us to manage RTS deployments on those on-prem servers. Deployments are initiated through the following GitHub Actions:
 
-It requires repository secrets to be set in GitHub:
+- [Deploy to Dev Green](/.github/workflows/dev-green.yml)
+- [Deploy to Dev](/.github/workflows/dev.yml)
+- [Deploy to Prod](/.github/workflows/prod.yml)
 
-    AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY
+Deployment actions require the following repository secrets to be set in GitHub:
+
+    AWS_ROLE_ARN
     DOCKER_REPO (the ECR repository to push images into)
-
-
-
-[^1]: The way memory is allocated for the JIT in OTP 25 is prohibited in macOS Sonomoa. [Disabling the JIT fixes the issue](https://github.com/erlang/otp/issues/7687#issuecomment-1737184968). This has [been fixed in OTP-25.3.2.7](https://github.com/erlang/otp/commit/ac591a599b09b48b45a7125aa30ec5419ba3cc2f) and beyond.
+    SLACK_WEBHOOK


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** None

Remove macOS Sonoma callout from readme - since we're currently using
OTP v27, we can remove this callout from the README.

Local development in a Docker container does not happen, particularly in
a Windows context these days, remove the local docker container section.
The Notion document linked in this section did not exist when I began
going through the README as a part of onboarding.

Update the deployment section to align with how/where deployments occur
today.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
