### PR TITLE
allow changing custom audio TTS string

### DIFF
--- a/lib/content/audio/custom.ex
+++ b/lib/content/audio/custom.ex
@@ -5,20 +5,22 @@ defmodule Content.Audio.Custom do
 
   require Logger
 
-  @enforce_keys [:message]
+  @enforce_keys [:top, :bottom, :audio_text]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
-          message: String.t()
+          top: String.t(),
+          bottom: String.t(),
+          audio_text: String.t()
         }
 
   defimpl Content.Audio do
-    def to_params(%Content.Audio.Custom{message: message}) do
-      {:ad_hoc, {message, :audio}}
+    def to_params(%Content.Audio.Custom{top: top, bottom: bottom}) do
+      {:ad_hoc, {PaEss.Utilities.custom_tts_text(top, bottom), :audio}}
     end
 
-    def to_tts(%Content.Audio.Custom{} = audio) do
-      {audio.message, nil}
+    def to_tts(%Content.Audio.Custom{audio_text: audio_text}) do
+      {audio_text, nil}
     end
 
     def to_logs(%Content.Audio.Custom{}) do

--- a/lib/engine/config.ex
+++ b/lib/engine/config.ex
@@ -18,7 +18,10 @@ defmodule Engine.Config do
         }
 
   @type sign_config ::
-          :auto | :off | :temporary_terminal | {:static_text, {String.t(), String.t()}}
+          :auto
+          | :off
+          | :temporary_terminal
+          | {:static_text, {String.t(), String.t(), String.t()}}
 
   @table_signs :config_engine_signs
   @table_headways :config_engine_headways
@@ -180,25 +183,19 @@ defmodule Engine.Config do
   end
 
   @spec parse_sign_config(map()) :: sign_config()
-  defp parse_sign_config(config_json) do
-    cond do
-      config_json["mode"] == "off" ->
-        :off
+  defp parse_sign_config(%{"mode" => "off"}), do: :off
+  defp parse_sign_config(%{"mode" => "auto"}), do: :auto
+  defp parse_sign_config(%{"mode" => "temporary_terminal"}), do: :temporary_terminal
 
-      config_json["mode"] == "static_text" or config_json["line1"] != nil or
-          config_json["line2"] != nil ->
-        {:static_text, {config_json["line1"], config_json["line2"]}}
-
-      config_json["mode"] == "auto" ->
-        :auto
-
-      config_json["mode"] == "temporary_terminal" ->
-        :temporary_terminal
-
-      true ->
-        nil
-    end
+  defp parse_sign_config(%{"mode" => "static_text"} = config) do
+    top = config["line1"]
+    bottom = config["line2"]
+    # Note: This conditional can be removed after all existing custom messages include this field.
+    audio_text = config["audio_text"] || PaEss.Utilities.custom_tts_text(top, bottom)
+    {:static_text, {top, bottom, audio_text}}
   end
+
+  defp parse_sign_config(_), do: nil
 
   defp schedule_update(pid, time \\ 1_000) do
     Process.send_after(pid, :update, time)

--- a/lib/fake/external_config/local.ex
+++ b/lib/fake/external_config/local.ex
@@ -11,7 +11,13 @@ defmodule Fake.ExternalConfig.Local do
       nil,
       %{
         "signs" => %{
-          "some_custom_sign" => %{"line1" => "custom", "line2" => "", "expires" => nil}
+          "some_custom_sign" => %{
+            "mode" => "static_text",
+            "line1" => "custom",
+            "line2" => "",
+            "audio_text" => "custom",
+            "expires" => nil
+          }
         },
         "chelsea_bridge_announcements" => "off"
       }
@@ -39,8 +45,10 @@ defmodule Fake.ExternalConfig.Local do
          "chelsea_inbound" => %{"mode" => "auto"},
          "chelsea_outbound" => %{"mode" => "off"},
          "custom_text_test" => %{
+           "mode" => "static_text",
            "line1" => "Test message",
            "line2" => "Please ignore",
+           "audio_text" => "Test message Please ignore",
            "expires" => "2017-07-04T12:00:00Z"
          },
          "off_test" => %{"mode" => "off"},

--- a/lib/message/custom.ex
+++ b/lib/message/custom.ex
@@ -1,10 +1,11 @@
 defmodule Message.Custom do
