### PR TITLE
fix: prevent unknown platform announcement at jfk

### DIFF
--- a/lib/content/audio/predictions.ex
+++ b/lib/content/audio/predictions.ex
@@ -174,10 +174,10 @@ defmodule Content.Audio.Predictions do
         !platform ->
           {nil, false, nil}
 
-        jfk_mezzanine? and minutes > @announce_platform_later_mins ->
+        jfk_mezzanine? and is_integer(minutes) and minutes > @announce_platform_later_mins ->
           {nil, false, :later}
 
-        jfk_mezzanine? and minutes > @announce_platform_soon_mins ->
+        jfk_mezzanine? and is_integer(minutes) and minutes > @announce_platform_soon_mins ->
           {nil, false, :soon}
 
         minutes == 1 or (!jfk_mezzanine? and !jfk_mezzanine_single_platform?) ->

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1352,6 +1352,52 @@ defmodule Signs.RealtimeTest do
       Signs.Realtime.handle_info(:run_loop, %{@jfk_mezzanine_sign | tick_read: 0})
     end
 
+    test "JFK mezzanine platform announces platform when arrival is imminent" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(destination: :ashmont, arrival: 120)]
+      end)
+
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [
+          prediction(destination: :alewife, arrival: 650, stop_id: "70086"),
+          prediction(destination: :alewife, arrival: 0, stop_id: "70096")
+        ]
+      end)
+
+      expect_messages(
+        {"Ashmont      2 min", [{"Alewife (B)    ARR", 6}, {"Alewife (Braintree plat)", 6}]}
+      )
+
+      expect_audios(
+        [
+          {:canned, {"115", spaced(["501", "4016", "864", "503", "504", "5002", "505"]), :audio}},
+          {:canned,
+           {"115",
+            [
+              "501",
+              "21000",
+              "4000",
+              "21000",
+              "864",
+              "21000",
+              "24055",
+              "21000",
+              "851",
+              "21000",
+              "4021",
+              "21000",
+              "529"
+            ], :audio}}
+        ],
+        [
+          {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
+          {"The next, Alewife, train; is now arriving; on the Braintree platform.", nil}
+        ]
+      )
+
+      Signs.Realtime.handle_info(:run_loop, %{@jfk_mezzanine_sign | tick_read: 0})
+    end
+
     test "JFK mezzanine shows platform when all predictions to Alewife use same platform" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [prediction(destination: :ashmont, arrival: 120)]


### PR DESCRIPTION

#### Summary of changes

**Asana Ticket:** [Bug: Unknown platform for Boarding train at JFK](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214815288273850?focus=true)

Fix an instance where handling platform announcements at JFK would previously read as:

> The next Alewife train is now boarding. We will announce the platform
> for boarding when the train is closer.

This was caused by comparing an atom returned by the `prediction_minutes/2` helper to an integer, resulting in the confusing messaging. Validate that the returned value is an integer before doing the comparison to ensure the platform is correctly displayed when we know it


#### Reviewer Checklist

- [x] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [x] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
