### PR TITLE
don't promote non-canonical destinations on second line

### DIFF
--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -24,6 +24,30 @@ defmodule Content.Utilities do
     RealtimeSigns.station_stop_engine().get_parent_stop(prediction.destination_stop_id)
   end
 
+  @canonical_destinations [
+    {"Red", 0, "place-asmnl"},
+    {"Red", 0, "place-brntn"},
+    {"Red", 1, "place-alfcl"},
+    {"Mattapan", 0, "place-matt"},
+    {"Mattapan", 1, "place-asmnl"},
+    {"Orange", 0, "place-forhl"},
+    {"Orange", 1, "place-ogmnl"},
+    {"Green-B", 0, "place-lake"},
+    {"Green-B", 1, "place-gover"},
+    {"Green-C", 0, "place-clmnl"},
+    {"Green-C", 1, "place-gover"},
+    {"Green-D", 0, "place-river"},
+    {"Green-D", 1, "place-unsqu"},
+    {"Green-E", 0, "place-hsmnl"},
+    {"Green-E", 1, "place-mdftf"},
+    {"Blue", 0, "place-bomnl"},
+    {"Blue", 1, "place-wondl"}
+  ]
+
+  def canonical_destination?(prediction) do
+    {prediction.route_id, prediction.direction_id, destination_for_prediction(prediction)} in @canonical_destinations
+  end
+
   @spec stop_track_number(String.t()) :: track_number() | nil
   def stop_track_number("Alewife-01"), do: 1
   def stop_track_number("Alewife-02"), do: 2

--- a/lib/content/utilities.ex
+++ b/lib/content/utilities.ex
@@ -24,25 +24,25 @@ defmodule Content.Utilities do
     RealtimeSigns.station_stop_engine().get_parent_stop(prediction.destination_stop_id)
   end
 
-  @canonical_destinations [
-    {"Red", 0, "place-asmnl"},
-    {"Red", 0, "place-brntn"},
-    {"Red", 1, "place-alfcl"},
-    {"Mattapan", 0, "place-matt"},
-    {"Mattapan", 1, "place-asmnl"},
-    {"Orange", 0, "place-forhl"},
-    {"Orange", 1, "place-ogmnl"},
-    {"Green-B", 0, "place-lake"},
-    {"Green-B", 1, "place-gover"},
-    {"Green-C", 0, "place-clmnl"},
-    {"Green-C", 1, "place-gover"},
-    {"Green-D", 0, "place-river"},
-    {"Green-D", 1, "place-unsqu"},
-    {"Green-E", 0, "place-hsmnl"},
-    {"Green-E", 1, "place-mdftf"},
-    {"Blue", 0, "place-bomnl"},
-    {"Blue", 1, "place-wondl"}
-  ]
+  @canonical_destinations MapSet.new([
+                            {"Red", 0, "place-asmnl"},
+                            {"Red", 0, "place-brntn"},
+                            {"Red", 1, "place-alfcl"},
+                            {"Mattapan", 0, "place-matt"},
+                            {"Mattapan", 1, "place-asmnl"},
+                            {"Orange", 0, "place-forhl"},
+                            {"Orange", 1, "place-ogmnl"},
+                            {"Green-B", 0, "place-lake"},
+                            {"Green-B", 1, "place-gover"},
+                            {"Green-C", 0, "place-clmnl"},
+                            {"Green-C", 1, "place-gover"},
+                            {"Green-D", 0, "place-river"},
+                            {"Green-D", 1, "place-unsqu"},
+                            {"Green-E", 0, "place-hsmnl"},
+                            {"Green-E", 1, "place-mdftf"},
+                            {"Blue", 0, "place-bomnl"},
+                            {"Blue", 1, "place-wondl"}
+                          ])
 
   def canonical_destination?(prediction) do
     {prediction.route_id, prediction.direction_id, destination_for_prediction(prediction)} in @canonical_destinations

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -227,7 +227,8 @@ defmodule Signs.Utilities.Messages do
         first_destination = Content.Utilities.destination_for_prediction(msg1)
 
         case Enum.find([msg2 | rest], fn x ->
-               Content.Utilities.destination_for_prediction(x) != first_destination
+               Content.Utilities.destination_for_prediction(x) != first_destination and
+                 Content.Utilities.canonical_destination?(x)
              end) do
           nil -> [msg1, msg2]
           preferred -> [msg1, preferred]

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -155,6 +155,7 @@ defmodule Signs.RealtimeTest do
     stub(Engine.StationStops.Mock, :get_parent_stop, fn
       "alewife" -> "place-alfcl"
       "ashmont" -> "place-asmnl"
+      "shawmut" -> "place-smmnl"
       "braintree" -> "place-brntn"
       "mattapan" -> "place-matt"
       "boston_college" -> "place-lake"
@@ -737,6 +738,19 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_messages({"Ashmont      2 min", "Braintree   12 min"})
+      Signs.Realtime.handle_info(:run_loop, @sign)
+    end
+
+    test "does not promote non-canonical destinations" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [
+          prediction(destination: :ashmont, arrival: 120),
+          prediction(destination: :ashmont, arrival: 500),
+          prediction(destination: :shawmut, arrival: 700)
+        ]
+      end)
+
+      expect_messages({"Ashmont      2 min", "Ashmont      8 min"})
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
@@ -2441,6 +2455,9 @@ defmodule Signs.RealtimeTest do
 
           :ashmont ->
             [route_id: "Red", direction_id: 0, destination_stop_id: "ashmont"]
+
+          :shawmut ->
+            [route_id: "Red", direction_id: 0, destination_stop_id: "shawmut"]
 
           :braintree ->
             [route_id: "Red", direction_id: 0, destination_stop_id: "braintree"]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Temp terminals that are far out being shown on PA/ESS](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213628670469069?focus=true)

This changes the "distinct destinations" logic to only consider canonical destinations for promotion to the second line of platform signs.