### PR TITLE
add pauses in audio readouts

### DIFF
--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -94,7 +94,7 @@ defmodule Content.Audio.Approaching do
           do: PaEss.Utilities.four_cars_text(),
           else: " Please stand back from the platform edge."
 
-      "Attention passengers: The next #{train} is now approaching#{platform}#{new_cars}.#{followup}#{crowding}"
+      "Attention passengers: The next#{train}; is now approaching#{platform}#{new_cars}.#{followup}#{crowding}"
     end
 
     defp platform_token(:ashmont), do: :on_the_ashmont_platform

--- a/lib/content/audio/approaching.ex
+++ b/lib/content/audio/approaching.ex
@@ -67,8 +67,8 @@ defmodule Content.Audio.Approaching do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
       approaching = if audio.four_cars?, do: "now approaching", else: "is now approaching"
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
-      platform = platform_string(audio.platform)
-      new_cars = new_cars_string(audio.new_cars? and not audio.four_cars?)
+      platform = if(s = platform_string(audio.platform), do: " #{s}")
+      new_cars = if(s = new_cars_string(audio), do: ", #{s}")
 
       followup =
         if audio.four_cars?,
@@ -87,24 +87,30 @@ defmodule Content.Audio.Approaching do
       train = Utilities.train_description(audio.destination, audio.route_id)
       crowding = PaEss.Utilities.crowding_text(audio.crowding_description)
       platform = platform_string(audio.platform)
-      new_cars = new_cars_string(audio.new_cars? and not audio.four_cars?)
+      new_cars = new_cars_string(audio)
 
       followup =
         if audio.four_cars?,
           do: PaEss.Utilities.four_cars_text(),
           else: " Please stand back from the platform edge."
 
-      "Attention passengers: The next#{train}; is now approaching#{platform}#{new_cars}.#{followup}#{crowding}"
+      main_sentence =
+        ["Attention passengers: The next, #{train}", "is now approaching", platform, new_cars]
+        |> PaEss.Utilities.tts_sentence()
+
+      "#{main_sentence}#{followup}#{crowding}"
     end
 
     defp platform_token(:ashmont), do: :on_the_ashmont_platform
     defp platform_token(:braintree), do: :on_the_braintree_platform
 
-    defp platform_string(:ashmont), do: " on the Ashmont platform"
-    defp platform_string(:braintree), do: " on the Braintree platform"
-    defp platform_string(_), do: ""
+    defp platform_string(:ashmont), do: "on the Ashmont platform"
+    defp platform_string(:braintree), do: "on the Braintree platform"
+    defp platform_string(_), do: nil
 
-    defp new_cars_string(true), do: ", with all new Red Line cars"
-    defp new_cars_string(false), do: ""
+    defp new_cars_string(audio) when audio.new_cars? and not audio.four_cars?,
+      do: "with all new Red Line cars"
+
+    defp new_cars_string(_), do: nil
   end
 end

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -24,7 +24,7 @@ defmodule Content.Audio.FirstTrainScheduled do
     def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
-      {"The first#{train} departs at #{time}", nil}
+      {["The first, #{train}", "departs at #{time}"] |> PaEss.Utilities.tts_sentence(), nil}
     end
 
     def to_logs(%Content.Audio.FirstTrainScheduled{}) do

