### PR TITLE
expand abbreviations in TTS for migrated stations

### DIFF
--- a/lib/message/custom.ex
+++ b/lib/message/custom.ex
@@ -8,30 +8,19 @@ defmodule Message.Custom do
         }
 
   defimpl Message do
-    @invalid_character ~r/[^a-zA-Z0-9,\/!@': ]/
-
     def to_single_line(%Message.Custom{}, _) do
       raise "Cannot render custom message on one line"
     end
 
     def to_full_page(%Message.Custom{top: top, bottom: bottom}) do
-      {validate(top, :top), validate(bottom, :bottom)}
+      {PaEss.Utilities.validate_custom_string(top, :top),
+       PaEss.Utilities.validate_custom_string(bottom, :bottom)}
     end
 
     def to_multi_line(%Message.Custom{} = message), do: to_full_page(message)
 
     def to_audio(%Message.Custom{top: top, bottom: bottom}, _multiple?) do
-      [
-        %Content.Audio.Custom{
-          message: String.trim("#{validate(top, :top)} #{validate(bottom, :bottom)}")
-        }
-      ]
-    end
-
-    defp validate(string, line) do
-      string
-      |> String.replace(@invalid_character, "")
-      |> String.slice(0, if(line == :top, do: 18, else: 24))
+      [%Content.Audio.Custom{message: PaEss.Utilities.custom_tts_text(top, bottom)}]
     end
   end
 end

--- a/lib/pa_ess/http_updater.ex
+++ b/lib/pa_ess/http_updater.ex
@@ -136,7 +136,7 @@ defmodule PaEss.HttpUpdater do
           [
             MsgType: "AdHoc",
             uid: get_uid(state),
-            msg: PaEss.Utilities.replace_abbreviations(text),
+            msg: text,
             typ: audio_type(type),
             sta: "#{station}#{zone_bitmap(zones)}",
             pri: priority,

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -596,7 +596,7 @@ defmodule PaEss.Utilities do
   end
 
   @spec replace_abbreviations(String.t()) :: String.t()
-  def replace_abbreviations(text) when is_binary(text) do
+  defp replace_abbreviations(text) when is_binary(text) do
     Enum.reduce(
       @abbreviation_replacements,
       text,

--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -606,6 +606,21 @@ defmodule PaEss.Utilities do
     )
   end
 
+  @invalid_custom_character ~r/[^a-zA-Z0-9,\/!@': ]/
+  @spec validate_custom_string(String.t(), :top | :bottom) :: String.t()
+  def validate_custom_string(string, line) do
+    string
+    |> String.replace(@invalid_custom_character, "")
+    |> String.slice(0, if(line == :top, do: 18, else: 24))
+  end
+
+  @spec custom_tts_text(String.t(), String.t()) :: String.t()
+  def custom_tts_text(top, bottom) do
+    "#{validate_custom_string(top, :top)} #{validate_custom_string(bottom, :bottom)}"
+    |> String.trim()
+    |> replace_abbreviations()
+  end
+
   @headsign_abbreviation_mappings [
     {"Ruggles", ["Ruggles"]},
     {"Downtown", ["Downtwn", "Downtown"]},

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -315,7 +315,12 @@ defmodule Signs.Bus do
     {_, {line1, line2}} = config
 
     messages =
-      [[line1, line2]]
+      [
+        [
+          PaEss.Utilities.validate_custom_string(line1, :top),
+          PaEss.Utilities.validate_custom_string(line2, :bottom)
+        ]
+      ]
       |> Enum.concat(
         bridge_message(
           bridge_status,
@@ -328,11 +333,13 @@ defmodule Signs.Bus do
       )
       |> paginate_pairs()
 
+    tts_text = PaEss.Utilities.custom_tts_text(line1, line2)
+
     audios =
-      [{:ad_hoc, {"#{line1} #{line2}", :audio}}]
+      [{:ad_hoc, {tts_text, :audio}}]
       |> Enum.concat(bridge_audio(bridge_status, bridge_enabled?, current_time, state))
 
-    tts_audios = [{"#{line1} #{line2}", nil}]
+    tts_audios = [{tts_text, nil}]
 
     {messages, audios, tts_audios}
   end

--- a/test/pa_ess/http_updater_test.exs
+++ b/test/pa_ess/http_updater_test.exs
@@ -114,24 +114,6 @@ defmodule PaEss.HttpUpdaterTest do
       assert log =~ "send_custom_audio"
     end
 
-    test "sends custom audio messages with replacements" do
-      state = make_state()
-
-      audio = {:ad_hoc, {"Custom OL Message", :audio}}
-
-      log =
-        capture_log(fn ->
-          assert {:ok, :sent} =
-                   PaEss.HttpUpdater.process(
-                     {:send_audio, [{"MCAP", ["n"]}, [audio], 5, 60, [[]]]},
-                     state
-                   )
-        end)
-
-      assert log =~ "send_custom_audio"
-      assert log =~ "Custom+Orange+Line+Message"
-    end
-
     test "can send two audio messages" do
       state = make_state(%{http_poster: FakePoster})
 

--- a/test/pa_ess/utilities_test.exs
+++ b/test/pa_ess/utilities_test.exs
@@ -46,24 +46,6 @@ defmodule Content.Audio.UtilitiesTest do
     assert destination_to_ad_hoc_string(:southbound) == "Southbound"
   end
 
-  describe "replace_abbreviations/1" do
-    test "replaces multiple times, including binary start and end" do
-      assert replace_abbreviations("RL and RL and OL") == "Red Line and Red Line and Orange Line"
-    end
-
-    test "does not replace when touching other letters" do
-      assert replace_abbreviations("BLAM!") == "BLAM!"
-    end
-
-    test "replaces when next to punctuation" do
-      assert replace_abbreviations("OL, OK") == "Orange Line, OK"
-    end
-
-    test "case insensitive replacement of 'SVC' with 'Service'" do
-      assert replace_abbreviations("SvC, OK") == "Service, OK"
-    end
-  end
-
   test "paginate_text" do
     assert [{"Attention passengers:", "the next Braintree train", 3}, {"is now arriving", "", 3}] =
              paginate_text("Attention passengers: the next Braintree train is now arriving", 24)

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1080,6 +1080,20 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, @sign)
     end
 
+    test "replaces abbreviations in custom messages" do
+      expect(Engine.Config.Mock, :sign_config, fn _, _ ->
+        {:static_text, {"No OL Svc", ""}}
+      end)
+
+      expect_messages({"No OL Svc", ""})
+
+      expect_audios([{:ad_hoc, {"No Orange Line Service", :audio}}], [
+        {"No Orange Line Service", nil}
+      ])
+
+      Signs.Realtime.handle_info(:run_loop, @sign)
+    end
+
     test "reads alerts" do
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_closed_station end)
       expect_messages({"No Southbound svc", "Use shuttle bus"})


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Replace abbreviations in TTS for custom messages at migrated stations](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214901763748036?focus=true)

This replaces abbreviations in custom messages when generating TTS readouts for migrated stations, same as we do for ARINC stations. Also unifies the code paths between rail and bus, so they work the same.