### PR TITLE
refactor sign context

### DIFF
--- a/lib/engine/alerts/fetcher.ex
+++ b/lib/engine/alerts/fetcher.ex
@@ -7,7 +7,8 @@ defmodule Engine.Alerts.Fetcher do
   @type stop_status ::
           :shuttles_closed_station
           | :shuttles_transfer_station
-          | :suspension
+          | :suspension_closed_station
+          | :suspension_transfer_station
           | :station_closure
           | :none
 

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -9,6 +9,7 @@ defmodule Signs.Realtime do
 
   alias Signs.Utilities
   alias Utilities.SourceConfig
+  alias Utilities.SignContext
 
   @announced_history_length 5
 
@@ -117,7 +118,6 @@ defmodule Signs.Realtime do
   def handle_call({:play_pa_message, pa_message}, _from, sign) do
     sign_in_overnight_period? =
       derive_sign_context(sign)
-      |> Signs.Utilities.Messages.flatten_sign_context(sign)
       |> Signs.Utilities.Messages.in_overnight_period?()
 
     {sign, should_play?} =
@@ -126,100 +126,64 @@ defmodule Signs.Realtime do
     {:reply, {sign, should_play?}, sign}
   end
 
-  @spec derive_sign_context(t()) :: Signs.Utilities.SignContext.t()
+  @spec derive_sign_context(t()) :: SignContext.t()
   defp derive_sign_context(sign) do
     sign_config = RealtimeSigns.config_engine().sign_config(sign.id, sign.default_mode)
     current_time = sign.current_time_fn.()
-
-    alert_status =
-      map_source_config(sign.source_config, fn config ->
-        stop_ids = SourceConfig.sign_stop_ids(config)
-        RealtimeSigns.alert_engine().min_stop_status(stop_ids)
-      end)
-
-    first_scheduled_departures =
-      map_source_config(sign.source_config, fn config ->
-        RealtimeSigns.headway_engine().get_first_scheduled_departure(
-          SourceConfig.sign_stop_ids(config)
-        )
-      end)
-
-    last_scheduled_departures =
-      map_source_config(sign.source_config, fn config ->
-        RealtimeSigns.headway_engine().get_last_scheduled_departure(
-          SourceConfig.sign_stop_ids(config)
-        )
-      end)
 
     prev_predictions_lookup =
       for prediction <- sign.prev_predictions, into: %{} do
         {prediction_key(prediction), prediction}
       end
 
