### PR TITLE
fix: show platform info at jfk for temp terminals

### DIFF
--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -107,7 +107,7 @@ defmodule Message.Predictions do
           match?({:jfk_mezzanine, _}, special_sign) and prediction.direction_id == 1 ->
             platform_name = Content.Utilities.stop_platform_name(prediction.stop_id)
 
-            # {_, false} in special_sign indicates both stop_ids for inbound trains are active.
+            # {_, false} in special_sign indicates both stop_ids for northbound trains are active.
             # In this case, predicted platform is still subject to change when it's 5+ minutes away
             {headsign_message, platform_message} =
               if is_integer(minutes) and minutes > 5 and special_sign == {:jfk_mezzanine, false} do

--- a/lib/message/predictions.ex
+++ b/lib/message/predictions.ex
@@ -5,6 +5,8 @@ defmodule Message.Predictions do
   @type t :: %__MODULE__{
           predictions: [Predictions.Prediction.t()],
           terminal?: boolean(),
+          # For JFK platform, track if Alewife-bound trains are using a single platform,
+          # indicated by `true`.
           special_sign: {:jfk_mezzanine, true | false} | :bowdoin_eastbound | nil
         }
 
@@ -102,10 +104,10 @@ defmodule Message.Predictions do
         track_number = Content.Utilities.stop_track_number(prediction.stop_id)
 
         cond do
-          match?({:jfk_mezzanine, _}, special_sign) and destination == "place-alfcl" ->
+          match?({:jfk_mezzanine, _}, special_sign) and prediction.direction_id == 1 ->
             platform_name = Content.Utilities.stop_platform_name(prediction.stop_id)
 
-            # {_, false} in special_sign indicates both stop_ids for Alewife-bound trains are active
+            # {_, false} in special_sign indicates both stop_ids for inbound trains are active.
             # In this case, predicted platform is still subject to change when it's 5+ minutes away
             {headsign_message, platform_message} =
               if is_integer(minutes) and minutes > 5 and special_sign == {:jfk_mezzanine, false} do

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -168,6 +168,7 @@ defmodule Signs.RealtimeTest do
       "shawmut" -> "place-smmnl"
       "braintree" -> "place-brntn"
       "mattapan" -> "place-matt"
+      "park_st" -> "place-pktrm"
       "boston_college" -> "place-lake"
       "cleveland_circle" -> "place-clmnl"
       "riverside" -> "place-river"
@@ -1187,6 +1188,27 @@ defmodule Signs.RealtimeTest do
       expect_audios([
         {"The next, Ashmont, train; arrives in, 2, minutes.", nil},
         {"The next, Alewife, train; arrives in, 6, minutes; on the Ashmont platform.", nil}
+      ])
+
+      Signs.Realtime.handle_info(:run_loop, %{@jfk_mezzanine_sign | tick_read: 0})
+    end
+
+    test "JFK mezzanine shows platform for temporary terminal" do
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ -> [] end)
+
+      expect(Engine.Predictions.Mock, :for_stop, fn _, _ ->
+        # At Ashmont, heading to temporary terminal Park St
+        [prediction(destination: :park_street, arrival: 240, stop_id: "70086")]
+      end)
+
+      expect_messages(
+        {[{"Southbound trains", 6}, {"Park St      4 min", 6}],
+         [{"Every 11 to 13 min", 6}, {"on Ashmont platform", 6}]}
+      )
+
+      expect_audios([
+        {"Southbound trains every 11 to 13 minutes.", nil},
+        {"The next, Park Street, train; arrives in, 4, minutes; on the Ashmont platform.", nil}
       ])
 
       Signs.Realtime.handle_info(:run_loop, %{@jfk_mezzanine_sign | tick_read: 0})
@@ -2213,6 +2235,9 @@ defmodule Signs.RealtimeTest do
 
           :southbound ->
             [route_id: "Red", direction_id: 0, destination_stop_id: "southbound"]
+
+          :park_street ->
+            [route_id: "Red", direction_id: 1, destination_stop_id: "park_st"]
 
           :mattapan ->
             [route_id: "Mattapan", direction_id: 0, destination_stop_id: "mattapan"]


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** [JFK/UMass Mezzanine Signs not displaying serviced platform](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216785101748911?focus=true)

Update the logic for conditions for displaying the platform information for JFK/UMass Mezzanine. Prior to this commit, we assumed that Alewife was the destination for inbound trains. However, during the current red line diversion, Park Street acts as a temporary terminal. Update the check to check whether the train is inbound to account for temporary terminals.

#### Signs UI Screenshot (localhost)

<img width="370" height="165" alt="Screenshot 2026-07-22 at 16 00 42" src="https://github.com/user-attachments/assets/2300d8da-d652-4d65-9c9b-6987f0537855" />


#### Reviewer Checklist

- [X] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [X] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