--- a/lib/content/audio/first_train_scheduled.ex
+++ b/lib/content/audio/first_train_scheduled.ex
@@ -24,7 +24,7 @@ defmodule Content.Audio.FirstTrainScheduled do
     def to_tts(%Content.Audio.FirstTrainScheduled{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       time = Content.Utilities.render_datetime_as_time(audio.scheduled_time)
-      {"The first #{train} departs at #{time}", nil}
+      {"The first#{train} departs at #{time}", nil}
     end
 
     def to_logs(%Content.Audio.FirstTrainScheduled{}) do

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -25,18 +25,15 @@ defmodule Content.Audio.Passthrough do
     end
 
     def to_tts(%Content.Audio.Passthrough{} = audio) do
-      text = tts_text(audio)
+      train = PaEss.Utilities.train_description(audio.destination, nil)
+      train_visual = PaEss.Utilities.train_description(audio.destination, nil, :visual)
 
-      {text, text}
+      {"The next #{train} does not take passengers. Please stand back from the platform edge.",
+       "The next #{train_visual} does not take passengers. Please stand back from the platform edge."}
     end
 
     def to_logs(%Content.Audio.Passthrough{}) do
       []
-    end
-
-    defp tts_text(%Content.Audio.Passthrough{} = audio) do
-      train = PaEss.Utilities.train_description(audio.destination, nil)
-      "The next #{train} does not take passengers. Please stand back from the platform edge."
     end
   end
 end

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -28,7 +28,7 @@ defmodule Content.Audio.Passthrough do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       train_visual = PaEss.Utilities.train_description(audio.destination, nil, :visual)
 
-      {"The next#{train}; does not take passengers. Please stand back from the platform edge.",
+      {"The next, #{train}; does not take passengers. Please stand back from the platform edge.",
        "The next #{train_visual} does not take passengers. Please stand back from the platform edge."}
     end
 

--- a/lib/content/audio/passthrough.ex
+++ b/lib/content/audio/passthrough.ex
@@ -28,7 +28,7 @@ defmodule Content.Audio.Passthrough do
       train = PaEss.Utilities.train_description(audio.destination, nil)
       train_visual = PaEss.Utilities.train_description(audio.destination, nil, :visual)
 
-      {"The next #{train} does not take passengers. Please stand back from the platform edge.",
+      {"The next#{train}; does not take passengers. Please stand back from the platform edge.",
        "The next #{train_visual} does not take passengers. Please stand back from the platform edge."}
     end
 

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -125,8 +125,8 @@ defmodule Content.Audio.Predictions do
             cond do
               minutes == :arriving -> "is now arriving"
               minutes == :boarding -> "is now boarding"
-              audio.terminal? -> "departs in #{minutes} #{min_or_mins}"
-              true -> "arrives in #{minutes} #{min_or_mins}"
+              audio.terminal? -> "departs in [pause] #{minutes} [pause] #{min_or_mins}"
+              true -> "arrives in [pause] #{minutes} [pause] #{min_or_mins}"
             end
 
           qualifier =

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -114,7 +114,8 @@ defmodule Content.Audio.Predictions do
         if PaEss.Utilities.prediction_stopped?(prediction, audio.terminal?) do
           num_stops_away = PaEss.Utilities.prediction_stops_away(prediction)
           stop_or_stops = if(num_stops_away == 1, do: "stop", else: "stops")
-          "The #{next_or_following} #{train} is stopped #{num_stops_away} #{stop_or_stops} away."
+
+          "The #{next_or_following}#{train}; is stopped, #{num_stops_away}, #{stop_or_stops} away."
         else
           track_number = Content.Utilities.stop_track_number(prediction.stop_id)
           {platform, platform_prefix?, platform_tbd} = platform_status(audio)
@@ -125,18 +126,19 @@ defmodule Content.Audio.Predictions do
             cond do
               minutes == :arriving -> "is now arriving"
               minutes == :boarding -> "is now boarding"
-              audio.terminal? -> "departs in [pause] #{minutes} [pause] #{min_or_mins}"
-              true -> "arrives in [pause] #{minutes} [pause] #{min_or_mins}"
+              audio.terminal? -> "departs in, #{minutes}, #{min_or_mins}"
+              true -> "arrives in, #{minutes}, #{min_or_mins}"
             end
 
           qualifier =
             cond do
-              track_number -> " on track #{track_number}"
-              platform -> " on the #{platform_string(platform)} platform"
-              true -> ""
+              track_number -> "on track #{track_number}"
+              platform -> "on the #{platform_string(platform)} platform"
+              true -> nil
             end
 
-          {prefix, suffix} = if(platform_prefix?, do: {qualifier, ""}, else: {"", qualifier})
+          {prefix, suffix} =
+            if(platform_prefix?, do: {qualifier, nil}, else: {nil, qualifier})
 
           followup =
             case platform_tbd do
@@ -147,7 +149,12 @@ defmodule Content.Audio.Predictions do
 
           four_cars = if four_cars?(audio), do: PaEss.Utilities.four_cars_text(), else: ""
 
-          "The #{next_or_following} #{train}#{prefix} #{status}#{suffix}.#{followup}#{four_cars}"
+          main_sentence =
+            ["The #{next_or_following}#{train}", prefix, status, suffix]
+            |> Enum.reject(&is_nil/1)
+            |> Enum.join("; ")
+
+          "#{main_sentence}.#{followup}#{four_cars}"
         end
 
       {text, nil}

--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -109,13 +109,15 @@ defmodule Content.Audio.Predictions do
       destination = Content.Utilities.destination_for_prediction(prediction)
       next_or_following = if(audio.next_or_following == :next, do: "next", else: "following")
       train = PaEss.Utilities.train_description(destination, prediction.route_id)
+      the_train = "The #{next_or_following}, #{train}"
 
       text =
         if PaEss.Utilities.prediction_stopped?(prediction, audio.terminal?) do
           num_stops_away = PaEss.Utilities.prediction_stops_away(prediction)
           stop_or_stops = if(num_stops_away == 1, do: "stop", else: "stops")
 
-          "The #{next_or_following}#{train}; is stopped, #{num_stops_away}, #{stop_or_stops} away."
+          [the_train, "is stopped, #{num_stops_away}, #{stop_or_stops} away"]
+          |> PaEss.Utilities.tts_sentence()
         else
           track_number = Content.Utilities.stop_track_number(prediction.stop_id)
           {platform, platform_prefix?, platform_tbd} = platform_status(audio)
@@ -137,8 +139,7 @@ defmodule Content.Audio.Predictions do
               true -> nil
             end
 
-          {prefix, suffix} =
-            if(platform_prefix?, do: {qualifier, nil}, else: {nil, qualifier})
+          {prefix, suffix} = if(platform_prefix?, do: {qualifier, nil}, else: {nil, qualifier})
 
           followup =
             case platform_tbd do
@@ -149,12 +150,8 @@ defmodule Content.Audio.Predictions do
 
           four_cars = if four_cars?(audio), do: PaEss.Utilities.four_cars_text(), else: ""
 
-          main_sentence =
-            ["The #{next_or_following}#{train}", prefix, status, suffix]
-            |> Enum.reject(&is_nil/1)
-            |> Enum.join("; ")
-
-          "#{main_sentence}.#{followup}#{four_cars}"
+          main_sentence = [the_train, prefix, status, suffix] |> PaEss.Utilities.tts_sentence()
+          "#{main_sentence}#{followup}#{four_cars}"
         end
 
       {text, nil}

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -54,8 +54,9 @@ defmodule Content.Audio.TrackChange do
           "70199" -> "E"
         end
 
-      {"Track change: The next#{train} is now boarding on the, #{platform}, platform",
-       "Track change: The next #{train_visual} is now boarding on the, #{platform}, platform"}
+      {["Track change: The next, #{train}", "is now boarding", "on the, #{platform}, platform"]
+       |> PaEss.Utilities.tts_sentence(),
+       "Track change: The next #{train_visual} is now boarding on the #{platform} platform."}
     end
 
     def to_logs(%Content.Audio.TrackChange{}) do

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -54,8 +54,8 @@ defmodule Content.Audio.TrackChange do
           "70199" -> "E"
         end
 
-      {"Track change: The next #{train} is now boarding on the [pause] #{platform} [pause] platform",
-       "Track change: The next #{train_visual} is now boarding on the [pause] #{platform} [pause] platform"}
+      {"Track change: The next#{train} is now boarding on the, #{platform}, platform",
+       "Track change: The next #{train_visual} is now boarding on the, #{platform}, platform"}
     end
 
     def to_logs(%Content.Audio.TrackChange{}) do

--- a/lib/content/audio/track_change.ex
+++ b/lib/content/audio/track_change.ex
@@ -44,6 +44,7 @@ defmodule Content.Audio.TrackChange do
 
     def to_tts(%Content.Audio.TrackChange{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
+      train_visual = PaEss.Utilities.train_description(audio.destination, audio.route_id, :visual)
 
       platform =
         case audio.berth do
@@ -53,9 +54,8 @@ defmodule Content.Audio.TrackChange do
           "70199" -> "E"
         end
 
-      text = "Track change: The next #{train} is now boarding on the #{platform} platform"
-
-      {text, text}
+      {"Track change: The next #{train} is now boarding on the [pause] #{platform} [pause] platform",
+       "Track change: The next #{train_visual} is now boarding on the [pause] #{platform} [pause] platform"}
     end
 
     def to_logs(%Content.Audio.TrackChange{}) do

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -84,7 +84,7 @@ defmodule Content.Audio.TrainIsBoarding do
           do: PaEss.Utilities.four_cars_boarding_text(),
           else: ""
 
-      "The next #{train} is now boarding#{track}#{four_cars_boarding}"
+      "The next#{train}; is now boarding#{track}#{four_cars_boarding}"
     end
   end
 end

--- a/lib/content/audio/train_is_boarding.ex
+++ b/lib/content/audio/train_is_boarding.ex
@@ -77,14 +77,17 @@ defmodule Content.Audio.TrainIsBoarding do
 
     defp tts_text(%Content.Audio.TrainIsBoarding{} = audio) do
       train = PaEss.Utilities.train_description(audio.destination, audio.route_id)
-      track = if(audio.track_number, do: " on track #{audio.track_number}", else: ".")
+      track = if(audio.track_number, do: "on track #{audio.track_number}", else: nil)
 
       four_cars_boarding =
         if audio.four_cars_boarding?,
           do: PaEss.Utilities.four_cars_boarding_text(),
           else: ""
 
-      "The next#{train}; is now boarding#{track}#{four_cars_boarding}"
+      main_sentence =
+        ["The next, #{train}", "is now boarding", track] |> PaEss.Utilities.tts_sentence()
+
+      "#{main_sentence}#{four_cars_boarding}"
     end
   end
 end

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -195,9 +195,7 @@ defmodule PaEss.Updater do
   defp format_audio(text), do: %{type: "tts", text: ssml(text), voice_id: "Matthew"}
 
   defp ssml(text) do
-    content = xml_escape(text)
-
-    ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{content}</prosody></amazon:effect></speak>)
+    ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{xml_escape(text)}</prosody></amazon:effect></speak>)
   end
 
   defp create_tag() do

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -195,7 +195,7 @@ defmodule PaEss.Updater do
   defp format_audio(text), do: %{type: "tts", text: ssml(text), voice_id: "Matthew"}
 
   defp ssml(text) do
-    content = xml_escape(text) |> String.replace("[pause]", "<break />")
+    content = xml_escape(text)
 
     ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{content}</prosody></amazon:effect></speak>)
   end

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -195,7 +195,9 @@ defmodule PaEss.Updater do
   defp format_audio(text), do: %{type: "tts", text: ssml(text), voice_id: "Matthew"}
 
   defp ssml(text) do
-    ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{xml_escape(text)}</prosody></amazon:effect></speak>)
+    content = xml_escape(text) |> String.replace("[pause]", "<break />")
+
+    ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{content}</prosody></amazon:effect></speak>)
   end
 
   defp create_tag() do

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -514,13 +514,13 @@ defmodule PaEss.Utilities do
 
     case {route_text, av} do
       {nil, :audio} ->
-        "[pause] #{destination_text} [pause] train"
+        ", #{destination_text}, train"
 
       {nil, :visual} ->
         "#{destination_text} train"
 
       {route_text, :audio} ->
-        "[pause] #{route_text} [pause] train to [pause] #{destination_text} [pause]"
+        ", #{route_text}, train to, #{destination_text}"
 
       {route_text, :visual} ->
         "#{route_text} train to #{destination_text}"

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -514,13 +514,13 @@ defmodule PaEss.Utilities do
 
     case {route_text, av} do
       {nil, :audio} ->
-        ", #{destination_text}, train"
+        "#{destination_text}, train"
 
       {nil, :visual} ->
         "#{destination_text} train"
 
       {route_text, :audio} ->
-        ", #{route_text}, train to, #{destination_text}"
+        "#{route_text}, train to, #{destination_text}"
 
       {route_text, :visual} ->
         "#{route_text} train to #{destination_text}"
@@ -1239,6 +1239,13 @@ defmodule PaEss.Utilities do
   def audio_message(items, av \\ :audio) do
     vars = Enum.map(items, &audio_take/1) |> pad_takes()
     {:canned, {take_message_id(vars), vars, av}}
+  end
+
+  @spec tts_sentence([String.t() | nil]) :: String.t()
+  def tts_sentence(phrases) do
+    Enum.reject(phrases, &is_nil/1)
+    |> Enum.join("; ")
+    |> then(&"#{&1}.")
   end
 
   @spec paginate_text(String.t(), integer()) :: Content.Message.pages()

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -512,10 +512,18 @@ defmodule PaEss.Utilities do
         :visual -> destination_to_sign_string(destination)
       end
 
-    if route_text do
-      "#{route_text} train to #{destination_text}"
-    else
-      "#{destination_text} train"
+    case {route_text, av} do
+      {nil, :audio} ->
+        "[pause] #{destination_text} [pause] train"
+
+      {nil, :visual} ->
+        "#{destination_text} train"
+
+      {route_text, :audio} ->
+        "[pause] #{route_text} [pause] train to [pause] #{destination_text} [pause]"
+
+      {route_text, :visual} ->
+        "#{route_text} train to #{destination_text}"
     end
   end
 

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -1138,18 +1138,18 @@ defmodule Signs.Bus do
     |> Enum.zip_with(["next", "following"], fn prediction, next_or_following ->
       route =
         case PaEss.Utilities.prediction_route_name(prediction) do
-          nil -> ""
-          name -> "[pause] route #{name} [pause] "
+          nil -> " "
+          name -> ", route #{name}, "
         end
 
       time =
         case prediction_minutes(prediction, current_time) do
           0 -> "is now arriving"
-          1 -> "arrives in [pause] 1 [pause] minute"
-          m -> "arrives in [pause] #{m} [pause] minutes"
+          1 -> "arrives in, 1, minute"
+          m -> "arrives in, #{m}, minutes"
         end
 
-      "The #{next_or_following} #{route}bus to [pause] #{prediction.headsign} [pause] #{time}."
+      "The #{next_or_following}#{route}bus to, #{prediction.headsign}; #{time}."
     end)
   end
 

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -1139,17 +1139,17 @@ defmodule Signs.Bus do
       route =
         case PaEss.Utilities.prediction_route_name(prediction) do
           nil -> ""
-          name -> "route #{name} "
+          name -> "[pause] route #{name} [pause] "
         end
 
       time =
         case prediction_minutes(prediction, current_time) do
           0 -> "is now arriving"
-          1 -> "arrives in 1 minute"
-          m -> "arrives in #{m} minutes"
+          1 -> "arrives in [pause] 1 [pause] minute"
+          m -> "arrives in [pause] #{m} [pause] minutes"
         end
 
-      "The #{next_or_following} #{route}bus to #{prediction.headsign} #{time}."
+      "The #{next_or_following} #{route}bus to [pause] #{prediction.headsign} [pause] #{time}."
     end)
   end
 

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -183,8 +183,8 @@ defmodule Signs.BusTest do
         ],
         [
           {[
-             "The next route 14 bus to Wakefield Ave arrives in 2 minutes.",
-             "The following route 14 bus to Wakefield Ave arrives in 11 minutes."
+             "The next [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 2 [pause] minutes.",
+             "The following [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 11 [pause] minutes."
            ], nil}
         ]
       )
