### PR TITLE
fix: suppress pa messages overnight 

### DIFF
--- a/lib/engine/alerts.ex
+++ b/lib/engine/alerts.ex
@@ -19,7 +19,7 @@ defmodule Engine.Alerts do
   @stops_table :alerts_by_stop
   @routes_table :alerts_by_route
 
-  # Platfrom stop IDs that don't receive Alerts
+  # Platform stop IDs that don't receive Alerts
   @platform_stop_ids MapSet.new([
                        "Alewife-01",
                        "Alewife-02",

--- a/lib/engine/pa_messages.ex
+++ b/lib/engine/pa_messages.ex
@@ -48,10 +48,14 @@ defmodule Engine.PaMessages do
     {:noreply, state}
   end
 
+  @spec select_pa_messages([PaMessages.PaMessage.t()], state()) ::
+          {[PaMessages.PaMessage.t()], state()}
   defp select_pa_messages(pa_messages, state) do
     now = DateTime.utc_now()
 
-    Enum.flat_map_reduce(pa_messages, state, fn message, state ->
+    pa_messages
+    |> Enum.reject(&is_overnight_and_non_emergency?/1)
+    |> Enum.flat_map_reduce(state, fn message, state ->
       last_sent = Map.get(state.pa_messages_last_sent, message.id, DateTime.from_unix!(0))
 
       if DateTime.diff(DateTime.utc_now(), last_sent, :millisecond) >= message.interval_in_ms do
@@ -60,6 +64,17 @@ defmodule Engine.PaMessages do
         {[], state}
       end
     end)
+  end
+
+  @spec is_overnight_and_non_emergency?(PaMessage.t()) :: boolean()
+  defp is_overnight_and_non_emergency?(pa_message) do
+    # emergencies will have a priority of 1 or less
+    Enum.all?(pa_message.sign_ids, &is_sign_in_overnight_period?(&1)) && pa_message.priority >= 2
+  end
+
+  @spec is_sign_in_overnight_period?(String.t()) :: boolean
+  defp is_sign_in_overnight_period?(sign_id) do
+    GenServer.call(:"Signs/#{sign_id}", {:overnight_status})
   end
 
   defp play_pa_messages(pa_messages) do

--- a/lib/engine/pa_messages.ex
+++ b/lib/engine/pa_messages.ex
@@ -53,9 +53,7 @@ defmodule Engine.PaMessages do
   defp select_pa_messages(pa_messages, state) do
     now = DateTime.utc_now()
 
-    pa_messages
-    |> Enum.reject(&is_overnight_and_non_emergency?/1)
-    |> Enum.flat_map_reduce(state, fn message, state ->
+    Enum.flat_map_reduce(pa_messages, state, fn message, state ->
       last_sent = Map.get(state.pa_messages_last_sent, message.id, DateTime.from_unix!(0))
 
       if DateTime.diff(DateTime.utc_now(), last_sent, :millisecond) >= message.interval_in_ms do
@@ -64,17 +62,6 @@ defmodule Engine.PaMessages do
         {[], state}
       end
     end)
-  end
-
-  @spec is_overnight_and_non_emergency?(PaMessage.t()) :: boolean()
-  defp is_overnight_and_non_emergency?(pa_message) do
-    # emergencies will have a priority of 1 or less
-    Enum.all?(pa_message.sign_ids, &is_sign_in_overnight_period?(&1)) && pa_message.priority >= 2
-  end
-
-  @spec is_sign_in_overnight_period?(String.t()) :: boolean
-  defp is_sign_in_overnight_period?(sign_id) do
-    GenServer.call(:"Signs/#{sign_id}", {:overnight_status})
   end
 
   defp play_pa_messages(pa_messages) do

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -115,14 +115,14 @@ defmodule Signs.Realtime do
   end
 
   def handle_call({:play_pa_message, pa_message}, _from, sign) do
-    {sign, should_play?} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)
-
     sign_in_overnight_period? =
       derive_sign_context(sign)
       |> Signs.Utilities.Messages.flatten_sign_context(sign)
       |> Signs.Utilities.Messages.in_overnight_period?()
 
-    should_play? = should_play? && !sign_in_overnight_period?
+    {sign, should_play?} =
+      Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign, sign_in_overnight_period?)
+
     {:reply, {sign, should_play?}, sign}
   end
 

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -119,6 +119,16 @@ defmodule Signs.Realtime do
     {:reply, {sign, should_play?}, sign}
   end
 
+  @spec handle_call({:overnight_status}, {pid(), term()}, t()) :: {:reply, boolean(), t()}
+  def handle_call({:overnight_status}, _from, sign) do
+    sign_in_overnight_period =
+      derive_sign_prediction_info(sign)
+      |> Signs.Utilities.Messages.flatten_sign_prediction_info(sign)
+      |> Signs.Utilities.Messages.in_overnight_period?()
+
+    {:reply, sign_in_overnight_period, sign}
+  end
+
   # TODO(now): Call out in review I will move this, it makes the diff easier in GH
   @spec derive_sign_prediction_info(t()) :: Signs.Utilities.SignPredictionInfo.t()
   defp derive_sign_prediction_info(sign) do

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -122,16 +122,16 @@ defmodule Signs.Realtime do
   @spec handle_call({:overnight_status}, {pid(), term()}, t()) :: {:reply, boolean(), t()}
   def handle_call({:overnight_status}, _from, sign) do
     sign_in_overnight_period =
-      derive_sign_prediction_info(sign)
-      |> Signs.Utilities.Messages.flatten_sign_prediction_info(sign)
+      derive_sign_context(sign)
+      |> Signs.Utilities.Messages.flatten_sign_context(sign)
       |> Signs.Utilities.Messages.in_overnight_period?()
 
     {:reply, sign_in_overnight_period, sign}
   end
 
   # TODO(now): Call out in review I will move this, it makes the diff easier in GH
-  @spec derive_sign_prediction_info(t()) :: Signs.Utilities.SignPredictionInfo.t()
-  defp derive_sign_prediction_info(sign) do
+  @spec derive_sign_context(t()) :: Signs.Utilities.SignContext.t()
+  defp derive_sign_context(sign) do
     sign_config = RealtimeSigns.config_engine().sign_config(sign.id, sign.default_mode)
     current_time = sign.current_time_fn.()
 
@@ -186,7 +186,7 @@ defmodule Signs.Realtime do
         &has_service_ended_for_source?(&1, current_time)
       )
 
-    %Signs.Utilities.SignPredictionInfo{
+    %Signs.Utilities.SignContext{
       predictions: predictions,
       all_predictions: all_predictions,
       sign_config: sign_config,
@@ -201,17 +201,17 @@ defmodule Signs.Realtime do
 
   def handle_info(:run_loop, sign) do
     # TODO(now): Call out in review there may be better abstraction/split here
-    sign_prediction_info =
-      %Signs.Utilities.SignPredictionInfo{
+    sign_context =
+      %Signs.Utilities.SignContext{
         predictions: predictions,
         all_predictions: all_predictions,
         current_time: current_time
-      } = derive_sign_prediction_info(sign)
+      } = derive_sign_context(sign)
 
     messages =
       Utilities.Messages.get_messages(
         sign,
-        sign_prediction_info
+        sign_context
       )
 
     {new_top, new_bottom} = Utilities.Messages.render_messages(messages)

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -196,7 +196,6 @@ defmodule Signs.Realtime do
   end
 
   def handle_info(:run_loop, sign) do
-    # TODO(now): Call out in review there may be better abstraction/split here
     sign_context =
       %Signs.Utilities.SignContext{
         predictions: predictions,

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -126,7 +126,6 @@ defmodule Signs.Realtime do
     {:reply, {sign, should_play?}, sign}
   end
 
-  # TODO(now): Call out in review I will move this, it makes the diff easier in GH
   @spec derive_sign_context(t()) :: Signs.Utilities.SignContext.t()
   defp derive_sign_context(sign) do
     sign_config = RealtimeSigns.config_engine().sign_config(sign.id, sign.default_mode)

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -119,7 +119,9 @@ defmodule Signs.Realtime do
     {:reply, {sign, should_play?}, sign}
   end
 
-  def handle_info(:run_loop, sign) do
+  # TODO(now): Call out in review I will move this, it makes the diff easier in GH
+  @spec derive_sign_prediction_info(t()) :: Signs.Utilities.SignPredictionInfo.t()
+  defp derive_sign_prediction_info(sign) do
     sign_config = RealtimeSigns.config_engine().sign_config(sign.id, sign.default_mode)
     current_time = sign.current_time_fn.()
 
@@ -174,17 +176,32 @@ defmodule Signs.Realtime do
         &has_service_ended_for_source?(&1, current_time)
       )
 
+    %Signs.Utilities.SignPredictionInfo{
+      predictions: predictions,
+      all_predictions: all_predictions,
+      sign_config: sign_config,
+      current_time: current_time,
+      alert_status: alert_status,
+      first_scheduled_departures: first_scheduled_departures,
+      last_scheduled_departures: last_scheduled_departures,
+      recent_departures: recent_departures,
+      service_end_statuses_per_source: service_end_statuses_per_source
+    }
+  end
+
+  def handle_info(:run_loop, sign) do
+    # TODO(now): Call out in review there may be better abstraction/split here
+    sign_prediction_info =
+      %Signs.Utilities.SignPredictionInfo{
+        predictions: predictions,
+        all_predictions: all_predictions,
+        current_time: current_time
+      } = derive_sign_prediction_info(sign)
+
     messages =
       Utilities.Messages.get_messages(
-        predictions,
         sign,
-        sign_config,
-        current_time,
-        alert_status,
-        first_scheduled_departures,
-        last_scheduled_departures,
-        recent_departures,
-        service_end_statuses_per_source
+        sign_prediction_info
       )
 
     {new_top, new_bottom} = Utilities.Messages.render_messages(messages)

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -116,17 +116,14 @@ defmodule Signs.Realtime do
 
   def handle_call({:play_pa_message, pa_message}, _from, sign) do
     {sign, should_play?} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, sign)
-    {:reply, {sign, should_play?}, sign}
-  end
 
-  @spec handle_call({:overnight_status}, {pid(), term()}, t()) :: {:reply, boolean(), t()}
-  def handle_call({:overnight_status}, _from, sign) do
-    sign_in_overnight_period =
+    sign_in_overnight_period? =
       derive_sign_context(sign)
       |> Signs.Utilities.Messages.flatten_sign_context(sign)
       |> Signs.Utilities.Messages.in_overnight_period?()
 
-    {:reply, sign_in_overnight_period, sign}
+    should_play? = should_play? && !sign_in_overnight_period?
+    {:reply, {sign, should_play?}, sign}
   end
 
   # TODO(now): Call out in review I will move this, it makes the diff easier in GH

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -229,16 +229,12 @@ defmodule Signs.Utilities.Audio do
 
   @spec log_send_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) :: :ok
   defp log_send_pa_message(pa_message, sign) do
-    Logger.info(
-      "pa_message: action=send id=#{pa_message.id} destination=#{sign.id} visual_text=#{pa_message.visual_text}"
-    )
+    Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
   end
 
   @spec log_skipped_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) ::
           :ok
   defp log_skipped_pa_message(pa_message, sign) do