-    recent_departures =
-      map_source_config(sign.source_config, fn config ->
-        SourceConfig.sign_stop_ids(config)
-        |> Stream.flat_map(&RealtimeSigns.last_trip_engine().get_recent_departures(&1))
-        |> Enum.max_by(fn {_, dt} -> dt end, DateTime, fn -> {nil, nil} end)
-        |> elem(1)
+    config_contexts =
+      if is_tuple(sign.source_config) do
+        Tuple.to_list(sign.source_config)
+      else
+        [sign.source_config]
+      end
+      |> Enum.map(fn config ->
+        stop_ids = SourceConfig.sign_stop_ids(config)
+
+        %SignContext.ConfigContext{
+          config: config,
+          predictions: fetch_predictions(config, prev_predictions_lookup),
+          alert_status: RealtimeSigns.alert_engine().min_stop_status(stop_ids),
+          headways:
+            Signs.Utilities.Headways.fetch_headways(config.headway_group, stop_ids, current_time),
+          first_scheduled_departure:
+            RealtimeSigns.headway_engine().get_first_scheduled_departure(stop_ids),
+          last_scheduled_departure:
+            RealtimeSigns.headway_engine().get_last_scheduled_departure(stop_ids),
+          most_recent_departure:
+            Stream.flat_map(stop_ids, &RealtimeSigns.last_trip_engine().get_recent_departures(&1))
+            |> Stream.map(&elem(&1, 1))
+            |> Enum.max(DateTime, fn -> nil end),
+          service_ended?: has_service_ended_for_source?(config, current_time)
+        }
       end)
 
-    {predictions, all_predictions} =
-      case sign.source_config do
-        {top, bottom} ->
-          top_predictions = fetch_predictions(top, prev_predictions_lookup)
-          bottom_predictions = fetch_predictions(bottom, prev_predictions_lookup)
-          {{top_predictions, bottom_predictions}, top_predictions ++ bottom_predictions}
-
-        config ->
-          predictions = fetch_predictions(config, prev_predictions_lookup)
-          {predictions, predictions}
-      end
-
-    service_end_statuses_per_source =
-      map_source_config(
-        sign.source_config,
-        &has_service_ended_for_source?(&1, current_time)
-      )
-
-    %Signs.Utilities.SignContext{
-      predictions: predictions,
-      all_predictions: all_predictions,
+    %SignContext{
       sign_config: sign_config,
       current_time: current_time,
-      alert_status: alert_status,
-      first_scheduled_departures: first_scheduled_departures,
-      last_scheduled_departures: last_scheduled_departures,
-      recent_departures: recent_departures,
-      service_end_statuses_per_source: service_end_statuses_per_source
+      config_contexts: config_contexts
     }
   end
 
   def handle_info(:run_loop, sign) do
-    sign_context =
-      %Signs.Utilities.SignContext{
-        predictions: predictions,
-        all_predictions: all_predictions,
-        current_time: current_time
-      } = derive_sign_context(sign)
-
-    messages =
-      Utilities.Messages.get_messages(
-        sign,
-        sign_context
-      )
-
+    sign_context = derive_sign_context(sign)
+    messages = Utilities.Messages.get_messages(sign, sign_context)
     {new_top, new_bottom} = Utilities.Messages.render_messages(messages)
 
     sign =
       sign
-      |> announce_passthrough_trains(predictions)
-      |> Utilities.Updater.update_sign(new_top, new_bottom, current_time)
+      |> announce_passthrough_trains(sign_context)
+      |> Utilities.Updater.update_sign(new_top, new_bottom, sign_context.current_time)
       |> Utilities.Reader.do_announcements(messages)
       |> Utilities.Reader.read_sign(messages)
       |> decrement_ticks()
       |> log_sign_messages(messages)
-      |> Map.put(:prev_predictions, all_predictions)
+      |> Map.put(:prev_predictions, Enum.flat_map(sign_context.config_contexts, & &1.predictions))
 
     Process.send_after(self(), :run_loop, 1000)
     {:noreply, sign}
@@ -292,9 +256,9 @@ defmodule Signs.Realtime do
     end
   end
 
-  @spec announce_passthrough_trains(Signs.Realtime.t(), predictions()) :: Signs.Realtime.t()
-  defp announce_passthrough_trains(sign, predictions) do
-    Utilities.Predictions.get_passthrough_train_audio(predictions, sign)
+  @spec announce_passthrough_trains(Signs.Realtime.t(), SignContext.t()) :: Signs.Realtime.t()
+  defp announce_passthrough_trains(sign, sign_context) do
+    Utilities.Predictions.get_passthrough_train_audio(sign_context)
     |> Enum.reduce(sign, fn audio, sign ->
       if audio.trip_id not in sign.announced_passthroughs do
         Signs.Utilities.Audio.send_audio([sign], [audio])
@@ -340,7 +304,4 @@ defmodule Signs.Realtime do
   def decrement_ticks(sign) do
     %{sign | tick_read: sign.tick_read - 1}
   end
-
-  defp map_source_config({top, bottom}, fun), do: {fun.(top), fun.(bottom)}
-  defp map_source_config(config, fun), do: fun.(config)
 end

--- a/lib/signs/utilities/headways.ex
+++ b/lib/signs/utilities/headways.ex
@@ -3,27 +3,7 @@ defmodule Signs.Utilities.Headways do
   Given a sign with a SourceConfig, fetches headways and
   generates the top and bottom lines for the sign
   """
-  alias Signs.Utilities.SourceConfig
   require Logger
-
-  @spec headway_message(SourceConfig.config(), DateTime.t()) :: Message.t() | nil
-  def headway_message(config, current_time) do
-    case fetch_headways(
-           config.headway_group,
-           Enum.map(config.sources, & &1.stop_id),
-           current_time
-         ) do
-      nil ->
-        nil
-
-      headways ->
-        %Message.Headway{
-          destination: config.headway_destination,
-          range: {headways.range_low, headways.range_high},
-          route: SourceConfig.single_route(config)
-        }
-    end
-  end
 
   # Process headways for Silver Line differently b/c of its different config shape
   def headway_message_sl(headway_group, headway_destination, stop_ids, current_time) do
@@ -40,7 +20,7 @@ defmodule Signs.Utilities.Headways do
     end
   end
 
-  defp fetch_headways(headway_group, stop_ids, current_time) do
+  def fetch_headways(headway_group, stop_ids, current_time) do
     with headways when not is_nil(headways) <-
            RealtimeSigns.config_engine().headway_config(headway_group, current_time),
          true <-

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -8,36 +8,12 @@ defmodule Signs.Utilities.Messages do
   @early_am_buffer -40
   @overnight_buffer 30
 
-  @type flattened_sign_context :: {
-          Signs.Utilities.SourceConfig.config(),
-          list(Signs.Realtime.predictions()),
-          Signs.Realtime.t(),
-          Engine.Alerts.Fetcher.stop_status(),
-          DateTime.t(),
-          DateTime.t(),
-          DateTime.t(),
-          boolean(),
-          boolean()
-        }
+  alias Signs.Utilities.SignContext
+  alias SignContext.ConfigContext
 
-  @spec get_messages(
-          Signs.Realtime.t(),
-          Signs.Utilities.SignContext.t()
-        ) :: [Message.t()]
-  def get_messages(
-        sign,
-        sign_context = %Signs.Utilities.SignContext{
-          current_time: current_time,
-          sign_config: sign_config
-        }
-      ) do
-    config =
-      flatten_sign_context(
-        sign_context,
-        sign
-      )
-
-    sign_in_overnight_period = in_overnight_period?(config)
+  @spec get_messages(Signs.Realtime.t(), SignContext.t()) :: [Message.t()]
+  def get_messages(sign, %SignContext{sign_config: sign_config} = sign_context) do
+    sign_in_overnight_period = in_overnight_period?(sign_context)
 
     cond do
       match?({:static_text, {_, _}}, sign_config) ->
@@ -52,81 +28,21 @@ defmodule Signs.Utilities.Messages do
         [%Message.Empty{}]
 
       true ->
-        Enum.map(config, fn {config, predictions, alert_status, first_scheduled_departures,
-                             _last_scheduled_departures, _most_recent_departure, service_status,
-                             in_overnight_period} ->
-          filtered_predictions =
-            filter_predictions(predictions, config, current_time, first_scheduled_departures)
-
-          alert_status = filter_alert_status(alert_status, sign_config)
-
-          prediction_message(filtered_predictions, config, sign, predictions) ||
-            service_ended_message(service_status, config, sign_in_overnight_period) ||
-            alert_message(alert_status, sign, config, in_overnight_period) ||
-            Signs.Utilities.Headways.headway_message(config, current_time) ||
-            early_am_message(current_time, first_scheduled_departures, config) ||
+        Enum.map(sign_context.config_contexts, fn config_context ->
+          prediction_message(config_context, sign_context, sign) ||
+            service_ended_message(config_context, sign_context) ||
+            alert_message(config_context, sign_context, sign) ||
+            headway_message(config_context) ||
+            early_am_message(config_context, sign_context) ||
             %Message.Empty{}
         end)
     end
     |> transform_messages()
   end
 
-  @spec flatten_sign_context(
-          Signs.Utilities.SignContext.t(),
-          Signs.Realtime.t()
-        ) ::
-          list(flattened_sign_context())
-  def flatten_sign_context(
-        %Signs.Utilities.SignContext{
-          predictions: predictions,
-          current_time: current_time,
-          alert_status: alert_status,
-          first_scheduled_departures: first_scheduled_departures,
-          last_scheduled_departures: last_scheduled_departures,
-          recent_departures: recent_departures,
-          service_end_statuses_per_source: service_end_statuses_per_source
-        },
-        sign
-      ) do
-    if match?(%{source_config: {_, _}}, sign) do
-      Enum.zip([
-        Tuple.to_list(sign.source_config),
-        Tuple.to_list(predictions),
-        Tuple.to_list(alert_status),
-        Tuple.to_list(first_scheduled_departures),
-        Tuple.to_list(last_scheduled_departures),
-        Tuple.to_list(recent_departures),
-        Tuple.to_list(service_end_statuses_per_source)
-      ])
-    else
-      [
-        {sign.source_config, predictions, alert_status, first_scheduled_departures,
-         last_scheduled_departures, recent_departures, service_end_statuses_per_source}
-      ]
-    end
-    |> Enum.map(fn {_config, _predictions, _alert_status, first_scheduled_departures,
-                    last_scheduled_departures, most_recent_departure,
-                    service_status} = sign_config ->
-      Tuple.append(
-        sign_config,
-        overnight_period?(
-          current_time,
-          first_scheduled_departures,
-          last_scheduled_departures,
-          most_recent_departure,
-          service_status
-        )
-      )
-    end)
-  end
-
-  @spec in_overnight_period?(list(flattened_sign_context())) :: boolean()
-  def in_overnight_period?(config) do
-    Enum.all?(config, fn {_config, _predictions, _alert_status, _first_scheduled_departures,
-                          _last_scheduled_departures, _most_recent_departure, _service_status,
-                          in_overnight_period} ->
-      in_overnight_period
-    end)
+  @spec in_overnight_period?(SignContext.t()) :: boolean()
+  def in_overnight_period?(%SignContext{} = sign_context) do
+    Enum.all?(sign_context.config_contexts, &overnight_period?(&1, sign_context))
   end
 
   @spec transform_messages([Message.t()]) :: [Message.t()]
@@ -201,13 +117,12 @@ defmodule Signs.Utilities.Messages do
   defp filter_alert_status(:suspension_transfer_station, :temporary_terminal), do: :none
   defp filter_alert_status(alert_status, _), do: alert_status
 
-  @spec filter_predictions(
-          [Predictions.Prediction.t()],
-          Signs.Utilities.SourceConfig.config(),
-          DateTime.t(),
-          DateTime.t()
-        ) :: [Predictions.Prediction.t()]
-  defp filter_predictions(predictions, config, current_time, scheduled) do
+  @spec filter_predictions(ConfigContext.t(), SignContext.t()) ::
+          [Predictions.Prediction.t()]
+  defp filter_predictions(
+         %ConfigContext{predictions: predictions, config: config} = config_context,
+         %SignContext{} = sign_context
+       ) do
     predictions
     |> Enum.filter(fn p -> p.seconds_until_departure && p.schedule_relationship != :skipped end)
     |> Enum.sort_by(fn prediction ->
@@ -217,16 +132,20 @@ defmodule Signs.Utilities.Messages do
          true -> 1
        end, prediction.seconds_until_departure, prediction.seconds_until_arrival}
     end)
-    |> filter_early_am_predictions(current_time, scheduled)
+    |> filter_early_am_predictions(config_context, sign_context)
     |> get_unique_destination_predictions(Signs.Utilities.SourceConfig.single_route(config))
   end
 
-  defp filter_early_am_predictions(predictions, current_time, scheduled) do
+  defp filter_early_am_predictions(
+         predictions,
+         %ConfigContext{first_scheduled_departure: first_scheduled_departure},
+         %SignContext{current_time: current_time}
+       ) do
     cond do
-      !in_early_am?(current_time, scheduled) ->
+      !in_early_am?(current_time, first_scheduled_departure) ->
         predictions
 
-      before_early_am_threshold?(current_time, scheduled) ->
+      before_early_am_threshold?(current_time, first_scheduled_departure) ->
         # More than 40 minutes before the first scheduled trip, filter out all predictions.
         []
 
@@ -283,24 +202,26 @@ defmodule Signs.Utilities.Messages do
     Timex.before?(current_time, Timex.shift(scheduled, minutes: @early_am_buffer))
   end
 
-  @spec prediction_message(
-          [Predictions.Prediction.t()],
-          Signs.Utilities.SourceConfig.config(),
-          Signs.Realtime.t(),
-          [Predictions.Prediction.t()]
-        ) :: Message.t() | nil
-  defp prediction_message(predictions, %{terminal?: terminal?}, sign, all_predictions) do
-    if predictions != [] do
+  @spec prediction_message(ConfigContext.t(), SignContext.t(), Signs.Realtime.t()) ::
+          Message.t() | nil
+  defp prediction_message(
+         %ConfigContext{config: config, predictions: predictions} = config_context,
+         %SignContext{} = sign_context,
+         sign
+       ) do
+    filtered_predictions = filter_predictions(config_context, sign_context)
+
+    if filtered_predictions != [] do
       %Message.Predictions{
-        predictions: predictions,
-        terminal?: terminal?,
+        predictions: filtered_predictions,
+        terminal?: config.terminal?,
         special_sign:
           case sign do
             %{pa_ess_loc: "BBOW", text_zone: "e"} ->
               :bowdoin_eastbound
 
             %{pa_ess_loc: "RJFK", text_zone: "m"} ->
-              {:jfk_mezzanine, all_same_stop_id?(all_predictions)}
+              {:jfk_mezzanine, all_same_stop_id?(predictions)}
 
             _ ->
               nil
@@ -314,35 +235,37 @@ defmodule Signs.Utilities.Messages do
     length(Enum.uniq_by(all_predictions, & &1.stop_id)) == 1
   end
 
-  defp early_am_message(current_time, scheduled_time, config) do
-    if in_early_am?(current_time, scheduled_time) do
-      %Message.FirstTrain{destination: config.headway_destination, scheduled: scheduled_time}
+  defp early_am_message(
+         %ConfigContext{config: config, first_scheduled_departure: first_scheduled_departure},
+         %SignContext{current_time: current_time}
+       ) do
+    if in_early_am?(current_time, first_scheduled_departure) do
+      %Message.FirstTrain{
+        destination: config.headway_destination,
+        scheduled: first_scheduled_departure
+      }
     end
   end
 
-  @spec overnight_period?(
-          DateTime.t(),
-          DateTime.t(),
-          DateTime.t(),
-          DateTime.t(),
-          boolean()
-        ) :: boolean()
+  @spec overnight_period?(ConfigContext.t(), SignContext.t()) :: boolean()
   defp overnight_period?(
-         _current_time,
-         first_scheduled_departure,
-         last_scheduled_departure,
-         _most_recent_departure,
-         false
+         %ConfigContext{
+           first_scheduled_departure: first_scheduled_departure,
+           last_scheduled_departure: last_scheduled_departure,
+           service_ended?: false
+         },
+         _
        )
        when first_scheduled_departure == nil or last_scheduled_departure == nil,
        do: false
 
   defp overnight_period?(
-         current_time,
-         first_scheduled_departure,
-         last_scheduled_departure,
-         _most_recent_departure,
-         false
+         %ConfigContext{
+           first_scheduled_departure: first_scheduled_departure,
+           last_scheduled_departure: last_scheduled_departure,
+           service_ended?: false
+         },
+         %SignContext{current_time: current_time}
        ),
        do:
          calculate_overnight_period(
@@ -352,11 +275,12 @@ defmodule Signs.Utilities.Messages do
          )
 
   defp overnight_period?(
-         current_time,
-         first_scheduled_departure,
-         _last_scheduled_departure,
-         most_recent_departure,
-         true
+         %ConfigContext{
+           first_scheduled_departure: first_scheduled_departure,
+           most_recent_departure: most_recent_departure,
+           service_ended?: true
+         },
+         %SignContext{current_time: current_time}
        ) do
     calculate_overnight_period(
       most_recent_departure,
@@ -383,12 +307,20 @@ defmodule Signs.Utilities.Messages do
       before_early_am_threshold?(current_time, first_scheduled_departure)
   end
 
-  defp alert_message(alert_status, sign, config, false = _config_in_overnight_period) do
+  defp alert_message(
+         %ConfigContext{config: config, alert_status: alert_status} = config_context,
+         %SignContext{sign_config: sign_config} = sign_context,
+         sign
+       ) do
+    alert_status = filter_alert_status(alert_status, sign_config)
     route = Signs.Utilities.SourceConfig.single_route(config)
     transfer_alert? = alert_status in [:suspension_transfer_station, :shuttles_transfer_station]
     union_square? = sign.pa_ess_loc == "GUNS"
 
     cond do
+      overnight_period?(config_context, sign_context) ->
+        nil
+
       alert_status in [:shuttles_closed_station, :suspension_closed_station, :station_closure] or
           (union_square? and transfer_alert?) ->
         %Message.Alert{
@@ -407,13 +339,24 @@ defmodule Signs.Utilities.Messages do
     end
   end
 
-  defp alert_message(_, _, _, true = _config_in_overnight_period), do: nil
-
-  defp service_ended_message(true = _service_ended?, config, false = _sign_in_overnight_period) do
-    route = Signs.Utilities.SourceConfig.single_route(config)
-
-    %Message.ServiceEnded{destination: config.headway_destination, route: route}
+  defp headway_message(%ConfigContext{config: config, headways: headways}) do
+    if headways do
+      %Message.Headway{
+        destination: config.headway_destination,
+        range: {headways.range_low, headways.range_high},
+        route: Signs.Utilities.SourceConfig.single_route(config)
+      }
+    end
   end
 
-  defp service_ended_message(_, _, _), do: nil
+  defp service_ended_message(
+         %ConfigContext{config: config} = config_context,
+         %SignContext{} = sign_context
+       ) do
+    route = Signs.Utilities.SourceConfig.single_route(config)
+
+    if config_context.service_ended? and not in_overnight_period?(sign_context) do
+      %Message.ServiceEnded{destination: config.headway_destination, route: route}
+    end
+  end
 end

--- a/lib/signs/utilities/predictions.ex
+++ b/lib/signs/utilities/predictions.ex
@@ -5,18 +5,12 @@ defmodule Signs.Utilities.Predictions do
   for the top and bottom lines.
   """
 
-  @spec get_passthrough_train_audio(Signs.Realtime.predictions(), Signs.Realtime.t()) ::
-          [Content.Audio.t()]
-  def get_passthrough_train_audio(predictions, sign) do
-    case {sign.source_config, predictions} do
-      {{top_config, bottom_config}, {top_predictions, bottom_predictions}} ->
-        [{top_config, top_predictions}, {bottom_config, bottom_predictions}]
+  alias Signs.Utilities.SignContext
 
-      {config, predictions} ->
-        [{config, predictions}]
-    end
-    |> Enum.flat_map(fn {config, predictions} ->
-      Enum.filter(predictions, fn prediction ->
+  @spec get_passthrough_train_audio(SignContext.t()) :: [Content.Audio.t()]
+  def get_passthrough_train_audio(%SignContext{} = sign_context) do
+    Enum.flat_map(sign_context.config_contexts, fn config_context ->
+      Enum.filter(config_context.predictions, fn prediction ->
         prediction.schedule_relationship == :skipped &&
           prediction.seconds_until_arrival &&
           prediction.seconds_until_arrival <=
@@ -26,7 +20,7 @@ defmodule Signs.Utilities.Predictions do
       |> Enum.flat_map(fn prediction ->
         [
           %Content.Audio.Passthrough{
-            destination: config.headway_destination,
+            destination: config_context.config.headway_destination,
             trip_id: prediction.trip_id,
             route_id: prediction.route_id
           }

--- a/lib/signs/utilities/sign_context.ex
+++ b/lib/signs/utilities/sign_context.ex
@@ -1,29 +1,37 @@
 defmodule Signs.Utilities.SignContext do
   @moduledoc false
 
-  @enforce_keys [
-    :predictions,
-    :all_predictions,
-    :sign_config,
-    :current_time,
-    :alert_status,
-    :first_scheduled_departures,
-    :last_scheduled_departures,
-    :recent_departures,
-    :service_end_statuses_per_source
-  ]
+  defmodule ConfigContext do
+    @enforce_keys [
+      :config,
+      :predictions,
+      :alert_status,
+      :headways,
+      :first_scheduled_departure,
+      :last_scheduled_departure,
+      :most_recent_departure,
+      :service_ended?
+    ]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{
+            config: Signs.Utilities.SourceConfig.config(),
+            predictions: [Predictions.Prediction.t()],
+            alert_status: Engine.Alerts.Fetcher.stop_status(),
+            headways: Engine.Config.Headway.t() | nil,
+            first_scheduled_departure: DateTime.t() | nil,
+            last_scheduled_departure: DateTime.t() | nil,
+            most_recent_departure: DateTime.t() | nil,
+            service_ended?: boolean()
+          }
+  end
+
+  @enforce_keys [:sign_config, :current_time, :config_contexts]
   defstruct @enforce_keys
 
-  @type single_or_tuple(t) :: t | {t, t}
   @type t :: %__MODULE__{
-          predictions: Signs.Realtime.predictions(),
-          all_predictions: list(Predictions.Prediction.t()),
           sign_config: Engine.Config.sign_config(),
           current_time: DateTime.t(),
-          alert_status: single_or_tuple(Engine.Alerts.Fetcher.stop_status()),
-          first_scheduled_departures: single_or_tuple(nil | DateTime.t()),
-          last_scheduled_departures: single_or_tuple(nil | DateTime.t()),
-          recent_departures: single_or_tuple(nil | DateTime.t()),
-          service_end_statuses_per_source: single_or_tuple(boolean())
+          config_contexts: [ConfigContext.t()]
         }
 end

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1582,7 +1582,7 @@ defmodule Signs.RealtimeTest do
         [prediction(arrival: 180, destination: :ashmont)]
       end)
 
-      expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
+      expect(Engine.ScheduledHeadways.Mock, :display_headways?, 2, fn _, _, _ -> false end)
 
       expect_messages({"Ashmont      3 min", "Northbound due 5:00"})
 
@@ -1599,7 +1599,7 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :alewife, arrival: 240, stop_id: "70086")]
       end)
 
-      expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
+      expect(Engine.ScheduledHeadways.Mock, :display_headways?, 2, fn _, _, _ -> false end)
 
       expect_messages(
         {[{"Southbound train", 6}, {"Alewife      4 min", 6}],
@@ -2062,6 +2062,8 @@ defmodule Signs.RealtimeTest do
   describe "Union Sq alert messaging" do
     setup do
       stub(Engine.Config.Mock, :sign_config, fn _, _ -> :auto end)
+      stub(Engine.Config.Mock, :headway_config, fn _, _ -> @headway_config end)
+      stub(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
       stub(Engine.Alerts.Mock, :min_stop_status, fn _ -> :shuttles_transfer_station end)
       stub(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
       stub(Engine.LastTrip.Mock, :is_last_trip?, fn _ -> false end)
@@ -2182,20 +2184,9 @@ defmodule Signs.RealtimeTest do
         []
       end)
 
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "2" ->
-        %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "2" ->
-        %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
+      expect(Engine.LastTrip.Mock, :get_recent_departures, 4, fn
+        "1" -> %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
+        "2" -> %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
       end)
 
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> false end)
@@ -2235,20 +2226,9 @@ defmodule Signs.RealtimeTest do
         [prediction(destination: :alewife, arrival: 240, stop_id: "70086")]
       end)
 
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "70086" ->
-        %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "1" ->
-        %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn "70086" ->
-        %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
+      expect(Engine.LastTrip.Mock, :get_recent_departures, 4, fn
+        "1" -> %{"a" => datetime(~D[2022-12-31], ~T[23:55:00])}
+        "70086" -> %{"b" => datetime(~D[2022-12-31], ~T[23:55:00])}
       end)
 
       expect(Engine.LastTrip.Mock, :is_last_trip?, fn "a" -> true end)
@@ -2495,20 +2475,9 @@ defmodule Signs.RealtimeTest do
         in_overnight_period
       end)
 
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
-        in_overnight_period
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
-        out_of_overnight_period
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
-        in_overnight_period
-      end)
-
-      expect(Engine.LastTrip.Mock, :get_recent_departures, fn _ ->
-        out_of_overnight_period
+      expect(Engine.LastTrip.Mock, :get_recent_departures, 4, fn
+        "1" -> in_overnight_period
+        "2" -> out_of_overnight_period
       end)
 
       expect_messages({"No Red Line", "Service ended for night"})

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -1,133 +1,13 @@
 defmodule Signs.Utilities.MessagesTest do
   use ExUnit.Case
-  import Mox
 
   require Signs.Utilities.Messages
 
   @midnight DateTime.new!(~D[2023-01-01], ~T[12:00:00], "America/New_York")
   def fake_time_fn, do: @midnight
 
-  describe "flatten_sign_context/2" do
-    setup do
-      stub(Engine.Config.Mock, :headway_config, fn _headway_group, _current_time -> nil end)
-
-      source_config = %Signs.Utilities.SourceConfig{
-        stop_id: "1",
-        direction_id: 0,
-        routes: ["Red"],
-        announce_arriving?: true,
-        announce_boarding?: false
-      }
-
-      %{
-        sign: %Signs.Realtime{
-          id: "sign_id",
-          pa_ess_loc: "TEST",
-          scu_id: "TESTSCU001",
-          text_zone: "x",
-          audio_zones: ["x"],
-          source_config: %{
-            terminal?: false,
-            sources: [source_config],
-            headway_group: "headway_group",
-            headway_destination: :southbound
-          },
-          current_content_top: "Southbound trains",
-          current_content_bottom: "Every 11 to 13 min",
-          current_time_fn: &Signs.Utilities.MessagesTest.fake_time_fn/0,
-          last_update: @midnight,
-          tick_read: 1,
-          read_period_seconds: 100,
-          pa_message_plays: %{},
-          last_message_log_time: @midnight
-        },
-        sign_context: %Signs.Utilities.SignContext{
-          predictions: [
-            %Predictions.Prediction{
-              stop_id: "1",
-              seconds_until_arrival: nil,
-              seconds_until_departure: nil,
-              direction_id: 0,
-              schedule_relationship: nil,
-              route_id: "route_id",
-              trip_id: "123",
-              destination_stop_id: "destination_stop_id",
-              stopped_at_predicted_stop?: false,
-              boarding_status: nil,
-              revenue_trip?: true,
-              vehicle_id: "v1",
-              multi_carriage_details: nil,
-              type: :mid_trip
-            }
-          ],
-          all_predictions: [],
-          sign_config: :auto,
-          current_time: @midnight,
-          alert_status: :none,
-          first_scheduled_departures: nil,
-          last_scheduled_departures: nil,
-          recent_departures: @midnight,
-          service_end_statuses_per_source: false
-        }
-      }
-    end
-
-    test "flattens prediction info for a single source configuration", %{
-      sign: sign,
-      sign_context: sign_context
-    } do
-      flattened_prediction_info = [
-        {
-          sign.source_config,
-          sign_context.predictions,
-          :none,
-          nil,
-          nil,
-          @midnight,
-          false,
-          false
-        }
-      ]
-
-      assert flattened_prediction_info ==
-               Signs.Utilities.Messages.flatten_sign_context(sign_context, sign)
-    end
-  end
-
-  describe "in_overnight_period?/1" do
-    test "returns true for an empty list" do
-      assert Signs.Utilities.Messages.in_overnight_period?([])
-    end
-
-    test "returns true when all signs in overnight period" do
-      prediction_info_one = {nil, nil, nil, nil, nil, nil, nil, true}
-      prediction_info_two = {nil, nil, nil, nil, nil, nil, nil, true}
-
-      assert Signs.Utilities.Messages.in_overnight_period?([prediction_info_one])
-
-      assert Signs.Utilities.Messages.in_overnight_period?([
-               prediction_info_one,
-               prediction_info_two
-             ])
-    end
-
-    test "returns false when any signs are not in overnight period" do
-      prediction_info_one = {nil, nil, nil, nil, nil, nil, nil, false}
-      prediction_info_two = {nil, nil, nil, nil, nil, nil, nil, true}
-
-      refute Signs.Utilities.Messages.in_overnight_period?([prediction_info_one])
-
-      refute Signs.Utilities.Messages.in_overnight_period?([
-               prediction_info_one,
-               prediction_info_two
-             ])
-    end
-  end
-
   describe "get_messages/2" do
     setup do
-      stub(Engine.Config.Mock, :headway_config, fn _headway_group, _current_time -> nil end)
-
       source_config = %Signs.Utilities.SourceConfig{
         stop_id: "1",
         direction_id: 0,
@@ -159,32 +39,42 @@ defmodule Signs.Utilities.MessagesTest do
           last_message_log_time: @midnight
         },
         sign_context: %Signs.Utilities.SignContext{
-          predictions: [
-            %Predictions.Prediction{
-              stop_id: "1",
-              seconds_until_arrival: nil,
-              seconds_until_departure: nil,
-              direction_id: 0,
-              schedule_relationship: nil,
-              route_id: "route_id",
-              trip_id: "123",
-              destination_stop_id: "destination_stop_id",
-              stopped_at_predicted_stop?: false,
-              boarding_status: nil,
-              revenue_trip?: true,
-              vehicle_id: "v1",
-              multi_carriage_details: nil,
-              type: :mid_trip
-            }
-          ],
-          all_predictions: [],
           sign_config: :auto,
           current_time: @midnight,
-          alert_status: :none,
-          first_scheduled_departures: DateTime.shift(@midnight, hour: -1),
-          last_scheduled_departures: DateTime.shift(@midnight, hour: 1),
-          recent_departures: @midnight,
-          service_end_statuses_per_source: false
+          config_contexts: [
+            %Signs.Utilities.SignContext.ConfigContext{
+              config: %{
+                terminal?: false,
+                sources: [source_config],
+                headway_group: "headway_group",
+                headway_destination: :southbound
+              },
+              predictions: [
+                %Predictions.Prediction{
+                  stop_id: "1",
+                  seconds_until_arrival: nil,
+                  seconds_until_departure: nil,
+                  direction_id: 0,
+                  schedule_relationship: nil,
+                  route_id: "route_id",
+                  trip_id: "123",
+                  destination_stop_id: "destination_stop_id",
+                  stopped_at_predicted_stop?: false,
+                  boarding_status: nil,
+                  revenue_trip?: true,
+                  vehicle_id: "v1",
+                  multi_carriage_details: nil,
+                  type: :mid_trip
+                }
+              ],
+              alert_status: :none,
+              headways: nil,
+              first_scheduled_departure: DateTime.shift(@midnight, hour: -1),
+              last_scheduled_departure: DateTime.shift(@midnight, hour: 1),
+              most_recent_departure: @midnight,
+              service_ended?: false
+            }
+          ]
         }
       }
     end
@@ -242,10 +132,12 @@ defmodule Signs.Utilities.MessagesTest do
       sign: sign,
       sign_context: sign_context
     } do
-      sign_context = %{
-        sign_context
-        | service_end_statuses_per_source: true
-      }
+      sign_context =
+        put_in(
+          sign_context,
+          [Access.key!(:config_contexts), Access.at(0), Access.key!(:service_ended?)],
+          true
+        )
 
       assert [%Message.ServiceEnded{destination: :southbound, route: "Red"}] =
                Signs.Utilities.Messages.get_messages(
@@ -260,12 +152,16 @@ defmodule Signs.Utilities.MessagesTest do
     } do
       now = DateTime.new!(~D[2023-01-01], ~T[04:05:00], "America/New_York")
 
-      sign_context = %{
-        sign_context
-        | current_time: now,
-          first_scheduled_departures: DateTime.shift(now, hour: 1),
-          last_scheduled_departures: DateTime.shift(now, hour: 10)
-      }
+      sign_context =
+        %{sign_context | current_time: now}
+        |> update_in(
+          [Access.key!(:config_contexts), Access.at(0)],
+          &%{
+            &1
+            | first_scheduled_departure: DateTime.shift(now, hour: 1),
+              last_scheduled_departure: DateTime.shift(now, hour: 10)
+          }
+        )
 
       assert [%Message.FirstTrain{destination: :southbound}] =
                Signs.Utilities.Messages.get_messages(


### PR DESCRIPTION
#### Summary of changes

This formalizes the new `SignContext` struct and promotes the "flattened" form into its own `ConfigContext` struct. Most of the message generation code now deals with these structs, which streamlines parameter passing.

This reactor ended up being a prerequisite for the PA message lookahead feature.

Most of the changes are mechanical, except for moving the headway information into the context instead of doing an ad-hoc fetch. All the test changes are adjusting the mocks for the new call order; there should be no user visible changes.