@@ -513,8 +513,8 @@ defmodule Signs.BusTest do
         ],
         [
           {[
-             "The next route 14 bus to Wakefield Ave arrives in 2 minutes.",
-             "The following route 14 bus to Wakefield Ave arrives in 11 minutes."
+             "The next [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 2 [pause] minutes.",
+             "The following [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 11 [pause] minutes."
            ], nil},
           {"The Chelsea Street bridge is raised. We expect this to last for at least 4 more minutes. SL3 buses may be delayed, detoured, or turned back.",
            "The Chelsea Street bridge is raised. We expect this to last for at least 4 more minutes. SL3 buses may be delayed, detoured, or turned back."},

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -183,8 +183,8 @@ defmodule Signs.BusTest do
         ],
         [
           {[
-             "The next [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 2 [pause] minutes.",
-             "The following [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 11 [pause] minutes."
+             "The next, route 14, bus to, Wakefield Ave; arrives in, 2, minutes.",
+             "The following, route 14, bus to, Wakefield Ave; arrives in, 11, minutes."
            ], nil}
         ]
       )
@@ -513,8 +513,8 @@ defmodule Signs.BusTest do
         ],
         [
           {[
-             "The next [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 2 [pause] minutes.",
-             "The following [pause] route 14 [pause] bus to [pause] Wakefield Ave [pause] arrives in [pause] 11 [pause] minutes."
+             "The next, route 14, bus to, Wakefield Ave; arrives in, 2, minutes.",
+             "The following, route 14, bus to, Wakefield Ave; arrives in, 11, minutes."
            ], nil},
           {"The Chelsea Street bridge is raised. We expect this to last for at least 4 more minutes. SL3 buses may be delayed, detoured, or turned back.",
            "The Chelsea Street bridge is raised. We expect this to last for at least 4 more minutes. SL3 buses may be delayed, detoured, or turned back."},

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -149,6 +149,16 @@ defmodule Signs.RealtimeTest do
       }
   }
 
