### PR TITLE
chore: use deploy-actions v2.22

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-ecs@v2.21
+      - uses: mbta/actions/deploy-ecs@v2.22
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-ecs@v2.21
+      - uses: mbta/actions/deploy-ecs@v2.22
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-ecs@v2.21
+      - uses: mbta/actions/deploy-ecs@v2.22
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** N/A

In 448d79e5, we bumped the `mbta/actions/deploy-ecs` action to v2.21.
This version has a bug that was rectified in v2.22, where prior to this
commit, ECS deployments would fail to stabilize:
```
  id: ecs-svc/4477346908675179503, Status:  IN_PROGRESS, Running:   1, Failed:   0, Pending:   0, Desired:   1
  id: ecs-svc/4477346908675179503, Status:  IN_PROGRESS, Running:   1, Failed:   1, Pending:   0, Desired:   1
The deployment failed because one or more containers stopped running. The reasons given were:
```

Link to an example deploy run - https://github.com/mbta/realtime_signs/actions/runs/29250711607/job/86819861441

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
