### PR TITLE
chore: remove 'tag' field

### DIFF
--- a/lib/pa_ess/updater.ex
+++ b/lib/pa_ess/updater.ex
@@ -25,7 +25,6 @@ defmodule PaEss.Updater do
       end
 
     visual = zip_pages(top, bottom) |> format_pages()
-    tag = create_tag()
     correlation_id = create_correlation_id()
     scu_migrated? = RealtimeSigns.config_engine().scu_migrated?(scu_id)
 
@@ -33,7 +32,6 @@ defmodule PaEss.Updater do
       sign_id: id,
       current_config: log_config,
       visual: Jason.encode!(visual),
-      tag: inspect(tag),
       correlation_id: inspect(correlation_id),
       legacy: !scu_migrated?
     ]
@@ -46,7 +44,6 @@ defmodule PaEss.Updater do
            zones: ["#{pa_ess_loc}-#{text_zone}"],
            visual_data: visual,
            expiration: 180,
-           tag: tag,
            correlation_id: correlation_id
          }, log_meta}
       )
@@ -70,7 +67,6 @@ defmodule PaEss.Updater do
     tts_audios = Enum.map(tts_audios, fn {audio, visual} -> {List.wrap(audio), visual} end)
 
     log_data = fn {audio, visual}, sign, legacy? ->
-      tag = create_tag()
       correlation_id = create_correlation_id()
 
       {[
@@ -85,11 +81,10 @@ defmodule PaEss.Updater do
            |> Enum.join(" ")
            |> inspect(),
          sign_id: sign.id,
-         tag: inspect(tag),
          correlation_id: inspect(correlation_id),
          legacy: legacy?,
          visual: paginate(visual, sign) |> format_pages() |> Jason.encode!()
-       ], tag, correlation_id}
+       ], correlation_id}
     end
 
     if migrated_signs != [] do
@@ -120,7 +115,7 @@ defmodule PaEss.Updater do
 
       Enum.each(migrated_signs, fn sign ->
         Enum.each(tts_items, fn {{audio, visual} = tts_audio, log_meta} ->
-          {logs, tag, correlation_id} = log_data.(tts_audio, sign, false)
+          {logs, correlation_id} = log_data.(tts_audio, sign, false)
 
           PaEss.ScuQueue.enqueue_message(
             sign.scu_id,
@@ -131,7 +126,6 @@ defmodule PaEss.Updater do
                audio_data: Enum.map(audio, &format_audio/1),
                expiration: 30,
                priority: priority,
-               tag: tag,
                correlation_id: correlation_id
              }, Keyword.merge(logs, log_meta)}
           )
@@ -143,7 +137,7 @@ defmodule PaEss.Updater do
       log_list =
         Enum.zip(tts_audios, log_metas)
         |> Enum.map(fn {tts_audio, log_meta} ->
-          {logs, _tag, _correlation_id} = log_data.(tts_audio, sign, true)
+          {logs, _correlation_id} = log_data.(tts_audio, sign, true)
           Keyword.merge(logs, log_meta)
         end)
 
@@ -202,10 +196,6 @@ defmodule PaEss.Updater do
 
   defp ssml(text) do
     ~s(<speak><amazon:effect name="drc"><prosody rate="90%">#{xml_escape(text)}</prosody></amazon:effect></speak>)
-  end
-
-  defp create_tag() do
-    :rand.bytes(16) |> Base.encode64(padding: false)
   end
 
   @spec create_correlation_id() :: String.t()


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** None
Remove the 'tag' field from logs. 'tag' is a special item in Splunk, which requires special consideration when querying on. To move away from this field, we added `correlation_id` in 41b7caf1. This commit is a follow-up, removing `tag`.


#### Notes to Reviewers

1. I need to formally update the query in PAESS - Audio Announcement Log. I've tested it in a separate search context, but want to get a little more data in splunk using `correlation_id` before making the switch
2. This should land after https://github.com/mbta/scully/pull/224

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [x] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