-    Logger.warning(
-      "pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id} visual_text=#{pa_message.visual_text}"
-    )
+    Logger.warning("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
   end
 end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -201,14 +201,15 @@ defmodule Signs.Utilities.Audio do
 
   @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t(), boolean()) ::
           {Signs.Realtime.t(), boolean()}
-  def handle_pa_message_play(pa_message, %Signs.Realtime{} = sign, true) do
+  def handle_pa_message_play(pa_message, %Signs.Realtime{} = sign, true)
+      when pa_message.priority >= 2 do
     log_skipped_pa_message(pa_message, sign)
     {sign, false}
   end
 
   @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t(), boolean()) ::
           {Signs.Realtime.t(), boolean()}
-  def handle_pa_message_play(pa_message, sign, false) do
+  def handle_pa_message_play(pa_message, sign, _overnight_mode) do
     handle_pa_message_play(pa_message, sign)
   end
 

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -229,12 +229,16 @@ defmodule Signs.Utilities.Audio do
 
   @spec log_send_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) :: :ok
   defp log_send_pa_message(pa_message, sign) do
-    Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
+    Logger.info(
+      "pa_message: action=send id=#{pa_message.id} destination=#{sign.id} visual_text=#{pa_message.visual_text}"
+    )
   end
 
   @spec log_skipped_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) ::
           :ok
   defp log_skipped_pa_message(pa_message, sign) do
