### PR TITLE
chore: Add dev-blue deploy Action

### DIFF
--- a/.github/workflows/dev-blue.yml
+++ b/.github/workflows/dev-blue.yml
@@ -1,0 +1,43 @@
+name: Deploy to Dev Blue
+
+on: workflow_dispatch
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
+    environment: dev-blue-linux
+    concurrency: dev-blue-linux
+    env:
+      ECS_CLUSTER: linux-staging
+      ECS_SERVICE: realtime-signs-dev-blue
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: mbta/actions/build-push-ecr@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
+        id: build-push
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+      - uses: mbta/actions/deploy-ecs@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          launch-type: EXTERNAL
+      - uses: mbta/actions/notify-slack-deploy@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The application needs several environment variables to access external services.
 
 Realtime Signs runs on on-prem servers. Deployments are managed with ECS Anywhere, which allows us to manage RTS deployments on those on-prem servers. Deployments are initiated through the following GitHub Actions:
 
+- [Deploy to Dev Blue](/.github/workflows/dev-blue.yml)
 - [Deploy to Dev Green](/.github/workflows/dev-green.yml)
 - [Deploy to Dev](/.github/workflows/dev.yml)
 - [Deploy to Prod](/.github/workflows/prod.yml)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [The Blue Stack ](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210919802869816?focus=true)

Adds a Github Action deploy process for dev-blue. This won't be merged until we have the Tofu module changes applied and manual steps completed by infra.

There's an argument for consolidating our environment deploys into a single action, but I actually really like having them separate like this for ease of differentiation, so I won't make that argument.
