### PR TITLE
chore: add correlation_id field to scu messages

### DIFF
--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -208,6 +208,7 @@ defmodule PaEss.Updater do
     :rand.bytes(16) |> Base.encode64(padding: false)
   end
 
+  @spec create_correlation_id() :: String.t()
   defp create_correlation_id() do
     :rand.bytes(16) |> Base.encode64(padding: false)
   end

--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -26,6 +26,7 @@ defmodule PaEss.Updater do
 
     visual = zip_pages(top, bottom) |> format_pages()
     tag = create_tag()
+    correlation_id = create_correlation_id()
     scu_migrated? = RealtimeSigns.config_engine().scu_migrated?(scu_id)
 
     log_meta = [
@@ -33,6 +34,7 @@ defmodule PaEss.Updater do
       current_config: log_config,
       visual: Jason.encode!(visual),
       tag: inspect(tag),
+      correlation_id: inspect(correlation_id),
       legacy: !scu_migrated?
     ]
 
@@ -44,7 +46,8 @@ defmodule PaEss.Updater do
            zones: ["#{pa_ess_loc}-#{text_zone}"],
            visual_data: visual,
            expiration: 180,
-           tag: tag
+           tag: tag,
+           correlation_id: correlation_id
          }, log_meta}
       )
     else
@@ -68,6 +71,7 @@ defmodule PaEss.Updater do
 
     log_data = fn {audio, visual}, sign, legacy? ->
       tag = create_tag()
+      correlation_id = create_correlation_id()
 
       {[
          audio:
@@ -82,9 +86,10 @@ defmodule PaEss.Updater do
            |> inspect(),
          sign_id: sign.id,
          tag: inspect(tag),
+         correlation_id: inspect(correlation_id),
          legacy: legacy?,
          visual: paginate(visual, sign) |> format_pages() |> Jason.encode!()
-       ], tag}
+       ], tag, correlation_id}
     end
 
     if migrated_signs != [] do
@@ -115,7 +120,7 @@ defmodule PaEss.Updater do
 
       Enum.each(migrated_signs, fn sign ->
         Enum.each(tts_items, fn {{audio, visual} = tts_audio, log_meta} ->
-          {logs, tag} = log_data.(tts_audio, sign, false)
+          {logs, tag, correlation_id} = log_data.(tts_audio, sign, false)
 
           PaEss.ScuQueue.enqueue_message(
             sign.scu_id,
@@ -126,7 +131,8 @@ defmodule PaEss.Updater do
                audio_data: Enum.map(audio, &format_audio/1),
                expiration: 30,
                priority: priority,
-               tag: tag
+               tag: tag,
+               correlation_id: correlation_id
              }, Keyword.merge(logs, log_meta)}
           )
         end)
@@ -137,7 +143,7 @@ defmodule PaEss.Updater do
       log_list =
         Enum.zip(tts_audios, log_metas)
         |> Enum.map(fn {tts_audio, log_meta} ->
-          {logs, _tag} = log_data.(tts_audio, sign, true)
+          {logs, _tag, _correlation_id} = log_data.(tts_audio, sign, true)
           Keyword.merge(logs, log_meta)
         end)
 
@@ -199,6 +205,10 @@ defmodule PaEss.Updater do
   end
 
   defp create_tag() do
+    :rand.bytes(16) |> Base.encode64(padding: false)
+  end
+
+  defp create_correlation_id() do
     :rand.bytes(16) |> Base.encode64(padding: false)
   end
 


### PR DESCRIPTION

#### Summary of changes

**Asana Ticket:** N/A

Introduce a new field, `correlation_id` to messages that we send to SCUs. This field is intentionally identical to the existing `tag` field, as the intent is for it to replace `tag` in the future.

The impetus for this change is "tag" has a special meaning in Splunk, making it slightly more cumbersome to query on.

#### Notes for Reviewers

- This must land before https://github.com/mbta/scully/pull/223

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