+  @park_st_sign %{
+    @sign
+    | source_config: %{
+        @sign.source_config
+        | sources: [
+            %{@src | announce_arriving?: false, announce_boarding?: true, stop_id: "70198"}
+          ]
+      }
+  }
+
   setup :verify_on_exit!
 
   setup do
@@ -783,6 +793,36 @@ defmodule Signs.RealtimeTest do
       })
     end
 
+    test "Park St track change announcement" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [
+          prediction(
+            seconds_until_departure: 15,
+            stop_id: "70198",
+            route_id: "Green-B",
+            destination: :boston_college,
+            stopped: 0
+          )
+        ]
+      end)
+
+      expect_messages({"Boston Coll    BRD", ""})
+
+      expect_audios(
+        [
+          {:canned,
+           {"119", spaced(["540", "501", "536", "507", "4202", "544", "851", "538", "529"]),
+            :audio_visual}}
+        ],
+        [
+          {"Track change: The next, B, train to, Boston College; is now boarding; on the, D, platform.",
+           "Track change: The next B train to Boston Coll is now boarding on the D platform."}
+        ]
+      )
+
+      Signs.Realtime.handle_info(:run_loop, @park_st_sign)
+    end
+
     test "announces approaching" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :ashmont, arrival: 45, trip_id: "1")]
@@ -1352,11 +1392,18 @@ defmodule Signs.RealtimeTest do
       end)
 
       expect_messages({"Southbound train", "due 5:00"})
+
+      expect_audios(
+        [{:canned, {"113", spaced(["866", "787", "864", "927", "8004", "9000"]), :audio}}],
+        [{"The first, Southbound, train; departs at 5:00.", nil}]
+      )
+
       expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
 
       Signs.Realtime.handle_info(:run_loop, %{
         @sign
-        | current_time_fn: fn -> datetime(~T[04:00:00]) end
+        | current_time_fn: fn -> datetime(~T[04:00:00]) end,
+          tick_read: 0
       })
     end
 
@@ -1645,7 +1692,7 @@ defmodule Signs.RealtimeTest do
             :audio_visual}}
         ],
         [
-          {"Attention passengers: The next, Ashmont, train; is now approaching, with all new Red Line cars. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching; with all new Red Line cars. Please stand back from the platform edge.",
            "Ashmont train is now approaching, with all new Red Line cars. Please stand back from the platform edge."}
         ]
       )

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -225,7 +225,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}],
         [
-          {"The next Southbound train does not take passengers. Please stand back from the platform edge.",
+          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -245,7 +245,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}],
         [
-          {"The next Southbound train does not take passengers. Please stand back from the platform edge.",
+          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -279,7 +279,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next Southbound train does not take passengers. Please stand back from the platform edge.",
+          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -289,7 +289,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "892", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next Alewife train does not take passengers. Please stand back from the platform edge.",
+          {"The next [pause] Alewife [pause] train does not take passengers. Please stand back from the platform edge.",
            "The next Alewife train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -311,7 +311,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next Southbound train does not take passengers. Please stand back from the platform edge.",
+          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -540,7 +540,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4100", "864", "533", "641", "5008", "534"]), :audio}}],
-        [{"The next Mattapan train is stopped 8 stops away.", nil}]
+        [{"The next [pause] Mattapan [pause] train is stopped 8 stops away.", nil}]
       )
 
       assert {_, %{announced_stalls: [{"1", 8}]}} = Signs.Realtime.handle_info(:run_loop, @sign)
@@ -581,7 +581,7 @@ defmodule Signs.RealtimeTest do
         [
           {:canned, {"109", ["501", "21000", "4100", "21000", "864", "21000", "544"], :audio}}
         ],
-        [{"The next Mattapan train is now boarding.", nil}]
+        [{"The next [pause] Mattapan [pause] train is now boarding.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, @terminal_sign)
@@ -625,7 +625,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"109", spaced(["501", "4100", "864", "544"]), :audio}}],
-        [{"The next Mattapan train is now boarding.", nil}]
+        [{"The next [pause] Mattapan [pause] train is now boarding.", nil}]
       )
 
       assert {_, %{announced_boardings: ["1"]}} = Signs.Realtime.handle_info(:run_loop, @sign)
