### PR TITLE
add zizmor to repo

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -3,12 +3,16 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions: {}
+
 jobs:
   asana:
-    uses: mbta/workflows/.github/workflows/asana.yml@v5
+    uses: mbta/workflows/.github/workflows/asana.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       attach-pr: true
       trigger-phrase: "\\*\\*Asana Ticket:\\*\\*"
+    permissions:
+      pull-requests: read # Needed to read Asana ticket info from PR description
     secrets:
       asana-token: ${{ secrets.ASANA_SECRET_FOR_INSURIFY_ACTION }}
       github-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}

--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -2,20 +2,28 @@ name: Deploy to Dev Green
 
 on: workflow_dispatch
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read    
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     environment: dev-green-linux
     concurrency: dev-green-linux
     env:
       ECS_CLUSTER: linux-staging
       ECS_SERVICE: realtime-signs-dev-green
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: mbta/actions/build-push-ecr@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         id: build-push
         with:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,20 +5,28 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read  
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     environment: dev-linux
     concurrency: dev-linux
     env:
       ECS_CLUSTER: linux-staging
       ECS_SERVICE: realtime-signs-dev
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: mbta/actions/build-push-ecr@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         id: build-push
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,14 +5,19 @@ on:
     branches-ignore:
       - master
 
+permissions: {}
+
 concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   linux:
+    name: linux
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: docker build .

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,22 +2,30 @@ name: Elixir CI
 
 on: [pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # if we did hit the cache, set up the environment
       - name: Setup ASDF environment
@@ -32,7 +40,7 @@ jobs:
           $ASDF_DIR/bin/asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -3,13 +3,19 @@ name: Deploy to Prod
 on:
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read  
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     environment: prod-linux
     concurrency: prod-linux
     env:
@@ -17,7 +23,9 @@ jobs:
       ECS_SERVICE: realtime-signs-prod
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: mbta/actions/build-push-ecr@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
         id: build-push
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Check
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          persona: auditor


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** [Add Zizmor to realtime_signs](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216719907405013?focus=true)

This commit adds zizmor to the repo. Doing so entails to components:
1. Adding a new workflow to run zizmor when workflow files are edited
2. Updating existing workflows to be compliant with the pedantic persona provided by zizmor

For this repository, the latter consisted of:
1. Pinning actions used. Most actions were up to date already, making this action largely a no-op. Version comment strings have been updated to ensure they do not use major version only tags (e.g. `v5`), as these can cause issues should the tag move to a new version.
2. Updating permissions so actions use have the least amount of permission when running
3. Justifying permissions via comments
4. Adding missing concurrency settings

#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [ ] This branch was deployed to the staging environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
