### PR TITLE
fix: handle AWS S3 non-JSON success responses

### DIFF
--- a/lib/engine/locations.ex
+++ b/lib/engine/locations.ex
@@ -64,7 +64,7 @@ defmodule Engine.Locations do
 
     last_modified_vehicle_locations =
       case download_data(full_url, state.last_modified_vehicle_positions) do
-        {:ok, body, new_last_modified} ->
+        {:ok, body, new_last_modified} when is_map(body) ->
           {locations_by_vehicle, locations_by_stop} = map_locations_data(body)
           EtsUtils.write_ets(state.vehicle_locations_table, locations_by_vehicle, :none)
           EtsUtils.write_ets(state.stop_locations_table, locations_by_stop, [])

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -57,7 +57,7 @@ defmodule Engine.Predictions do
              headers: if(last_modified, do: [if_modified_since: last_modified], else: []),
              receive_timeout: 2000
            ) do
-        {:ok, %Req.Response{body: json, status: 200, headers: headers}} ->
+        {:ok, %Req.Response{body: json, status: 200, headers: headers}} when is_map(json) ->
           {new_predictions, vehicles_running_revenue_trips} =
             Predictions.Predictions.get_all(json, current_time)
 

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -52,27 +52,28 @@ defmodule Engine.Predictions do
     http_client = Application.get_env(:realtime_signs, :http_client)
 
     new_last_modified =
-      case http_client.get(
-             Application.get_env(:realtime_signs, :trip_update_url),
-             headers: if(last_modified, do: [if_modified_since: last_modified], else: []),
-             receive_timeout: 2000
-           ) do
-        {:ok, %Req.Response{body: json, status: 200, headers: headers}} ->
-          {new_predictions, vehicles_running_revenue_trips} =
-            Predictions.Predictions.get_all(json, current_time)
+      with {:ok, %Req.Response{body: body, status: 200, headers: headers}} <-
+             http_client.get(
+               Application.get_env(:realtime_signs, :trip_update_url),
+               headers: if(last_modified, do: [if_modified_since: last_modified], else: []),
+               receive_timeout: 2000
+             ),
+           true <- is_map(body) do
+        {new_predictions, vehicles_running_revenue_trips} =
+          Predictions.Predictions.get_all(body, current_time)
 
-          Predictions.LastTrip.get_last_trips(json)
-          |> Engine.LastTrip.update_last_trips()
+        Predictions.LastTrip.get_last_trips(body)
+        |> Engine.LastTrip.update_last_trips()
 
-          Predictions.LastTrip.get_recent_departures(json)
-          |> Engine.LastTrip.update_recent_departures()
+        Predictions.LastTrip.get_recent_departures(body)
+        |> Engine.LastTrip.update_recent_departures()
 
-          EtsUtils.write_ets(state.trip_updates_table, new_predictions, [])
+        EtsUtils.write_ets(state.trip_updates_table, new_predictions, [])
 
-          :ets.insert(state.revenue_vehicles_table, {:all, vehicles_running_revenue_trips})
+        :ets.insert(state.revenue_vehicles_table, {:all, vehicles_running_revenue_trips})
 
-          Enum.find_value(headers, fn {key, value} -> if(key == "Last-Modified", do: value) end)
-
+        Enum.find_value(headers, fn {key, value} -> if(key == "Last-Modified", do: value) end)
+      else
         {:ok, %Req.Response{status: 304}} ->
           last_modified
 

--- a/lib/engine/predictions.ex
+++ b/lib/engine/predictions.ex
@@ -52,28 +52,27 @@ defmodule Engine.Predictions do
     http_client = Application.get_env(:realtime_signs, :http_client)
 
     new_last_modified =
-      with {:ok, %Req.Response{body: body, status: 200, headers: headers}} <-
-             http_client.get(
-               Application.get_env(:realtime_signs, :trip_update_url),
-               headers: if(last_modified, do: [if_modified_since: last_modified], else: []),
-               receive_timeout: 2000
-             ),
-           true <- is_map(body) do
-        {new_predictions, vehicles_running_revenue_trips} =
-          Predictions.Predictions.get_all(body, current_time)
+      case http_client.get(
+             Application.get_env(:realtime_signs, :trip_update_url),
+             headers: if(last_modified, do: [if_modified_since: last_modified], else: []),
+             receive_timeout: 2000
+           ) do
+        {:ok, %Req.Response{body: json, status: 200, headers: headers}} ->
+          {new_predictions, vehicles_running_revenue_trips} =
+            Predictions.Predictions.get_all(json, current_time)
 
-        Predictions.LastTrip.get_last_trips(body)
-        |> Engine.LastTrip.update_last_trips()
+          Predictions.LastTrip.get_last_trips(json)
+          |> Engine.LastTrip.update_last_trips()
 
-        Predictions.LastTrip.get_recent_departures(body)
-        |> Engine.LastTrip.update_recent_departures()
+          Predictions.LastTrip.get_recent_departures(json)
+          |> Engine.LastTrip.update_recent_departures()
 
-        EtsUtils.write_ets(state.trip_updates_table, new_predictions, [])
+          EtsUtils.write_ets(state.trip_updates_table, new_predictions, [])
 
-        :ets.insert(state.revenue_vehicles_table, {:all, vehicles_running_revenue_trips})
+          :ets.insert(state.revenue_vehicles_table, {:all, vehicles_running_revenue_trips})
 
-        Enum.find_value(headers, fn {key, value} -> if(key == "Last-Modified", do: value) end)
-      else
+          Enum.find_value(headers, fn {key, value} -> if(key == "Last-Modified", do: value) end)
+
         {:ok, %Req.Response{status: 304}} ->
           last_modified
 


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** [RTS: Handle ambiguous AWS responses ](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1217260661954539?focus=true)

In e2d9492a, we moved from Hackney to Req for HTTP requests. Req will automatically do parsing on the body of an HTTP request using the default included JSON decoder. However, it will not automatically fail if the response body is not JSON. In some cases, we request objects from S3 using Req, which will return the following "success" message as a string:

```
<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>OMITTED</RequestId><HostId>OMITTED</HostId></Error>
```

This commit adds checks to see if the content is a map or not ( indicating a successful parse of JSON)


#### Reviewer Checklist

- [ ] Meets ticket's acceptance criteria
- [ ] Any new or changed functions have typespecs
- [ ] Tests were added for any new functionality (don't just rely on Codecov)
- [ ] If `signs.json` was changed, there is a follow-up PR to `signs_ui` to update its dependency on this project
- [X] This branch was deployed to the ~staging~ dev environment and is currently running with no unexpected increase in warnings, and no errors or crashes (compare on Splunk: [staging](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-dev%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840107.3874236) vs. [prod](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Drealtime-signs-prod%20%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22%20OR%20%22CRASH%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1545840137.3874305))
