### PR TITLE
deps: remove unused `configparser_ex`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -49,10 +49,6 @@ config :realtime_signs,
 config :realtime_signs, RealtimeSignsWeb.Endpoint,
   secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________"
 
-config :ex_aws,
-  access_key_id: [{:system, "SIGNS_S3_CONFIG_KEY"}, :instance_role],
-  secret_access_key: [{:system, "SIGNS_S3_CONFIG_SECRET"}, :instance_role]
-
 config :logger, utc_log: true
 
 config :logger, :console,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,11 +5,3 @@ config :logger, :console, level: :info
 config :realtime_signs,
   external_config_getter: ExternalConfig.S3,
   restart_fn: &System.restart/0
-
-config :ex_aws,
-  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role],
-  secret_access_key: [
-    {:system, "AWS_SECRET_ACCESS_KEY"},
-    {:awscli, "default", 30},
-    :instance_role
-  ]

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,6 @@ defmodule RealtimeSigns.Mixfile do
       {:quantum, "~> 3.0"},
       {:phoenix, "~> 1.8.7"},
       {:plug_cowboy, "~> 2.5"},
-      {:configparser_ex, "~> 4.0", only: [:prod]},
       {:remote_ip, "~> 1.2"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.15.0", "0e6e882fcdaaa0a5a9f2b3db55b1394dba07e8d6d9bcad08318fb604c6839712", [:rebar3], [], "hexpm", "b147ed22ce71d72eafdad94f055165c1c182f61a2ff49df28bcc71d1d5b94a60"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
-  "configparser_ex": {:hex, :configparser_ex, "4.0.0", "17e2b831cfa33a08c56effc610339b2986f0d82a9caa0ed18880a07658292ab6", [:mix], [], "hexpm", "02e6d1a559361a063cba7b75bc3eb2d6ad7e62730c551cc4703541fd11e65e5b"},
   "cowboy": {:hex, :cowboy, "2.17.0", "059d6ae769214cedf55d115ce5bf38649ff6b32ec693067cf6b185d0ab1b53c3", [:make, :rebar3], [{:cowlib, ">= 2.18.0 and < 3.0.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, ">= 1.8.0 and < 3.0.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "84f0e4c9d5820342cd506472052b79336d0d9d3624e46303f6d0af9dc94e8d5f"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.4.0", "f239f68b588efa7707abce16a84d0d2acf3a0f50571f8bb7f56a15865aae820c", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7d98bac1ee4565d31b62d59f8823dfd8356a169e7fcbb83831b8a5397404c9de"},
   "cowlib": {:hex, :cowlib, "2.18.0", "4a3ef8cb012c21c7cbb7c925f75405e26d7fcd393fd78c46187539dbc9a48310", [:make, :rebar3], [], "hexpm", "c4f89d33a61162d4cfdcb5a1af7e562d80a700b2573cc71020ce6521b152dc1a"},


### PR DESCRIPTION
This is an optional dependency of ExAws and only needed to load AWS CLI config files. It appears to be an artifact of when RTS was deployed to on-prem Windows servers, since the dependency is `prod`-only and we don't have the AWS CLI installed in the Docker containers we deploy to ECS today.

Also remove configuration that configured ExAws using `SIGNS_S3_CONFIG_` environment variables in non-prod environments; these are not found in the current `.envrc.template`. Having done this, the entire config block can be deleted, since it is the same as the default value[^1].

[^1]: https://github.com/ex-aws/ex_aws#aws-key-configuration