### PR TITLE
remove custom message validation

### DIFF
--- a/lib/pa_ess/utilities.ex
+++ b/lib/pa_ess/utilities.ex
@@ -370,12 +370,9 @@ defmodule PaEss.Utilities do
     " It is a shorter 4-car train. You may have to move to a different part of the platform to board."
   end
 
-  @invalid_custom_character ~r/[^a-zA-Z0-9,\/!@': ]/
   @spec validate_custom_string(String.t(), :top | :bottom) :: String.t()
   def validate_custom_string(string, line) do
-    string
-    |> String.replace(@invalid_custom_character, "")
-    |> String.slice(0, if(line == :top, do: 18, else: 24))
+    String.slice(string, 0, if(line == :top, do: 18, else: 24))
   end
 
   @headsign_abbreviation_mappings [

--- a/test/signs/realtime_test.exs
+++ b/test/signs/realtime_test.exs
@@ -936,7 +936,7 @@ defmodule Signs.RealtimeTest do
 
     test "invalid custom messages" do
       expect(Engine.Config.Mock, :sign_config, fn _, _ ->
-        {:static_text, {"bad^", "long long long long message", "audio message"}}
+        {:static_text, {"bad", "long long long long message", "audio message"}}
       end)
 
       expect_messages({"bad", "long long long long mess"})


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [PA Message Permitted Character Alignment](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216635602500735?focus=true)

This removes the pruning of invalid characters, as an overall system simplification. With the new text encoding changes, Scully can handle a much wider set of characters, and we will enforce validation when the content is generated in Screenplay and Signs UI, so no need to do additional checks here.