### PR TITLE
delay PA messages when there's an upcoming announcement

### DIFF
--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -217,7 +217,9 @@ defmodule Signs.Bus do
         state
       end
     end)
-    |> Signs.Utilities.Audio.play_pa_messages(current_time)
+    |> Signs.Utilities.Audio.play_pa_messages(current_time,
+      upcoming_announcement?: should_read?(DateTime.add(current_time, 30), state)
+    )
     |> then(fn state ->
       if should_read?(current_time, state) do
         send_audio(audios, tts_audios, state)

--- a/lib/signs/realtime.ex
+++ b/lib/signs/realtime.ex
@@ -162,14 +162,16 @@ defmodule Signs.Realtime do
     sign_context = derive_sign_context(sign)
     messages = Utilities.Messages.get_messages(sign, sign_context)
     {new_top, new_bottom} = Utilities.Messages.render_messages(messages)
-    sign_in_overnight_period? = Signs.Utilities.Messages.in_overnight_period?(sign_context)
 
     sign =
       sign
       |> announce_passthrough_trains(sign_context)
       |> Utilities.Updater.update_sign(new_top, new_bottom, sign_context.current_time)
       |> Utilities.Reader.do_announcements(messages)
-      |> Utilities.Audio.play_pa_messages(sign_context.current_time, sign_in_overnight_period?)
+      |> Utilities.Audio.play_pa_messages(sign_context.current_time,
+        overnight?: Signs.Utilities.Messages.in_overnight_period?(sign_context),
+        upcoming_announcement?: upcoming_announcement?(sign, sign_context)
+      )
       |> Utilities.Reader.read_sign(messages)
       |> decrement_ticks()
       |> log_sign_messages(messages)
@@ -182,6 +184,23 @@ defmodule Signs.Realtime do
   def handle_info(msg, state) do
     Logger.warning("Signs.Realtime unknown_message: #{inspect(msg)}")
     {:noreply, state}
+  end
+
+  defp upcoming_announcement?(sign, sign_context) do
+    {upcoming_announcements, _} =
+      update_in(
+        sign_context,
+        [Access.key!(:config_contexts), Access.all(), Access.key!(:predictions), Access.all()],
+        fn prediction ->
+          prediction
+          |> Map.update!(:seconds_until_arrival, &advance_30_seconds/1)
+          |> Map.update!(:seconds_until_departure, &advance_30_seconds/1)
+        end
+      )
+      |> then(&Utilities.Messages.get_messages(sign, &1))
+      |> then(&Utilities.Audio.get_announcements(sign, &1))
+
+    upcoming_announcements != [] or sign.tick_read < 30
   end
 
   defp has_service_ended_for_source?(source, current_time) do
@@ -294,4 +313,7 @@ defmodule Signs.Realtime do
   def decrement_ticks(sign) do
     %{sign | tick_read: sign.tick_read - 1}
   end
+
+  defp advance_30_seconds(nil), do: nil
+  defp advance_30_seconds(n), do: n - 30
 end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -199,21 +199,29 @@ defmodule Signs.Utilities.Audio do
     )
   end
 
-  def play_pa_messages(sign, now, overnight? \\ false) do
+  def play_pa_messages(sign, now, opts \\ []) do
     RealtimeSigns.pa_message_engine().for_sign(sign.id)
     |> Enum.reduce(sign, fn pa_message, sign ->
       update_in(sign, [Access.key!(:pa_message_schedules), pa_message.id], fn next ->
         new_next = DateTime.add(now, pa_message.interval_in_ms, :millisecond)
 
-        if is_nil(next) or DateTime.after?(now, next) do
-          if not (overnight? and pa_message.priority > 1) do
-            send_audio([sign], [pa_message])
-          end
-
-          new_next
-        else
+        cond do
           # If the interval is changed to be shorter, bump the schedule up if needed
-          earlier_datetime(next, new_next)
+          next && DateTime.before?(now, next) ->
+            earlier_datetime(next, new_next)
+
+          # Skip playback
+          (opts[:overnight?] && pa_message.priority > 1) ||
+              (opts[:upcoming_announcement?] && pa_message.priority > 2) ->
+            new_next
+
+          # Defer playback
+          opts[:upcoming_announcement?] && pa_message.priority > 1 ->
+            DateTime.add(now, 30)
+
+          true ->
+            send_audio([sign], [pa_message])
+            new_next
         end
       end)
     end)

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -633,7 +633,8 @@ defmodule Signs.BusTest do
             id: 1,
             visual_text: "A PA Message",
             audio_text: "A PA Message",