-    Logger.warning("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
+    Logger.warning(
+      "pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id} visual_text=#{pa_message.visual_text}"
+    )
   end
 end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -199,6 +199,19 @@ defmodule Signs.Utilities.Audio do
     )
   end
 
+  @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t(), boolean()) ::
+          {Signs.Realtime.t(), boolean()}
+  def handle_pa_message_play(pa_message, %Signs.Realtime{} = sign, true) do
+    log_skipped_pa_message(pa_message, sign)
+    {sign, false}
+  end
+
+  @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t(), boolean()) ::
+          {Signs.Realtime.t(), boolean()}
+  def handle_pa_message_play(pa_message, sign, false) do
+    handle_pa_message_play(pa_message, sign)
+  end
+
   @spec handle_pa_message_play(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) ::
           {Signs.Realtime.t() | Signs.Bus.t(), boolean()}
   def handle_pa_message_play(pa_message, sign) do
@@ -206,11 +219,22 @@ defmodule Signs.Utilities.Audio do
     now = DateTime.utc_now()
 
     if !last_sent || DateTime.diff(now, last_sent, :millisecond) >= pa_message.interval_in_ms do
-      Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
+      log_send_pa_message(pa_message, sign)
       {update_in(sign.pa_message_plays, &Map.put(&1, pa_message.id, now)), true}
     else
-      Logger.warning("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
+      log_skipped_pa_message(pa_message, sign)
       {sign, false}
     end
+  end
+
+  @spec log_send_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) :: :ok
+  defp log_send_pa_message(pa_message, sign) do
+    Logger.info("pa_message: action=send id=#{pa_message.id} destination=#{sign.id}")
+  end
+
+  @spec log_skipped_pa_message(PaMessages.PaMessage.t(), Signs.Realtime.t() | Signs.Bus.t()) ::
+          :ok
+  defp log_skipped_pa_message(pa_message, sign) do
+    Logger.warning("pa_message: action=skipped id=#{pa_message.id} destination=#{sign.id}")
   end
 end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -8,7 +8,7 @@ defmodule Signs.Utilities.Messages do
   @early_am_buffer -40
   @overnight_buffer 30
 