@@ -643,7 +643,10 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"111", spaced(["501", "537", "507", "4203", "544"]), :audio}}],
-        [{"The next C train to Cleveland Circle is now boarding.", nil}]
+        [
+          {"The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now boarding.",
+           nil}
+        ]
       )
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -665,7 +668,7 @@ defmodule Signs.RealtimeTest do
            {"114", spaced(["896", "903", "919", "904", "910", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"Attention passengers: The next C train to Cleveland Circle is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now approaching. Please stand back from the platform edge.",
            "C train to Clvlnd Cir is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -720,8 +723,9 @@ defmodule Signs.RealtimeTest do
           {:canned, {"111", spaced(["501", "536", "507", "4202", "544"]), :audio}}
         ],
         [
-          {"The next D train to Riverside is now boarding.", nil},
-          {"The next B train to Boston College is now boarding.", nil}
+          {"The next [pause] D [pause] train to [pause] Riverside [pause] is now boarding.", nil},
+          {"The next [pause] B [pause] train to [pause] Boston College [pause] is now boarding.",
+           nil}
         ]
       )
 
@@ -765,7 +769,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"103", ["869"], :audio_visual}}
         ],
         [
-          {"The next Wonderland train is now boarding.", nil},
+          {"The next [pause] Wonderland [pause] train is now boarding.", nil},
           {"Attention Passengers: To board the next train, please push the button on either side of the door.",
            "Attention Passengers: To board the next train, please push the button on either side of the door."}
         ]
@@ -791,7 +795,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Ashmont train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -809,7 +813,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Ashmont train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -840,7 +844,7 @@ defmodule Signs.RealtimeTest do
            {"114", spaced(["896", "903", "919", "904", "910", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"Attention passengers: The next C train to Cleveland Circle is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now approaching. Please stand back from the platform edge.",
            "C train to Clvlnd Cir is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -870,7 +874,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5002", "505"]), :audio}}],
-        [{"The next Ashmont train arrives in 2 minutes.", nil}]
+        [{"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | prev_prediction_keys: []})
@@ -895,7 +899,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Ashmont train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -918,7 +922,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "907", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Forest Hills train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Forest Hills [pause] train is now approaching. Please stand back from the platform edge.",
            "Frst Hills train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -942,7 +946,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "907", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Forest Hills train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Forest Hills [pause] train is now approaching. Please stand back from the platform edge.",
            "Frst Hills train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -968,8 +972,9 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5004", "505"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
-          {"The following Ashmont train arrives in 4 minutes.", nil}
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The following [pause] Ashmont [pause] train arrives in [pause] 4 [pause] minutes.",
+           nil}
         ]
       )
 
@@ -1001,7 +1006,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"184", ["5511", "5513"], :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
           {"Southbound trains every 11 to 13 minutes.", nil}
         ]
       )
@@ -1065,8 +1070,9 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5002", "505"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 1 minute.", nil},
-          {"The following Ashmont train arrives in 2 minutes.", nil}
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 1 [pause] minute.", nil},
+          {"The following [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.",
+           nil}
         ]
       )
 
@@ -1091,8 +1097,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["501", "4021", "864", "503", "504", "5001", "532"]), :audio}}
         ],
         [
-          {"The next Ashmont train is now boarding.", nil},
-          {"The next Braintree train arrives in 1 minute.", nil}
+          {"The next [pause] Ashmont [pause] train is now boarding.", nil},
+          {"The next [pause] Braintree [pause] train arrives in [pause] 1 [pause] minute.", nil}
         ]
       )
 
@@ -1119,8 +1125,9 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5002", "505"]), :audio}}
         ],
         [
-          {"The next Ashmont train is now arriving.", nil},
-          {"The following Ashmont train arrives in 2 minutes.", nil}
+          {"The next [pause] Ashmont [pause] train is now arriving.", nil},
+          {"The following [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.",
+           nil}
         ]
       )
 
@@ -1148,8 +1155,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"109", spaced(["501", "4000", "864", "24055"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
-          {"The next Alewife train is now arriving.", nil}
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The next [pause] Alewife [pause] train is now arriving.", nil}
         ]
       )
 
@@ -1173,7 +1180,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "533", "641", "5003", "534"]), :audio}}],
-        [{"The next Ashmont train is stopped 3 stops away.", nil}]
+        [{"The next [pause] Ashmont [pause] train is stopped 3 stops away.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_stalls: ["1", "2"]})
@@ -1195,7 +1202,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "533", "641", "5003", "534"]), :audio}}],
-        [{"The next Ashmont train is stopped 3 stops away.", nil}]
+        [{"The next [pause] Ashmont [pause] train is stopped 3 stops away.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_stalls: ["1"]})
@@ -1223,7 +1230,8 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Southbound trains every 11 to 13 minutes.", nil},
-          {"The next Alewife train arrives in 4 minutes on the Ashmont platform.", nil}
+          {"The next [pause] Alewife [pause] train arrives in [pause] 4 [pause] minutes on the Ashmont platform.",
+           nil}
         ]
       )
 
@@ -1254,8 +1262,8 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "503", "504", "5007", "505", "849"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 6 minutes.", nil},
-          {"The next Alewife train arrives in 7 minutes. We will announce the platform for boarding soon.",
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 6 [pause] minutes.", nil},
+          {"The next [pause] Alewife [pause] train arrives in [pause] 7 [pause] minutes. We will announce the platform for boarding soon.",
            nil}
         ]
       )
@@ -1286,8 +1294,8 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "503", "504", "5011", "505", "857"]), :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
-          {"The next Alewife train arrives in 11 minutes. We will announce the platform for boarding when the train is closer.",
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The next [pause] Alewife [pause] train arrives in [pause] 11 [pause] minutes. We will announce the platform for boarding when the train is closer.",
            nil}
         ]
       )
@@ -1323,8 +1331,9 @@ defmodule Signs.RealtimeTest do
             :audio}}
         ],
         [
-          {"The next Ashmont train arrives in 2 minutes.", nil},
-          {"The next Alewife train arrives in 6 minutes on the Ashmont platform.", nil}
+          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The next [pause] Alewife [pause] train arrives in [pause] 6 [pause] minutes on the Ashmont platform.",
+           nil}
         ]
       )
 
