### PR TITLE
remove Watts environment variables

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -17,11 +17,6 @@ export API_V3_URL=https://api-dev-green.mbtace.com
 #export CHELSEA_BRIDGE_USERNAME=
 #export CHELSEA_BRIDGE_PASSWORD=
 
-# URL and access key for Watts. Required. The staging key can be found in the shared 1Password vault,
-# in the "Watts Staging API key" entry.
-export WATTS_URL=https://watts-staging.mbtace.com
-#export WATTS_API_KEY=
-
 # URL and access key for Screenplay. Required. API keys can be found in the shared 1Password vault,
 # search for "Screenplay"
 export SCREENPLAY_BASE_URL=https://screenplay-dev.mbtace.com

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,8 +24,6 @@ if config_env() != :test do
     api_v3_url: System.get_env("API_V3_URL"),
     api_v3_key: System.get_env("API_V3_KEY"),
     scully_api_key: System.get_env("SCULLY_API_KEY"),
-    watts_url: System.get_env("WATTS_URL"),
-    watts_api_key: System.get_env("WATTS_API_KEY"),
     scu_ip_map: System.get_env("SCU_IP_MAP", "{}") |> Jason.decode!(),
     chelsea_bridge_password: System.get_env("CHELSEA_BRIDGE_PASSWORD"),
     chelsea_bridge_username: System.get_env("CHELSEA_BRIDGE_USERNAME"),


### PR DESCRIPTION
#### Summary of changes

Now that the audio caching changes are deployed, RTS doesn't need to call Watts, so we can clean up the environment variables.