-  @enforce_keys [:top, :bottom]
+  @enforce_keys [:top, :bottom, :audio_text]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           top: String.t(),
-          bottom: String.t()
+          bottom: String.t(),
+          audio_text: String.t()
         }
 
   defimpl Message do
@@ -19,8 +20,8 @@ defmodule Message.Custom do
 
     def to_multi_line(%Message.Custom{} = message), do: to_full_page(message)
 
-    def to_audio(%Message.Custom{top: top, bottom: bottom}, _multiple?) do
-      [%Content.Audio.Custom{message: PaEss.Utilities.custom_tts_text(top, bottom)}]
+    def to_audio(%Message.Custom{top: top, bottom: bottom, audio_text: audio_text}, _multiple?) do
+      [%Content.Audio.Custom{top: top, bottom: bottom, audio_text: audio_text}]
     end
   end
 end

--- a/lib/signs/bus.ex
+++ b/lib/signs/bus.ex
@@ -312,7 +312,7 @@ defmodule Signs.Bus do
          route_alerts_lookup,
          state
        ) do
-    {_, {line1, line2}} = config
+    {_, {line1, line2, audio_text}} = config
 
     messages =
       [
@@ -333,13 +333,11 @@ defmodule Signs.Bus do
       )
       |> paginate_pairs()
 
-    tts_text = PaEss.Utilities.custom_tts_text(line1, line2)
-
     audios =
-      [{:ad_hoc, {tts_text, :audio}}]
+      [{:ad_hoc, {PaEss.Utilities.custom_tts_text(line1, line2), :audio}}]
       |> Enum.concat(bridge_audio(bridge_status, bridge_enabled?, current_time, state))
 
-    tts_audios = [{tts_text, nil}]
+    tts_audios = [{audio_text, nil}]
 
     {messages, audios, tts_audios}
   end

--- a/lib/signs/utilities/audio.ex
+++ b/lib/signs/utilities/audio.ex
@@ -23,8 +23,8 @@ defmodule Signs.Utilities.Audio do
       %Message.Custom{} = message ->
         [audio] = Message.to_audio(message, length(messages) > 1)
 
-        if sign.announced_custom_text != audio.message do
-          {audios ++ [audio], %{sign | announced_custom_text: audio.message}}
+        if sign.announced_custom_text != audio.audio_text do
+          {audios ++ [audio], %{sign | announced_custom_text: audio.audio_text}}
         else
           {audios, sign}
         end

--- a/lib/signs/utilities/messages.ex
+++ b/lib/signs/utilities/messages.ex
@@ -16,12 +16,12 @@ defmodule Signs.Utilities.Messages do
     sign_in_overnight_period = in_overnight_period?(sign_context)
 
     cond do
-      match?({:static_text, {_, _}}, sign_config) ->
+      match?({:static_text, {_, _, _}}, sign_config) ->
         if sign_in_overnight_period do
           [%Message.Empty{}]
         else
-          {:static_text, {line1, line2}} = sign_config
-          [%Message.Custom{top: line1, bottom: line2}]
+          {:static_text, {line1, line2, audio_text}} = sign_config
+          [%Message.Custom{top: line1, bottom: line2, audio_text: audio_text}]
         end
 
       sign_config == :off ->

--- a/test/engine/config_test.exs
+++ b/test/engine/config_test.exs
@@ -19,7 +19,7 @@ defmodule Engine.ConfigTest do
         })
 
       assert Engine.Config.sign_config(state.table_name_signs, "custom_text_test", :off) ==
-               {:static_text, {"Test message", "Please ignore"}}
+               {:static_text, {"Test message", "Please ignore", "Test message Please ignore"}}
     end
 
     test "does not return custom text when it's expired" do
@@ -45,7 +45,7 @@ defmodule Engine.ConfigTest do
       initialize_test_state(%{table_name_signs: :test_new_format, current_version: "new_format"})
 
       assert Engine.Config.sign_config(:test_new_format, "some_custom_sign", :off) ==
-               {:static_text, {"custom", ""}}
+               {:static_text, {"custom", "", "custom"}}
     end
 
     test "handles a config with multi-sign headways" do

--- a/test/signs/bus_test.exs
+++ b/test/signs/bus_test.exs
@@ -131,7 +131,7 @@ defmodule Signs.BusTest do
       stub(Engine.Config.Mock, :sign_config, fn
         "auto_sign", _default -> :auto
         "off_sign", _default -> :off
-        "static_sign", _default -> {:static_text, {"custom", "message"}}
+        "static_sign", _default -> {:static_text, {"custom", "message", "special message"}}
       end)
 
       stub(Engine.Config.Mock, :chelsea_bridge_config, fn -> :auto end)