@@ -1643,7 +1652,7 @@ defmodule Signs.RealtimeTest do
             :audio_visual}}
         ],
         [
-          {"Attention passengers: The next Ashmont train is now approaching, with all new Red Line cars. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching, with all new Red Line cars. Please stand back from the platform edge.",
            "Ashmont train is now approaching, with all new Red Line cars. Please stand back from the platform edge."}
         ]
       )
@@ -1676,7 +1685,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Ashmont train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -1697,7 +1706,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["923", "902", "920", "924", "21014", "922"]), :audio_visual}}],
         [
-          {"Attention passengers: The next Braintree train is now approaching. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"Attention passengers: The next [pause] Braintree [pause] train is now approaching. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            "Shorter 4 car Braintree train now approaching. Please move to front of the train to board."}
         ]
       )
@@ -1721,7 +1730,7 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4021", "864", "503", "504", "5002", "505", "922"]), :audio}}
         ],
         [
-          {"The next Braintree train arrives in 2 minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"The next [pause] Braintree [pause] train arrives in [pause] 2 [pause] minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            nil}
         ]
       )
@@ -1750,8 +1759,9 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4021", "864", "502", "504", "5003", "505"]), :audio}}
         ],
         [
-          {"The next Braintree train departs in 2 minutes.", nil},
-          {"The following Braintree train departs in 3 minutes.", nil}
+          {"The next [pause] Braintree [pause] train departs in [pause] 2 [pause] minutes.", nil},
+          {"The following [pause] Braintree [pause] train departs in [pause] 3 [pause] minutes.",
+           nil}
         ]
       )
 
@@ -1780,7 +1790,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"111", spaced(["501", "4021", "864", "544", "926"]), :audio}}
         ],
         [
-          {"The next Braintree train is now boarding. It is a shorter 4-car train. You may have to move to a different part of the platform to board.",
+          {"The next [pause] Braintree [pause] train is now boarding. It is a shorter 4-car train. You may have to move to a different part of the platform to board.",
            nil}
         ]
       )
@@ -1808,7 +1818,7 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "502", "504", "5002", "505", "922"]), :audio}}
         ],
         [
-          {"The next Alewife train departs in 2 minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"The next [pause] Alewife [pause] train departs in [pause] 2 [pause] minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            nil}
         ]
       )
@@ -1833,8 +1843,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["501", "4000", "864", "503", "504", "5007", "505"]), :audio}}
         ],
         [
-          {"The next Braintree train arrives in 2 minutes.", nil},
-          {"The next Alewife train arrives in 7 minutes.", nil}
+          {"The next [pause] Braintree [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The next [pause] Alewife [pause] train arrives in [pause] 7 [pause] minutes.", nil}
         ]
       )
 
@@ -1928,8 +1938,10 @@ defmodule Signs.RealtimeTest do
             :audio}}
         ],
         [
-          {"The next Alewife train on the Ashmont platform arrives in 4 minutes.", nil},
-          {"The following Alewife train on the Ashmont platform arrives in 9 minutes.", nil}
+          {"The next [pause] Alewife [pause] train on the Ashmont platform arrives in [pause] 4 [pause] minutes.",
+           nil},
+          {"The following [pause] Alewife [pause] train on the Ashmont platform arrives in [pause] 9 [pause] minutes.",
+           nil}
         ]
       )
 
@@ -1948,7 +1960,10 @@ defmodule Signs.RealtimeTest do
           {:canned,
            {"117", spaced(["501", "4043", "864", "503", "504", "5004", "505", "541"]), :audio}}
         ],
-        [{"The next Forest Hills train arrives in 4 minutes on track 1.", nil}]
+        [
+          {"The next [pause] Forest Hills [pause] train arrives in [pause] 4 [pause] minutes on track 1.",
+           nil}
+        ]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0})
@@ -1973,7 +1988,7 @@ defmodule Signs.RealtimeTest do
         [
           {:canned, {"109", spaced(["501", "4043", "864", "544"]), :audio}}
         ],
-        [{"The next Forest Hills train is now boarding.", nil}]
+        [{"The next [pause] Forest Hills [pause] train is now boarding.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0})
@@ -2146,7 +2161,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"105", spaced(["787", "882"]), :audio}}
         ],
         [
-          {"The next Mattapan train is stopped 8 stops away.", nil},
+          {"The next [pause] Mattapan [pause] train is stopped 8 stops away.", nil},
           {"Southbound service has ended for the night.", nil}
         ]
       )
@@ -2202,7 +2217,8 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Southbound service has ended for the night.", nil},
-          {"The next Alewife train arrives in 4 minutes on the Ashmont platform.", nil}
+          {"The next [pause] Alewife [pause] train arrives in [pause] 4 [pause] minutes on the Ashmont platform.",
+           nil}
         ]
       )
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -225,7 +225,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}],
         [
-          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
+          {"The next, Southbound, train; does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -245,7 +245,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}],
         [
-          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
+          {"The next, Southbound, train; does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -279,7 +279,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
+          {"The next, Southbound, train; does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -289,7 +289,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "892", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next [pause] Alewife [pause] train does not take passengers. Please stand back from the platform edge.",
+          {"The next, Alewife, train; does not take passengers. Please stand back from the platform edge.",
            "The next Alewife train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -311,7 +311,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"112", spaced(["501", "787", "920", "933", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"The next [pause] Southbound [pause] train does not take passengers. Please stand back from the platform edge.",
+          {"The next, Southbound, train; does not take passengers. Please stand back from the platform edge.",
            "The next Southbound train does not take passengers. Please stand back from the platform edge."}
         ]
       )
@@ -540,7 +540,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4100", "864", "533", "641", "5008", "534"]), :audio}}],
-        [{"The next [pause] Mattapan [pause] train is stopped 8 stops away.", nil}]
+        [{"The next, Mattapan, train; is stopped, 8, stops away.", nil}]
       )
 
       assert {_, %{announced_stalls: [{"1", 8}]}} = Signs.Realtime.handle_info(:run_loop, @sign)
@@ -581,7 +581,7 @@ defmodule Signs.RealtimeTest do
         [
           {:canned, {"109", ["501", "21000", "4100", "21000", "864", "21000", "544"], :audio}}
         ],
-        [{"The next [pause] Mattapan [pause] train is now boarding.", nil}]
+        [{"The next, Mattapan, train; is now boarding.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, @terminal_sign)
@@ -625,7 +625,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"109", spaced(["501", "4100", "864", "544"]), :audio}}],
-        [{"The next [pause] Mattapan [pause] train is now boarding.", nil}]
+        [{"The next, Mattapan, train; is now boarding.", nil}]
       )
 
       assert {_, %{announced_boardings: ["1"]}} = Signs.Realtime.handle_info(:run_loop, @sign)
@@ -644,8 +644,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"111", spaced(["501", "537", "507", "4203", "544"]), :audio}}],
         [
-          {"The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now boarding.",
-           nil}
+          {"The next, C, train to, Cleveland Circle; is now boarding.", nil}
         ]
       )
 
