### PR TITLE
add special case for June 13-14 service

### DIFF
--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -188,9 +188,18 @@ defmodule Signs.Utilities.Messages do
   defp in_early_am?(_, nil), do: false
 
   defp in_early_am?(current_time, scheduled) do
+    # Special case: Service runs extra late on June 13-14, so adjust the threshold.
+    # This can be removed after the date has passed.
+    early_am_start =
+      if DateTime.to_date(current_time) |> Date.compare(~D[2026-06-14]) == :eq do
+        ~T[05:00:00]
+      else
+        @early_am_start
+      end
+
     Timex.between?(
       DateTime.to_time(current_time),
-      @early_am_start,
+      early_am_start,
       DateTime.to_time(scheduled),
       inclusive: :start
     )

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -1725,6 +1725,29 @@ defmodule Signs.RealtimeTest do
       })
     end
 
+    # Special case: Service runs extra late on June 13-14, so the early AM threshold is adjusted.
+    # This can be removed after the date has passed.
+    test "June 13-14 late service" do
+      date = ~D[2026-06-14]
+
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        [prediction(arrival: 180, destination: :ashmont)]
+      end)
+
+      expect(Engine.ScheduledHeadways.Mock, :get_first_scheduled_departure, fn _ ->
+        DateTime.new!(date, ~T[06:00:00], "America/New_York")
+      end)
+
+      expect(Engine.ScheduledHeadways.Mock, :display_headways?, fn _, _, _ -> false end)
+
+      expect_messages({"Ashmont      3 min", ""})
+
+      Signs.Realtime.handle_info(:run_loop, %{
+        @sign
+        | current_time_fn: fn -> DateTime.new!(date, ~T[04:10:00], "America/New_York") end
+      })
+    end
+
     test "Identifies new Red Line Cars" do
       expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
         [


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Support Very Late Service in PA/ESS](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214365239209200?focus=true)

This adjusts the "early AM threshold" for June 13-14 as a special case, to deal with extra late service on that day. The effect is that the early AM period and associated prediction suppression will not start until 5:00. This should be the only logic that has a hard-coded notion of service day, everything else should adjust appropriately based on the data recieved.