-            interval_in_ms: 120_000
+            interval_in_ms: 120_000,
+            priority: 2
           }
         ]
       end)
@@ -646,6 +647,24 @@ defmodule Signs.BusTest do
 
       state = %{@sign_state | last_read_time: Timex.now()}
       Signs.Bus.handle_info(:run_loop, state)
+    end
+
+    test "defers PA message playback" do
+      expect(Engine.PaMessages.Mock, :for_sign, fn _ ->
+        [
+          %PaMessages.PaMessage{
+            id: 1,
+            visual_text: "A PA Message",
+            audio_text: "A PA Message",
+            interval_in_ms: 120_000,
+            priority: 2
+          }
+        ]
+      end)
+
+      expect_messages(["No bus service", ""])
+      expect_audios([{:canned, {"103", ["878"], :audio}}], [{"No bus service", nil}])
+      Signs.Bus.handle_info(:run_loop, @sign_state)
     end
 
     test "arriving prediction" do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -43,7 +43,7 @@ defmodule Signs.RealtimeTest do
     current_content_bottom: "Every 11 to 13 min",
     current_time_fn: &Signs.RealtimeTest.fake_time_fn/0,
     last_update: @fake_time,
-    tick_read: 1,
+    tick_read: 100,
     read_period_seconds: 100,
     pa_message_schedules: %{},
     last_message_log_time: @fake_time
@@ -216,8 +216,8 @@ defmodule Signs.RealtimeTest do
     end
 
     test "decrements ticks and doesn't send audio or text when sign is not expired" do
-      assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, @sign)
-      assert sign.tick_read == 0
+      assert {:noreply, sign} = Signs.Realtime.handle_info(:run_loop, %{@sign | tick_read: 50})
+      assert sign.tick_read == 49
     end
 
     test "refreshes content when expired" do
@@ -953,7 +953,7 @@ defmodule Signs.RealtimeTest do
         [prediction(arrival: 45, destination: :forest_hills, trip_id: "1")]
       end)
 
-      expect(Engine.Locations.Mock, :for_vehicle, 1, fn _ ->
+      expect(Engine.Locations.Mock, :for_vehicle, 2, fn _ ->
         location(crowding_confidence: :high)
       end)
 
@@ -977,7 +977,7 @@ defmodule Signs.RealtimeTest do
         [prediction(arrival: 45, destination: :forest_hills)]
       end)
 
-      expect(Engine.Locations.Mock, :for_vehicle, fn _ ->
+      expect(Engine.Locations.Mock, :for_vehicle, 2, fn _ ->
         location(crowding_confidence: :low)
       end)
 
@@ -2445,6 +2445,31 @@ defmodule Signs.RealtimeTest do
         })
 
       assert DateTime.add(now, 120) |> DateTime.compare(new_time) == :eq
+    end
+
+    test "Defers PA messages when an upcoming announcement is likely" do
+      expect(Engine.PaMessages.Mock, :for_sign, fn _ ->
+        [
+          %PaMessages.PaMessage{
+            id: 1,
+            visual_text: "A PA Message",
+            audio_text: "A PA Message",
+            interval_in_ms: 120_000,
+            priority: 2
+          }
+        ]
+      end)
+
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(destination: :ashmont, arrival: 60)]
+      end)
+
+      expect_messages({"Ashmont      1 min", ""})
+
+      {:noreply, %{pa_message_schedules: %{1 => new_time}}} =
+        Signs.Realtime.handle_info(:run_loop, @sign)
+
+      assert DateTime.add(@fake_time, 30) |> DateTime.compare(new_time) == :eq
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [PA Audio - PA/PSA Readout Lookahead](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1212457153746785?focus=true)

This adds logic for dropping or delaying PA message readouts if there's likely going to be an upcoming announcement. See ticket for details of the algorithm.