-  @type flattened_sign_prediction_info :: {
+  @type flattened_sign_context :: {
           Signs.Utilities.SourceConfig.config(),
           list(Signs.Realtime.predictions()),
           Signs.Realtime.t(),
@@ -22,18 +22,18 @@ defmodule Signs.Utilities.Messages do
 
   @spec get_messages(
           Signs.Realtime.t(),
-          Signs.Utilities.SignPredictionInfo.t()
+          Signs.Utilities.SignContext.t()
         ) :: [Message.t()]
   def get_messages(
         sign,
-        sign_prediction_info = %Signs.Utilities.SignPredictionInfo{
+        sign_context = %Signs.Utilities.SignContext{
           current_time: current_time,
           sign_config: sign_config
         }
       ) do
     config =
-      flatten_sign_prediction_info(
-        sign_prediction_info,
+      flatten_sign_context(
+        sign_context,
         sign
       )
 
@@ -71,13 +71,13 @@ defmodule Signs.Utilities.Messages do
     |> transform_messages()
   end
 
-  @spec flatten_sign_prediction_info(
-          Signs.Utilities.SignPredictionInfo.t(),
+  @spec flatten_sign_context(
+          Signs.Utilities.SignContext.t(),
           Signs.Realtime.t()
         ) ::
-          list(flattened_sign_prediction_info())
-  def flatten_sign_prediction_info(
-        %Signs.Utilities.SignPredictionInfo{
+          list(flattened_sign_context())
+  def flatten_sign_context(
+        %Signs.Utilities.SignContext{
           predictions: predictions,
           current_time: current_time,
           alert_status: alert_status,
@@ -120,7 +120,7 @@ defmodule Signs.Utilities.Messages do
     end)
   end
 
-  @spec in_overnight_period?(list(flattened_sign_prediction_info())) :: boolean()
+  @spec in_overnight_period?(list(flattened_sign_context())) :: boolean()
   def in_overnight_period?(config) do
     Enum.all?(config, fn {_config, _predictions, _alert_status, _first_scheduled_departures,
                           _last_scheduled_departures, _most_recent_departure, _service_status,

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -8,67 +8,36 @@ defmodule Signs.Utilities.Messages do
   @early_am_buffer -40
   @overnight_buffer 30
 
-  @spec get_messages(
-          Signs.Realtime.predictions(),
+  @type flattened_sign_prediction_info :: {
+          Signs.Utilities.SourceConfig.config(),
+          list(Signs.Realtime.predictions()),
           Signs.Realtime.t(),
-          Engine.Config.sign_config(),
+          Engine.Alerts.Fetcher.stop_status(),
           DateTime.t(),
-          Engine.Alerts.Fetcher.stop_status()
-          | {Engine.Alerts.Fetcher.stop_status(), Engine.Alerts.Fetcher.stop_status()},
-          DateTime.t() | {DateTime.t(), DateTime.t()},
-          DateTime.t() | {DateTime.t(), DateTime.t()},
-          DateTime.t() | {DateTime.t(), DateTime.t()},
-          boolean() | {boolean(), boolean()}
+          DateTime.t(),
+          DateTime.t(),
+          boolean(),
+          boolean()
+        }
+
+  @spec get_messages(
+          Signs.Realtime.t(),
+          Signs.Utilities.SignPredictionInfo.t()
         ) :: [Message.t()]
   def get_messages(
-        predictions,
         sign,
-        sign_config,
-        current_time,
-        alert_status,
-        first_scheduled_departures,
-        last_scheduled_departures,
-        most_recent_departure,
-        service_status
+        sign_prediction_info = %Signs.Utilities.SignPredictionInfo{
+          current_time: current_time,
+          sign_config: sign_config
+        }
       ) do
     config =
-      if match?(%{source_config: {_, _}}, sign) do
-        Enum.zip([
-          Tuple.to_list(sign.source_config),
-          Tuple.to_list(predictions),
-          Tuple.to_list(alert_status),
-          Tuple.to_list(first_scheduled_departures),
-          Tuple.to_list(last_scheduled_departures),
-          Tuple.to_list(most_recent_departure),
-          Tuple.to_list(service_status)
-        ])
-      else
-        [
-          {sign.source_config, predictions, alert_status, first_scheduled_departures,
-           last_scheduled_departures, most_recent_departure, service_status}
-        ]
-      end
-      |> Enum.map(fn {_config, _predictions, _alert_status, first_scheduled_departures,
-                      last_scheduled_departures, most_recent_departure,
-                      service_status} = sign_config ->
-        Tuple.append(
-          sign_config,
-          overnight_period?(
-            current_time,
-            first_scheduled_departures,
-            last_scheduled_departures,
-            most_recent_departure,
-            service_status
-          )
-        )
-      end)
+      flatten_sign_prediction_info(
+        sign_prediction_info,
+        sign
+      )
 
-    sign_in_overnight_period =
-      Enum.all?(config, fn {_config, _predictions, _alert_status, _first_scheduled_departures,
-                            _last_scheduled_departures, _most_recent_departure, _service_status,
-                            in_overnight_period} ->
-        in_overnight_period
-      end)
+    sign_in_overnight_period = in_overnight_period?(config)
 
     cond do
       match?({:static_text, {_, _}}, sign_config) ->
@@ -100,6 +69,64 @@ defmodule Signs.Utilities.Messages do
         end)
     end
     |> transform_messages()
+  end
+
+  @spec flatten_sign_prediction_info(
+          Signs.Utilities.SignPredictionInfo.t(),
+          Signs.Realtime.t()
+        ) ::
+          list(flattened_sign_prediction_info())
+  def flatten_sign_prediction_info(
+        %Signs.Utilities.SignPredictionInfo{
+          predictions: predictions,
+          current_time: current_time,
+          alert_status: alert_status,
+          first_scheduled_departures: first_scheduled_departures,
+          last_scheduled_departures: last_scheduled_departures,
+          recent_departures: recent_departures,
+          service_end_statuses_per_source: service_end_statuses_per_source
+        },
+        sign
+      ) do
+    if match?(%{source_config: {_, _}}, sign) do
+      Enum.zip([
+        Tuple.to_list(sign.source_config),
+        Tuple.to_list(predictions),
+        Tuple.to_list(alert_status),
+        Tuple.to_list(first_scheduled_departures),
+        Tuple.to_list(last_scheduled_departures),
+        Tuple.to_list(recent_departures),
+        Tuple.to_list(service_end_statuses_per_source)
+      ])
+    else
+      [
+        {sign.source_config, predictions, alert_status, first_scheduled_departures,
+         last_scheduled_departures, recent_departures, service_end_statuses_per_source}
+      ]
+    end
+    |> Enum.map(fn {_config, _predictions, _alert_status, first_scheduled_departures,
+                    last_scheduled_departures, most_recent_departure,
+                    service_status} = sign_config ->
+      Tuple.append(
+        sign_config,
+        overnight_period?(
+          current_time,
+          first_scheduled_departures,
+          last_scheduled_departures,
+          most_recent_departure,
+          service_status
+        )
+      )
+    end)
+  end
+
+  @spec in_overnight_period?(list(flattened_sign_prediction_info())) :: boolean()
+  def in_overnight_period?(config) do
+    Enum.all?(config, fn {_config, _predictions, _alert_status, _first_scheduled_departures,
+                          _last_scheduled_departures, _most_recent_departure, _service_status,
+                          in_overnight_period} ->
+      in_overnight_period
+    end)
   end
 
   @spec transform_messages([Message.t()]) :: [Message.t()]

--- a/lib/signs/utilities/sign_context.ex
+++ b/lib/signs/utilities/sign_context.ex
@@ -1,4 +1,4 @@
-defmodule Signs.Utilities.SignPredictionInfo do
+defmodule Signs.Utilities.SignContext do
   @moduledoc false
 
   @enforce_keys [

--- a/lib/signs/utilities/sign_prediction_info.ex
+++ b/lib/signs/utilities/sign_prediction_info.ex
@@ -1,4 +1,6 @@
 defmodule Signs.Utilities.SignPredictionInfo do
+  @moduledoc false
+
   @enforce_keys [
     :predictions,
     :all_predictions,

--- a/lib/signs/utilities/sign_prediction_info.ex
+++ b/lib/signs/utilities/sign_prediction_info.ex
@@ -1,0 +1,27 @@
+defmodule Signs.Utilities.SignPredictionInfo do
+  @enforce_keys [
+    :predictions,
+    :all_predictions,
+    :sign_config,
+    :current_time,
+    :alert_status,
+    :first_scheduled_departures,
+    :last_scheduled_departures,
+    :recent_departures,
+    :service_end_statuses_per_source
+  ]
+  defstruct @enforce_keys
+
+  @type single_or_tuple(t) :: t | {t, t}
+  @type t :: %__MODULE__{
+          predictions: Signs.Realtime.predictions(),
+          all_predictions: list(Predictions.Prediction.t()),
+          sign_config: Engine.Config.sign_config(),
+          current_time: DateTime.t(),
+          alert_status: single_or_tuple(Engine.Alerts.Fetcher.stop_status()),
+          first_scheduled_departures: single_or_tuple(nil | DateTime.t()),
+          last_scheduled_departures: single_or_tuple(nil | DateTime.t()),
+          recent_departures: single_or_tuple(nil | DateTime.t()),
+          service_end_statuses_per_source: single_or_tuple(boolean())
+        }
+end

--- a/lib/signs/utilities/source_config.ex
+++ b/lib/signs/utilities/source_config.ex
@@ -1,6 +1,6 @@
 defmodule Signs.Utilities.SourceConfig do
   @moduledoc """
-  Configuration for a sign's data sourcess, via JSON. Configuration of a sign looks like:
+  Configuration for a sign's data sources, via JSON. Configuration of a sign looks like:
 
   ## Sign (zone) config
 
@@ -45,7 +45,7 @@ defmodule Signs.Utilities.SourceConfig do
   object as defined below. For mezzanine signs, this will be a list of two of these objects,
   which will cause each line to display separately using the corresponding config.
 
-  * headway_group: This determines which headway group to look up when getting headyway time
+  * headway_group: This determines which headway group to look up when getting headway time
     ranges, and must match the values set by signs-ui. Most mezzanine signs show both directions
     of the same headway group, and so will have the same value for both configs. A notable
     exception is Ashmont, which handles both the Ashmont and Mattapan headway groups.

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -2299,6 +2299,28 @@ defmodule Signs.RealtimeTest do
       assert {:reply, {_, false}, _} =
                Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
     end
+
+    test "Does not play if the sign is in overnight mode" do
+      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn ["1"] ->
+        ~U[2026-05-17 08:30:00Z]
+      end)
+
+      expect(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn ["1"] ->
+        ~U[2026-05-18 03:30:00Z]
+      end)
+
+      pa_message = %PaMessages.PaMessage{
+        id: 1,
+        visual_text: "A PA Message",
+        audio_text: "A PA Message",
+        interval_in_ms: 120_000
+      }
+
+      sign = %{@sign | current_time_fn: fn -> datetime(~D[2026-05-18], ~T[03:00:00]) end}
+
+      assert {:reply, {_, false}, _} =
+               Signs.Realtime.handle_call({:play_pa_message, pa_message}, nil, sign)
+    end
   end
 
   describe "Overnight Period" do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -175,6 +175,7 @@ defmodule Signs.RealtimeTest do
       stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :none end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> true end)
+      stub(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn _ -> nil end)
       stub(Engine.Locations.Mock, :for_vehicle, fn _ -> nil end)
       stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> false end)
       stub(Engine.LastTrip.Mock, :get_recent_departures, fn _ -> %{} end)
@@ -2255,6 +2256,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Plays message if no prior plays" do
+      expect(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn ["1"] -> nil end)
+
       pa_message = %PaMessages.PaMessage{
         id: 1,
         visual_text: "A PA Message",
@@ -2266,6 +2269,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Plays message if interval has passed" do
+      expect(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn ["1"] -> nil end)
+
       pa_message = %PaMessages.PaMessage{
         id: 1,
         visual_text: "A PA Message",
@@ -2280,6 +2285,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "Does not play if less than interval has passed" do
+      expect(Engine.ScheduledHeadways.Mock, :get_last_scheduled_departure, fn ["1"] -> nil end)
+
       pa_message = %PaMessages.PaMessage{
         id: 1,
         visual_text: "A PA Message",

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -1,0 +1,136 @@
+defmodule AudioTest do
+  use ExUnit.Case
+
+  @fake_time DateTime.new!(~D[2023-01-01], ~T[12:00:00], "America/New_York")
+  def fake_time_fn, do: @fake_time
+
+  describe "handle_pa_message_play/2" do
+    setup do
+      pa_message = %PaMessages.PaMessage{
+        id: 1,
+        visual_text: "A PA Message",
+        audio_text: "A PA Message",
+        interval_in_ms: 120_000
+      }
+
+      realtime_sign = %Signs.Realtime{
+        id: "sign_id",
+        pa_ess_loc: "TEST",
+        scu_id: "TESTSCU001",
+        text_zone: "x",
+        audio_zones: ["x"],
+        source_config: %{
+          terminal?: false,
+          sources: [
+            %Signs.Utilities.SourceConfig{
+              stop_id: "1",
+              direction_id: 0,
+              routes: ["Red"],
+              announce_arriving?: true,
+              announce_boarding?: false
+            }
+          ],
+          headway_group: "headway_group",
+          headway_destination: :southbound
+        },
+        current_content_top: "Southbound trains",
+        current_content_bottom: "Every 11 to 13 min",
+        current_time_fn: &Signs.RealtimeTest.fake_time_fn/0,
+        last_update: @fake_time,
+        tick_read: 1,
+        read_period_seconds: 100,
+        pa_message_plays: %{},
+        last_message_log_time: @fake_time
+      }
+
+      bus_sign = %Signs.Bus{
+        id: "auto_sign",
+        pa_ess_loc: "ABCD",
+        scu_id: "ABCDSCU001",
+        text_zone: "m",
+        audio_zones: ["m"],
+        max_minutes: 60,
+        configs: nil,
+        top_configs: nil,
+        bottom_configs: nil,
+        extra_audio_configs: nil,
+        chelsea_bridge: nil,
+        read_loop_interval: 360,
+        read_loop_offset: 30,
+        prev_predictions: [],
+        prev_bridge_status: nil,
+        current_messages: {nil, nil},
+        last_update: nil,
+        last_read_time: Timex.shift(Timex.now(), minutes: -10),
+        pa_message_plays: %{}
+      }
+
+      %{
+        pa_message: pa_message,
+        realtime_sign: realtime_sign,
+        bus_sign: bus_sign
+      }
+    end
+
+    test "returns true for realtime sign if no prior plays", %{
+      pa_message: pa_message,
+      realtime_sign: realtime_sign
+    } do
+      assert {_, true} =
+               Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, false)
+    end
+
+    test "returns true for bus sign if no prior plays", %{
+      pa_message: pa_message,
+      bus_sign: bus_sign
+    } do
+      assert {_, true} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, bus_sign)
+    end
+
+    test "returns true for realtime sign if interval has passed", %{
+      pa_message: pa_message,
+      realtime_sign: realtime_sign
+    } do
+      realtime_sign = %{realtime_sign | pa_message_plays: %{1 => ~U[2024-06-10 12:00:00.000Z]}}
+
+      assert {_, true} =
+               Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, false)
+    end
+
+    test "returns true for bus sign if interval has passed", %{
+      pa_message: pa_message,
+      bus_sign: bus_sign
+    } do
+      bus_sign = %{bus_sign | pa_message_plays: %{1 => ~U[2024-06-10 12:00:00.000Z]}}
+
+      assert {_, true} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, bus_sign)
+    end
+
+    test "returns false for realtime sign if the interval has not passed", %{
+      pa_message: pa_message,
+      realtime_sign: realtime_sign
+    } do
+      realtime_sign = %{realtime_sign | pa_message_plays: %{1 => DateTime.utc_now()}}
+
+      assert {_, false} =
+               Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, false)
+    end
+
+    test "returns false for bus sign if the interval has not passed", %{
+      pa_message: pa_message,
+      bus_sign: bus_sign
+    } do
+      bus_sign = %{bus_sign | pa_message_plays: %{1 => DateTime.utc_now()}}
+
+      assert {_, false} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, bus_sign)
+    end
+
+    test "returns false for realtime sign in overnight mode", %{
+      pa_message: pa_message,
+      realtime_sign: realtime_sign
+    } do
+      assert {_, false} =
+               Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, true)
+    end
+  end
+end

--- a/test/signs/utilities/audio_test.exs
+++ b/test/signs/utilities/audio_test.exs
@@ -10,7 +10,8 @@ defmodule AudioTest do
         id: 1,
         visual_text: "A PA Message",
         audio_text: "A PA Message",
-        interval_in_ms: 120_000
+        interval_in_ms: 120_000,
+        priority: 2
       }
 
       realtime_sign = %Signs.Realtime{
@@ -125,11 +126,21 @@ defmodule AudioTest do
       assert {_, false} = Signs.Utilities.Audio.handle_pa_message_play(pa_message, bus_sign)
     end
 
-    test "returns false for realtime sign in overnight mode", %{
+    test "returns false for realtime sign in overnight mode for non-emergency messages", %{
       pa_message: pa_message,
       realtime_sign: realtime_sign
     } do
       assert {_, false} =
+               Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, true)
+    end
+
+    test "returns true for realtime sign in overnight mode for emergency messages", %{
+      pa_message: pa_message,
+      realtime_sign: realtime_sign
+    } do
+      pa_message = %{pa_message | priority: 1}
+
+      assert {_, true} =
                Signs.Utilities.Audio.handle_pa_message_play(pa_message, realtime_sign, true)
     end
   end

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -1,0 +1,277 @@
+defmodule Signs.Utilities.MessagesTest do
+  use ExUnit.Case
+  import Mox
+
+  require Signs.Utilities.Messages
+
+  @midnight DateTime.new!(~D[2023-01-01], ~T[12:00:00], "America/New_York")
+  def fake_time_fn, do: @midnight
+
+  describe "flatten_sign_prediction_info/2" do
+    setup do
+      stub(Engine.Config.Mock, :headway_config, fn _headway_group, _current_time -> nil end)
+
+      source_config = %Signs.Utilities.SourceConfig{
+        stop_id: "1",
+        direction_id: 0,
+        routes: ["Red"],
+        announce_arriving?: true,
+        announce_boarding?: false
+      }
+
+      %{
+        sign: %Signs.Realtime{
+          id: "sign_id",
+          pa_ess_loc: "TEST",
+          scu_id: "TESTSCU001",
+          text_zone: "x",
+          audio_zones: ["x"],
+          source_config: %{
+            terminal?: false,
+            sources: [source_config],
+            headway_group: "headway_group",
+            headway_destination: :southbound
+          },
+          current_content_top: "Southbound trains",
+          current_content_bottom: "Every 11 to 13 min",
+          current_time_fn: &Signs.Utilities.MessagesTest.fake_time_fn/0,
+          last_update: @midnight,
+          tick_read: 1,
+          read_period_seconds: 100,
+          pa_message_plays: %{},
+          last_message_log_time: @midnight
+        },
+        sign_prediction_info: %Signs.Utilities.SignPredictionInfo{
+          predictions: [
+            %Predictions.Prediction{
+              stop_id: "1",
+              seconds_until_arrival: nil,
+              seconds_until_departure: nil,
+              direction_id: 0,
+              schedule_relationship: nil,
+              route_id: "route_id",
+              trip_id: "123",
+              destination_stop_id: "destination_stop_id",
+              stopped_at_predicted_stop?: false,
+              boarding_status: nil,
+              revenue_trip?: true,
+              vehicle_id: "v1",
+              multi_carriage_details: nil,
+              type: :mid_trip
+            }
+          ],
+          all_predictions: [],
+          sign_config: :auto,
+          current_time: @midnight,
+          alert_status: :none,
+          first_scheduled_departures: nil,
+          last_scheduled_departures: nil,
+          recent_departures: @midnight,
+          service_end_statuses_per_source: false
+        }
+      }
+    end
+
+    test "flattens prediction info for a single source configuration", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      flattened_prediction_info = [
+        {
+          sign.source_config,
+          sign_prediction_info.predictions,
+          :none,
+          nil,
+          nil,
+          @midnight,
+          false,
+          false
+        }
+      ]
+
+      assert flattened_prediction_info ==
+               Signs.Utilities.Messages.flatten_sign_prediction_info(sign_prediction_info, sign)
+    end
+  end
+
+  describe "in_overnight_period?/1" do
+    test "returns true for an empty list" do
+      assert Signs.Utilities.Messages.in_overnight_period?([])
+    end
+
+    test "returns true when all signs in overnight period" do
+      prediction_info_one = {nil, nil, nil, nil, nil, nil, nil, true}
+      prediction_info_two = {nil, nil, nil, nil, nil, nil, nil, true}
+
+      assert Signs.Utilities.Messages.in_overnight_period?([prediction_info_one])
+
+      assert Signs.Utilities.Messages.in_overnight_period?([
+               prediction_info_one,
+               prediction_info_two
+             ])
+    end
+
+    test "returns false when any signs are not in overnight period" do
+      prediction_info_one = {nil, nil, nil, nil, nil, nil, nil, false}
+      prediction_info_two = {nil, nil, nil, nil, nil, nil, nil, true}
+
+      refute Signs.Utilities.Messages.in_overnight_period?([prediction_info_one])
+
+      refute Signs.Utilities.Messages.in_overnight_period?([
+               prediction_info_one,
+               prediction_info_two
+             ])
+    end
+  end
+
+  describe "get_messages/2" do
+    setup do
+      stub(Engine.Config.Mock, :headway_config, fn _headway_group, _current_time -> nil end)
+
+      source_config = %Signs.Utilities.SourceConfig{
+        stop_id: "1",
+        direction_id: 0,
+        routes: ["Red"],
+        announce_arriving?: true,
+        announce_boarding?: false
+      }
+
+      %{
+        sign: %Signs.Realtime{
+          id: "sign_id",
+          pa_ess_loc: "TEST",
+          scu_id: "TESTSCU001",
+          text_zone: "x",
+          audio_zones: ["x"],
+          source_config: %{
+            terminal?: false,
+            sources: [source_config],
+            headway_group: "headway_group",
+            headway_destination: :southbound
+          },
+          current_content_top: "Southbound trains",
+          current_content_bottom: "Every 11 to 13 min",
+          current_time_fn: &Signs.Utilities.MessagesTest.fake_time_fn/0,
+          last_update: @midnight,
+          tick_read: 1,
+          read_period_seconds: 100,
+          pa_message_plays: %{},
+          last_message_log_time: @midnight
+        },
+        sign_prediction_info: %Signs.Utilities.SignPredictionInfo{
+          predictions: [
+            %Predictions.Prediction{
+              stop_id: "1",
+              seconds_until_arrival: nil,
+              seconds_until_departure: nil,
+              direction_id: 0,
+              schedule_relationship: nil,
+              route_id: "route_id",
+              trip_id: "123",
+              destination_stop_id: "destination_stop_id",
+              stopped_at_predicted_stop?: false,
+              boarding_status: nil,
+              revenue_trip?: true,
+              vehicle_id: "v1",
+              multi_carriage_details: nil,
+              type: :mid_trip
+            }
+          ],
+          all_predictions: [],
+          sign_config: :auto,
+          current_time: @midnight,
+          alert_status: :none,
+          first_scheduled_departures: DateTime.shift(@midnight, hour: -1),
+          last_scheduled_departures: DateTime.shift(@midnight, hour: 1),
+          recent_departures: @midnight,
+          service_end_statuses_per_source: false
+        }
+      }
+    end
+
+    test "returns an empty message when sign is in the overnight period", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      sign_prediction_info = %{
+        sign_prediction_info
+        | sign_config: {:static_text, {"This is line 1", "This is line 2"}},
+          current_time: DateTime.shift(@midnight, hour: 2)
+      }
+
+      assert [%Message.Empty{}] ==
+               Signs.Utilities.Messages.get_messages(
+                 sign,
+                 sign_prediction_info
+               )
+    end
+
+    test "returns a custom message containing two lines of text", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      sign_prediction_info = %{
+        sign_prediction_info
+        | sign_config: {:static_text, {"This is line 1", "This is line 2"}}
+      }
+
+      assert [%Message.Custom{top: "This is line 1", bottom: "This is line 2"}] ==
+               Signs.Utilities.Messages.get_messages(
+                 sign,
+                 sign_prediction_info
+               )
+    end
+
+    test "returns an empty message when sign is off", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      sign_prediction_info = %{
+        sign_prediction_info
+        | sign_config: :off
+      }
+
+      assert [%Message.Empty{}] ==
+               Signs.Utilities.Messages.get_messages(
+                 sign,
+                 sign_prediction_info
+               )
+    end
+
+    test "returns a service ended message", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      sign_prediction_info = %{
+        sign_prediction_info
+        | service_end_statuses_per_source: true
+      }
+
+      assert [%Message.ServiceEnded{destination: :southbound, route: "Red"}] =
+               Signs.Utilities.Messages.get_messages(
+                 sign,
+                 sign_prediction_info
+               )
+    end
+
+    test "returns a first train message", %{
+      sign: sign,
+      sign_prediction_info: sign_prediction_info
+    } do
+      now = DateTime.new!(~D[2023-01-01], ~T[04:05:00], "America/New_York")
+
+      sign_prediction_info = %{
+        sign_prediction_info
+        | current_time: now,
+          first_scheduled_departures: DateTime.shift(now, hour: 1),
+          last_scheduled_departures: DateTime.shift(now, hour: 10)
+      }
+
+      assert [%Message.FirstTrain{destination: :southbound}] =
+               Signs.Utilities.Messages.get_messages(
+                 sign,
+                 sign_prediction_info
+               )
+    end
+  end
+end

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -7,7 +7,7 @@ defmodule Signs.Utilities.MessagesTest do
   @midnight DateTime.new!(~D[2023-01-01], ~T[12:00:00], "America/New_York")
   def fake_time_fn, do: @midnight
 
-  describe "flatten_sign_prediction_info/2" do
+  describe "flatten_sign_context/2" do
     setup do
       stub(Engine.Config.Mock, :headway_config, fn _headway_group, _current_time -> nil end)
 
@@ -41,7 +41,7 @@ defmodule Signs.Utilities.MessagesTest do
           pa_message_plays: %{},
           last_message_log_time: @midnight
         },
-        sign_prediction_info: %Signs.Utilities.SignPredictionInfo{
+        sign_context: %Signs.Utilities.SignContext{
           predictions: [
             %Predictions.Prediction{
               stop_id: "1",
@@ -74,12 +74,12 @@ defmodule Signs.Utilities.MessagesTest do
 
     test "flattens prediction info for a single source configuration", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
       flattened_prediction_info = [
         {
           sign.source_config,
-          sign_prediction_info.predictions,
+          sign_context.predictions,
           :none,
           nil,
           nil,
@@ -90,7 +90,7 @@ defmodule Signs.Utilities.MessagesTest do
       ]
 
       assert flattened_prediction_info ==
-               Signs.Utilities.Messages.flatten_sign_prediction_info(sign_prediction_info, sign)
+               Signs.Utilities.Messages.flatten_sign_context(sign_context, sign)
     end
   end
 
@@ -158,7 +158,7 @@ defmodule Signs.Utilities.MessagesTest do
           pa_message_plays: %{},
           last_message_log_time: @midnight
         },
-        sign_prediction_info: %Signs.Utilities.SignPredictionInfo{
+        sign_context: %Signs.Utilities.SignContext{
           predictions: [
             %Predictions.Prediction{
               stop_id: "1",
@@ -191,10 +191,10 @@ defmodule Signs.Utilities.MessagesTest do
 
     test "returns an empty message when sign is in the overnight period", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
-      sign_prediction_info = %{
-        sign_prediction_info
+      sign_context = %{
+        sign_context
         | sign_config: {:static_text, {"This is line 1", "This is line 2"}},
           current_time: DateTime.shift(@midnight, hour: 2)
       }
@@ -202,66 +202,66 @@ defmodule Signs.Utilities.MessagesTest do
       assert [%Message.Empty{}] ==
                Signs.Utilities.Messages.get_messages(
                  sign,
-                 sign_prediction_info
+                 sign_context
                )
     end
 
     test "returns a custom message containing two lines of text", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
-      sign_prediction_info = %{
-        sign_prediction_info
+      sign_context = %{
+        sign_context
         | sign_config: {:static_text, {"This is line 1", "This is line 2"}}
       }
 
       assert [%Message.Custom{top: "This is line 1", bottom: "This is line 2"}] ==
                Signs.Utilities.Messages.get_messages(
                  sign,
-                 sign_prediction_info
+                 sign_context
                )
     end
 
     test "returns an empty message when sign is off", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
-      sign_prediction_info = %{
-        sign_prediction_info
+      sign_context = %{
+        sign_context
         | sign_config: :off
       }
 
       assert [%Message.Empty{}] ==
                Signs.Utilities.Messages.get_messages(
                  sign,
-                 sign_prediction_info
+                 sign_context
                )
     end
 
     test "returns a service ended message", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
-      sign_prediction_info = %{
-        sign_prediction_info
+      sign_context = %{
+        sign_context
         | service_end_statuses_per_source: true
       }
 
       assert [%Message.ServiceEnded{destination: :southbound, route: "Red"}] =
                Signs.Utilities.Messages.get_messages(
                  sign,
-                 sign_prediction_info
+                 sign_context
                )
     end
 
     test "returns a first train message", %{
       sign: sign,
-      sign_prediction_info: sign_prediction_info
+      sign_context: sign_context
     } do
       now = DateTime.new!(~D[2023-01-01], ~T[04:05:00], "America/New_York")
 
-      sign_prediction_info = %{
-        sign_prediction_info
+      sign_context = %{
+        sign_context
         | current_time: now,
           first_scheduled_departures: DateTime.shift(now, hour: 1),
           last_scheduled_departures: DateTime.shift(now, hour: 10)
@@ -270,7 +270,7 @@ defmodule Signs.Utilities.MessagesTest do
       assert [%Message.FirstTrain{destination: :southbound}] =
                Signs.Utilities.Messages.get_messages(
                  sign,
-                 sign_prediction_info
+                 sign_context
                )
     end
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Suppressing Overnight PA/ESS readouts](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214305709282852?focus=true)

**Note to Reviewers**

Additional tests for this fix are needed, but I'd like to make sure I'm on the correct route here.

This PR is split into three commits. They are (hopefully) self-describing, but there are a handful of cases where I've put comments directly inline with the source for one reason or another.

Generally, I would have split this into 2 PRs - one containing the refactor + typo fixes, and one with the actual fix. I've included them both in this PR to demonstrate the intent of the refactor. Feel free to review the first commit, and if that's simply the wrong direction to take this, let me know/reject the PR and we'll iterate from there.

**Changes**

Pull the predictions, alert status, departure information, etc. that was
previously calculated in `get_messages/9` into a separate function,
grouping said information into a struct called `SignPredictionInfo`.
This separation allows the calculated information to be used by other
processes, other than `get_message/9`. As a result of wrapping this info
in a struct, the arity of `get_message` has been reduced from 9 to 2.

Simple unit tests have been created in `messages_test.exs` to smoke test
the refactor. While not these do not fully cover the derivation of
messages, they are a step in the right direction

Suppress non-emergency messages such that they do not play overnight.

Fix minor typos found in comments when going through relevant parts of
the codebase.

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