@@ -277,7 +277,7 @@ defmodule Signs.BusTest do
 
     test "static mode" do
       expect_messages(["custom", "message"])
-      expect_audios([{:ad_hoc, {"custom message", :audio}}], [{"custom message", nil}])
+      expect_audios([{:ad_hoc, {"custom message", :audio}}], [{"special message", nil}])
 
       state = Map.merge(@sign_state, %{id: "static_sign"})
 

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -332,7 +332,7 @@ defmodule Signs.RealtimeTest do
 
     test "when custom text is present, display it, overriding alerts" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"custom", "message"}}
+        {:static_text, {"custom", "message", "custom message"}}
       end)
 
       expect(Engine.Alerts.Mock, :min_stop_status, fn _ -> :suspension_closed_station end)
@@ -351,7 +351,7 @@ defmodule Signs.RealtimeTest do
 
     test "when sign has a default mode, uses that when the sign has no mode configured" do
       expect(Engine.Config.Mock, :sign_config, fn _, default -> default end)
-      sign = %{@sign | default_mode: {:static_text, {"default", "message"}}}
+      sign = %{@sign | default_mode: {:static_text, {"default", "message", "default message"}}}
 
       expect_messages({"default", "message"})
       expect_audios([{:ad_hoc, {"default message", :audio}}], [{"default message", nil}])
@@ -1054,28 +1054,28 @@ defmodule Signs.RealtimeTest do
 
     test "reads custom messages" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"custom", "message"}}
+        {:static_text, {"custom", "message", "special message"}}
       end)
 
       expect_messages({"custom", "message"})
-      expect_audios([{:ad_hoc, {"custom message", :audio}}], [{"custom message", nil}])
+      expect_audios([{:ad_hoc, {"custom message", :audio}}], [{"special message", nil}])
 
       Signs.Realtime.handle_info(:run_loop, %{
         @sign
         | tick_read: 0,
-          announced_custom_text: "custom message"
+          announced_custom_text: "special message"
       })
     end
 
     test "invalid custom messages" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"bad^", "long long long long message"}}
+        {:static_text, {"bad^", "long long long long message", "audio message"}}
       end)
 
       expect_messages({"bad", "long long long long mess"})
 
       expect_audios([{:ad_hoc, {"bad long long long long mess", :audio}}], [
-        {"bad long long long long mess", nil}
+        {"audio message", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -1083,13 +1083,13 @@ defmodule Signs.RealtimeTest do
 
     test "replaces abbreviations in custom messages" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"No OL Svc", ""}}
+        {:static_text, {"No OL Svc", "", "No OL Svc"}}
       end)
 
       expect_messages({"No OL Svc", ""})
 
       expect_audios([{:ad_hoc, {"No Orange Line Service", :audio}}], [
-        {"No Orange Line Service", nil}
+        {"No OL Svc", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, @sign)
@@ -2518,7 +2518,7 @@ defmodule Signs.RealtimeTest do
 
     test "does not show custom text during overnight period" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"custom", "message"}}
+        {:static_text, {"custom", "message", "custom message"}}
       end)
 
       expect_messages({"", ""})

--- a/test/signs/utilities/messages_test.exs
+++ b/test/signs/utilities/messages_test.exs
@@ -102,10 +102,16 @@ defmodule Signs.Utilities.MessagesTest do
     } do
       sign_context = %{
         sign_context
-        | sign_config: {:static_text, {"This is line 1", "This is line 2"}}
+        | sign_config: {:static_text, {"This is line 1", "This is line 2", "Audio"}}
       }
 
-      assert [%Message.Custom{top: "This is line 1", bottom: "This is line 2"}] ==
+      assert [
+               %Message.Custom{
+                 top: "This is line 1",
+                 bottom: "This is line 2",
+                 audio_text: "Audio"
+               }
+             ] ==
                Signs.Utilities.Messages.get_messages(
                  sign,
                  sign_context


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Custom Text Audio Modification for migrated stations](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1212682780570818?focus=true)

This reads the new `audio_text` field from custom message configs and uses it to override the TTS string for migrated stations. Note that abbreviations are _not_ replaced in this case, because we want to allow explicit control via the new UI.