@@ -668,7 +667,7 @@ defmodule Signs.RealtimeTest do
            {"114", spaced(["896", "903", "919", "904", "910", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"Attention passengers: The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, C, train to, Cleveland Circle; is now approaching. Please stand back from the platform edge.",
            "C train to Clvlnd Cir is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -723,9 +722,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"111", spaced(["501", "536", "507", "4202", "544"]), :audio}}
         ],
         [
-          {"The next [pause] D [pause] train to [pause] Riverside [pause] is now boarding.", nil},
-          {"The next [pause] B [pause] train to [pause] Boston College [pause] is now boarding.",
-           nil}
+          {"The next, D, train to, Riverside; is now boarding.", nil},
+          {"The next, B, train to, Boston College; is now boarding.", nil}
         ]
       )
 
@@ -769,7 +767,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"103", ["869"], :audio_visual}}
         ],
         [
-          {"The next [pause] Wonderland [pause] train is now boarding.", nil},
+          {"The next, Wonderland, train; is now boarding.", nil},
           {"Attention Passengers: To board the next train, please push the button on either side of the door.",
            "Attention Passengers: To board the next train, please push the button on either side of the door."}
         ]
@@ -795,7 +793,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -813,7 +811,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -844,7 +842,7 @@ defmodule Signs.RealtimeTest do
            {"114", spaced(["896", "903", "919", "904", "910", "21014", "925"]), :audio_visual}}
         ],
         [
-          {"Attention passengers: The next [pause] C [pause] train to [pause] Cleveland Circle [pause] is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, C, train to, Cleveland Circle; is now approaching. Please stand back from the platform edge.",
            "C train to Clvlnd Cir is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -874,7 +872,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5002", "505"]), :audio}}],
-        [{"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil}]
+        [{"The next, Ashmont, train; arrives in, 2, minutes.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | prev_prediction_keys: []})
@@ -899,7 +897,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -922,7 +920,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "907", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Forest Hills [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Forest Hills, train; is now approaching. Please stand back from the platform edge.",
            "Frst Hills train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -946,7 +944,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "907", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Forest Hills [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Forest Hills, train; is now approaching. Please stand back from the platform edge.",
            "Frst Hills train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -972,9 +970,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5004", "505"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
-          {"The following [pause] Ashmont [pause] train arrives in [pause] 4 [pause] minutes.",
-           nil}
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
+          {"The following, Ashmont, train; arrives in, 4, minutes.", nil}
         ]
       )
 
@@ -1006,7 +1003,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"184", ["5511", "5513"], :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
           {"Southbound trains every 11 to 13 minutes.", nil}
         ]
       )
@@ -1070,9 +1067,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5002", "505"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 1 [pause] minute.", nil},
-          {"The following [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.",
-           nil}
+          {"The next, Ashmont, train; arrives in, 1, minute.", nil},
+          {"The following, Ashmont, train; arrives in, 2, minutes.", nil}
         ]
       )
 
@@ -1097,8 +1093,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["501", "4021", "864", "503", "504", "5001", "532"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train is now boarding.", nil},
-          {"The next [pause] Braintree [pause] train arrives in [pause] 1 [pause] minute.", nil}
+          {"The next, Ashmont, train; is now boarding.", nil},
+          {"The next, Braintree, train; arrives in, 1, minute.", nil}
         ]
       )
 
@@ -1125,9 +1121,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4016", "864", "503", "504", "5002", "505"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train is now arriving.", nil},
-          {"The following [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.",
-           nil}
+          {"The next, Ashmont, train; is now arriving.", nil},
+          {"The following, Ashmont, train; arrives in, 2, minutes.", nil}
         ]
       )
 
@@ -1155,8 +1150,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"109", spaced(["501", "4000", "864", "24055"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
-          {"The next [pause] Alewife [pause] train is now arriving.", nil}
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
+          {"The next, Alewife, train; is now arriving.", nil}
         ]
       )
 
@@ -1180,7 +1175,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "533", "641", "5003", "534"]), :audio}}],
-        [{"The next [pause] Ashmont [pause] train is stopped 3 stops away.", nil}]
+        [{"The next, Ashmont, train; is stopped, 3, stops away.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_stalls: ["1", "2"]})
@@ -1202,7 +1197,7 @@ defmodule Signs.RealtimeTest do
 
       expect_audios(
         [{:canned, {"115", spaced(["501", "4016", "864", "533", "641", "5003", "534"]), :audio}}],
-        [{"The next [pause] Ashmont [pause] train is stopped 3 stops away.", nil}]
+        [{"The next, Ashmont, train; is stopped, 3, stops away.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0, announced_stalls: ["1"]})
@@ -1230,8 +1225,7 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Southbound trains every 11 to 13 minutes.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 4 [pause] minutes on the Ashmont platform.",
-           nil}
+          {"The next, Alewife, train; arrives in, 4, minutes; on the Ashmont platform.", nil}
         ]
       )
 
@@ -1262,8 +1256,8 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "503", "504", "5007", "505", "849"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 6 [pause] minutes.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 7 [pause] minutes. We will announce the platform for boarding soon.",
+          {"The next, Ashmont, train; arrives in, 6, minutes.", nil},
+          {"The next, Alewife, train; arrives in, 7, minutes. We will announce the platform for boarding soon.",
            nil}
         ]
       )
@@ -1294,8 +1288,8 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "503", "504", "5011", "505", "857"]), :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 11 [pause] minutes. We will announce the platform for boarding when the train is closer.",
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
+          {"The next, Alewife, train; arrives in, 11, minutes. We will announce the platform for boarding when the train is closer.",
            nil}
         ]
       )
