### PR TITLE
fix: stop announcement cutoffs for Amory, Babcock

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -9,7 +9,7 @@ defmodule PaEss.Utilities do
   @comma "21012"
   @period "21014"
   @stopped_regex ~r/Stopped (\d+) stops? away/
-  @short_sign_scu_ids ["SCOUSCU001"]
+  @short_sign_scu_ids ["SCOUSCU001", "GAMOSCU001", "GBABSCU001"]
   @width 24
   @short_width 18
 

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -59,7 +59,7 @@ defmodule Content.Audio.UtilitiesTest do
       assert replace_abbreviations("OL, OK") == "Orange Line, OK"
     end
 
-    test "case insenstive replacement of 'SVC' with 'Service'" do
+    test "case insensitive replacement of 'SVC' with 'Service'" do
       assert replace_abbreviations("SvC, OK") == "Service, OK"
     end
   end
@@ -77,5 +77,22 @@ defmodule Content.Audio.UtilitiesTest do
     assert ["1", "21000", "2", "21000", "3"] = pad_takes(["1", "2", "3"])
     assert ["1", "21012", "21000", "2"] = pad_takes(["1", "21012", "2"])
     assert ["1", "21000", "2", "21014"] = pad_takes(["1", "2", "21014"])
+  end
+
+  describe "sign_length/1" do
+    test "returns :short for stations with shorter signs" do
+      assert :short = sign_length("SCOUSCU001")
+      assert :short = sign_length("GAMOSCU001")
+      assert :short = sign_length("GBABSCU001")
+    end
+  end
+
+  describe "max_text_length/1" do
+    test "returns a smaller character count for stations with shorter signs" do
+      short_width = 18
+      assert ^short_width = max_text_length("SCOUSCU001")
+      assert ^short_width = max_text_length("GAMOSCU001")
+      assert ^short_width = max_text_length("GBABSCU001")
+    end
   end
 end

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -78,21 +78,4 @@ defmodule Content.Audio.UtilitiesTest do
     assert ["1", "21012", "21000", "2"] = pad_takes(["1", "21012", "2"])
     assert ["1", "21000", "2", "21014"] = pad_takes(["1", "2", "21014"])
   end
-
-  describe "sign_length/1" do
-    test "returns :short for stations with shorter signs" do
-      assert :short = sign_length("SCOUSCU001")
-      assert :short = sign_length("GAMOSCU001")
-      assert :short = sign_length("GBABSCU001")
-    end
-  end
-
-  describe "max_text_length/1" do
-    test "returns a smaller character count for stations with shorter signs" do
-      short_width = 18
-      assert ^short_width = max_text_length("SCOUSCU001")
-      assert ^short_width = max_text_length("GAMOSCU001")
-      assert ^short_width = max_text_length("GBABSCU001")
-    end
-  end
 end


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** [Short DDX signs: fix announcement cutoffs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213814114047426)

Add the SCU ID's for Amory and Babcock on the Green Line to shorten the text shown on screens at these stations.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