@@ -1331,9 +1325,8 @@ defmodule Signs.RealtimeTest do
             :audio}}
         ],
         [
-          {"The next [pause] Ashmont [pause] train arrives in [pause] 2 [pause] minutes.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 6 [pause] minutes on the Ashmont platform.",
-           nil}
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
+          {"The next, Alewife, train; arrives in, 6, minutes; on the Ashmont platform.", nil}
         ]
       )
 
@@ -1652,7 +1645,7 @@ defmodule Signs.RealtimeTest do
             :audio_visual}}
         ],
         [
-          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching, with all new Red Line cars. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching, with all new Red Line cars. Please stand back from the platform edge.",
            "Ashmont train is now approaching, with all new Red Line cars. Please stand back from the platform edge."}
         ]
       )
@@ -1685,7 +1678,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["896", "895", "920", "910", "21014", "925"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Ashmont [pause] train is now approaching. Please stand back from the platform edge.",
+          {"Attention passengers: The next, Ashmont, train; is now approaching. Please stand back from the platform edge.",
            "Ashmont train is now approaching. Please stand back from the platform edge."}
         ]
       )
@@ -1706,7 +1699,7 @@ defmodule Signs.RealtimeTest do
       expect_audios(
         [{:canned, {"112", spaced(["923", "902", "920", "924", "21014", "922"]), :audio_visual}}],
         [
-          {"Attention passengers: The next [pause] Braintree [pause] train is now approaching. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"Attention passengers: The next, Braintree, train; is now approaching. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            "Shorter 4 car Braintree train now approaching. Please move to front of the train to board."}
         ]
       )
@@ -1730,7 +1723,7 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4021", "864", "503", "504", "5002", "505", "922"]), :audio}}
         ],
         [
-          {"The next [pause] Braintree [pause] train arrives in [pause] 2 [pause] minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"The next, Braintree, train; arrives in, 2, minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            nil}
         ]
       )
@@ -1759,9 +1752,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["667", "4021", "864", "502", "504", "5003", "505"]), :audio}}
         ],
         [
-          {"The next [pause] Braintree [pause] train departs in [pause] 2 [pause] minutes.", nil},
-          {"The following [pause] Braintree [pause] train departs in [pause] 3 [pause] minutes.",
-           nil}
+          {"The next, Braintree, train; departs in, 2, minutes.", nil},
+          {"The following, Braintree, train; departs in, 3, minutes.", nil}
         ]
       )
 
@@ -1790,7 +1782,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"111", spaced(["501", "4021", "864", "544", "926"]), :audio}}
         ],
         [
-          {"The next [pause] Braintree [pause] train is now boarding. It is a shorter 4-car train. You may have to move to a different part of the platform to board.",
+          {"The next, Braintree, train; is now boarding. It is a shorter 4-car train. You may have to move to a different part of the platform to board.",
            nil}
         ]
       )
@@ -1818,7 +1810,7 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4000", "864", "502", "504", "5002", "505", "922"]), :audio}}
         ],
         [
-          {"The next [pause] Alewife [pause] train departs in [pause] 2 [pause] minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
+          {"The next, Alewife, train; departs in, 2, minutes. It is a shorter 4-car train. Move toward the front of the train to board, and stand back from the platform edge.",
            nil}
         ]
       )
@@ -1843,8 +1835,8 @@ defmodule Signs.RealtimeTest do
           {:canned, {"115", spaced(["501", "4000", "864", "503", "504", "5007", "505"]), :audio}}
         ],
         [
-          {"The next [pause] Braintree [pause] train arrives in [pause] 2 [pause] minutes.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 7 [pause] minutes.", nil}
+          {"The next, Braintree, train; arrives in, 2, minutes.", nil},
+          {"The next, Alewife, train; arrives in, 7, minutes.", nil}
         ]
       )
 
@@ -1938,10 +1930,8 @@ defmodule Signs.RealtimeTest do
             :audio}}
         ],
         [
-          {"The next [pause] Alewife [pause] train on the Ashmont platform arrives in [pause] 4 [pause] minutes.",
-           nil},
-          {"The following [pause] Alewife [pause] train on the Ashmont platform arrives in [pause] 9 [pause] minutes.",
-           nil}
+          {"The next, Alewife, train; on the Ashmont platform; arrives in, 4, minutes.", nil},
+          {"The following, Alewife, train; on the Ashmont platform; arrives in, 9, minutes.", nil}
         ]
       )
 
@@ -1961,8 +1951,7 @@ defmodule Signs.RealtimeTest do
            {"117", spaced(["501", "4043", "864", "503", "504", "5004", "505", "541"]), :audio}}
         ],
         [
-          {"The next [pause] Forest Hills [pause] train arrives in [pause] 4 [pause] minutes on track 1.",
-           nil}
+          {"The next, Forest Hills, train; arrives in, 4, minutes; on track 1.", nil}
         ]
       )
 
@@ -1988,7 +1977,7 @@ defmodule Signs.RealtimeTest do
         [
           {:canned, {"109", spaced(["501", "4043", "864", "544"]), :audio}}
         ],
-        [{"The next [pause] Forest Hills [pause] train is now boarding.", nil}]
+        [{"The next, Forest Hills, train; is now boarding.", nil}]
       )
 
       Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 0})
@@ -2161,7 +2150,7 @@ defmodule Signs.RealtimeTest do
           {:canned, {"105", spaced(["787", "882"]), :audio}}
         ],
         [
-          {"The next [pause] Mattapan [pause] train is stopped 8 stops away.", nil},
+          {"The next, Mattapan, train; is stopped, 8, stops away.", nil},
           {"Southbound service has ended for the night.", nil}
         ]
       )
@@ -2217,8 +2206,7 @@ defmodule Signs.RealtimeTest do
         ],
         [
           {"Southbound service has ended for the night.", nil},
-          {"The next [pause] Alewife [pause] train arrives in [pause] 4 [pause] minutes on the Ashmont platform.",
-           nil}
+          {"The next, Alewife, train; arrives in, 4, minutes; on the Ashmont platform.", nil}
         ]
       )
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Add breaks around key elements of PA/ESS audio](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214236074987522?focus=true)

This adds pauses to the TTS outputs in order to emphasize the important parts of the messages. Includes a couple more cases not specified in the original ticket, but that follow the same intent:
* Train descriptions in non-revenue announcements, boarding announcements, first train messages, etc.
* Platform letters in "track change" announcements.
* Route names in long-form bus sign readouts.

The test changes provide a nice record of the effective behavior changes.